### PR TITLE
merge t117-non-exhaustive: flag_cluster, and no non_exhaustive exemption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,13 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+[lints.rust]
+# dylint's driver sets `--cfg dylint_lib="<library>"` while it lints; a plain
+# `cargo build` / `cargo clippy` does not. That is what lets this pack `allow`
+# one of its own lints in its own source without `unknown_lints` firing when
+# the pack is compiled off-driver.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("mordant"))'] }
+
 [dependencies]
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "9fca3bc9fc2bc83c60bde26d18ed68f11564b228" }
 dylint_linting = "6.0"

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -169,41 +169,62 @@ impl Atom {
     }
 }
 
+/// How well `PlaceInfo::atom` names what the projection actually read.
+///
+/// A `Downcast` is absorbing: it ends the exact field path and no later
+/// projection puts it back, so "payload" and "exact" cannot hold at once and
+/// every caller below branches payload-first. Three states, not four.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Exactness {
+    /// Pure field access: the atom is exact.
+    Exact,
+    /// A `Downcast` appeared: this reads a variant payload of the atom.
+    VariantPayload,
+    /// Some other projection: the atom names more than was read.
+    Inexact,
+}
+
+impl Exactness {
+    /// A projection this does not model. It can only lose precision, and it
+    /// cannot un-see a `Downcast`.
+    fn blur(self) -> Self {
+        match self {
+            Exactness::Exact | Exactness::Inexact => Exactness::Inexact,
+            Exactness::VariantPayload => Exactness::VariantPayload,
+        }
+    }
+}
+
 struct PlaceInfo {
     atom: Atom,
-    /// Projection was pure field access (the atom is exact).
-    pure: bool,
-    /// A `Downcast` appeared: this reads a variant payload of `atom`.
-    downcast: bool,
+    exactness: Exactness,
     index_locals: Vec<Local>,
 }
 
 fn place_info(place: Place<'_>) -> PlaceInfo {
     let mut path = Vec::new();
-    let mut pure = true;
-    let mut downcast = false;
+    let mut exactness = Exactness::Exact;
     let mut index_locals = Vec::new();
     for elem in place.projection.iter() {
         match elem {
-            ProjectionElem::Field(f, _) if pure => path.push(f.as_u32()),
+            ProjectionElem::Field(f, _) if exactness == Exactness::Exact => path.push(f.as_u32()),
             ProjectionElem::Field(..) => {}
             // `(*r).f`: the reference is the value for slicing purposes, so
             // a deref neither ends the field path nor makes it inexact.
             ProjectionElem::Deref => {}
-            ProjectionElem::Downcast(..) => {
-                downcast = true;
-                pure = false;
-            }
+            ProjectionElem::Downcast(..) => exactness = Exactness::VariantPayload,
             ProjectionElem::Index(v) => {
                 index_locals.push(v);
-                if pure {
+                if exactness == Exactness::Exact {
                     path.push(ANY_ELEM);
                 }
             }
-            ProjectionElem::ConstantIndex { .. } | ProjectionElem::Subslice { .. } if pure => {
+            ProjectionElem::ConstantIndex { .. } | ProjectionElem::Subslice { .. }
+                if exactness == Exactness::Exact =>
+            {
                 path.push(ANY_ELEM);
             }
-            _ => pure = false,
+            _ => exactness = exactness.blur(),
         }
     }
     PlaceInfo {
@@ -211,8 +232,7 @@ fn place_info(place: Place<'_>) -> PlaceInfo {
             local: place.local,
             path,
         },
-        pure,
-        downcast,
+        exactness,
         index_locals,
     }
 }
@@ -357,12 +377,10 @@ fn mentions_self(ty: Ty<'_>, self_did: DefId) -> bool {
 fn reads_of_place(place: Place<'_>, same: bool, out: &mut Vec<Read>) {
     let info = place_info(place);
     out.extend(info.index_locals.iter().map(|l| Read::Index(*l)));
-    if info.downcast {
-        out.push(Read::Payload(info.atom));
-    } else if same && info.pure {
-        out.push(Read::Same(info.atom));
-    } else {
-        out.push(Read::Derived(info.atom));
+    match info.exactness {
+        Exactness::VariantPayload => out.push(Read::Payload(info.atom)),
+        Exactness::Exact if same => out.push(Read::Same(info.atom)),
+        Exactness::Exact | Exactness::Inexact => out.push(Read::Derived(info.atom)),
     }
 }
 
@@ -407,7 +425,7 @@ fn gather<'tcx>(
                         let pinfo = place_info(p);
                         if p.projection.is_empty() {
                             alias[dest.local].push(p.local);
-                        } else if pinfo.downcast {
+                        } else if pinfo.exactness == Exactness::VariantPayload {
                             payload_alias[dest.local].push(p.local);
                         }
                     }
@@ -452,12 +470,14 @@ fn gather<'tcx>(
                         if let Some(p) = operand_place(op) {
                             let info = place_info(p);
                             reads.extend(info.index_locals.iter().map(|l| Read::Index(*l)));
-                            if info.downcast {
-                                reads.push(Read::Payload(info.atom));
-                            } else if info.pure {
-                                reads.push(Read::AggField(i as u32, info.atom));
-                            } else {
-                                reads.push(Read::Derived(info.atom));
+                            match info.exactness {
+                                Exactness::VariantPayload => {
+                                    reads.push(Read::Payload(info.atom));
+                                }
+                                Exactness::Exact => {
+                                    reads.push(Read::AggField(i as u32, info.atom));
+                                }
+                                Exactness::Inexact => reads.push(Read::Derived(info.atom)),
                             }
                         }
                     }

--- a/src/flag_cluster.rs
+++ b/src/flag_cluster.rs
@@ -1,0 +1,117 @@
+use crate::baseline::emit;
+use rustc_hir::{Item, ItemKind};
+use rustc_lint::{LateContext, LateLintPass};
+
+use crate::MordantConfig;
+
+rustc_session::declare_lint! {
+    /// Flags a named-field struct carrying `flag-cluster-min-bools` or more
+    /// `bool` fields, however they are assigned. `n` bools is `2^n`
+    /// representable states; if fewer are legal, an enum names the ones that
+    /// are.
+    ///
+    /// Silent on any struct with an explicit `repr` — its layout is dictated
+    /// from outside Rust (a hardware register, a wire format), so all `2^n`
+    /// states may genuinely be reachable.
+    pub FLAG_CLUSTER,
+    Warn,
+    "struct with several independent bool fields"
+}
+
+pub struct FlagCluster {
+    min_bools: usize,
+}
+
+rustc_session::impl_lint_pass!(FlagCluster => [FLAG_CLUSTER]);
+
+/// Below this the lint is meaningless, and `MordantConfig`'s derived `Default`
+/// yields 0 when the linted workspace has no `dylint.toml` at all.
+const FLOOR: usize = 2;
+
+impl FlagCluster {
+    pub fn new(config: &MordantConfig) -> Self {
+        Self {
+            min_bools: config.flag_cluster_min_bools.max(FLOOR),
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for FlagCluster {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        let ItemKind::Struct(..) = item.kind else {
+            return;
+        };
+        let did = item.owner_id.to_def_id();
+        let adt = cx.tcx.adt_def(did);
+        let repr = adt.repr();
+        // An explicit repr means something outside Rust fixes the layout.
+        if repr.c() || repr.packed() || repr.transparent() || repr.simd() || repr.int.is_some() {
+            return;
+        }
+        let variant = adt.non_enum_variant();
+        // Tuple-struct fields are named "0", "1", …; the message wants names.
+        if variant
+            .fields
+            .iter()
+            .any(|f| f.name.as_str().starts_with(|c: char| c.is_ascii_digit()))
+        {
+            return;
+        }
+        let bools: Vec<_> = variant
+            .fields
+            .iter()
+            .filter(|f| {
+                cx.tcx
+                    .type_of(f.did)
+                    .instantiate_identity()
+                    .skip_normalization()
+                    .is_bool()
+            })
+            .map(|f| f.name)
+            .collect();
+        if bools.len() < self.min_bools {
+            return;
+        }
+        let names: Vec<String> = bools.iter().map(|s| format!("`{s}`")).collect();
+        emit(
+            cx,
+            FLAG_CLUSTER,
+            cx.tcx.def_span(did),
+            format!(
+                "the {} bool fields {} of `{}` are {} representable states",
+                bools.len(),
+                names.join(", "),
+                cx.tcx.def_path_str(did),
+                states(bools.len()),
+            ),
+            "if fewer are legal, name them in an enum; if the layout is fixed elsewhere, give it a repr",
+        );
+    }
+}
+
+fn states(n: usize) -> String {
+    match u32::try_from(n).ok().and_then(|n| 2u64.checked_pow(n)) {
+        Some(n) => n.to_string(),
+        None => format!("2^{n}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::states;
+
+    #[test]
+    fn states_is_two_to_the_n() {
+        assert_eq!(states(3), "8");
+        assert_eq!(states(4), "16");
+        assert_eq!(states(5), "32");
+    }
+
+    /// The count cannot be raised to a power of two in `u64`, so the message
+    /// must say so rather than print a wrong number.
+    #[test]
+    fn states_does_not_overflow() {
+        assert_eq!(states(64), "2^64");
+        assert_eq!(states(usize::MAX), format!("2^{}", usize::MAX));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod baseline;
 mod bypassed_validator;
 mod discarded_error;
 mod exclusive_options;
+mod flag_cluster;
 mod guard_flag;
 mod nonidentity_key;
 mod parallel_bools;
@@ -50,6 +51,9 @@ pub struct MordantConfig {
     /// `wildcard_local_enum` stays silent above this many variants.
     #[serde(default = "default_max_variants")]
     pub wildcard_local_enum_max_variants: usize,
+    /// Bool fields at which `flag_cluster` fires.
+    #[serde(default = "default_min_bools")]
+    pub flag_cluster_min_bools: usize,
     /// Ratchet file name, resolved upward from each crate's manifest dir. Runs
     /// suppress up to the recorded count per (lint, file) and surface only new
     /// findings. Regenerate with `MORDANT_BASELINE_WRITE=1`.
@@ -62,6 +66,10 @@ fn default_min_fields() -> usize {
 
 fn default_max_variants() -> usize {
     12
+}
+
+fn default_min_bools() -> usize {
+    3
 }
 
 #[expect(clippy::no_mangle_with_rust_abi)]
@@ -77,6 +85,7 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
         stringified_error::STRINGIFIED_ERROR,
         exclusive_options::EXCLUSIVE_OPTIONS,
         parallel_bools::PARALLEL_BOOLS,
+        flag_cluster::FLAG_CLUSTER,
         bypassed_validator::BYPASSED_VALIDATOR,
         bypassed_validator::PUB_INVARIANT_FIELDS,
         unread_error_variant::UNREAD_ERROR_VARIANT,
@@ -92,6 +101,8 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     lint_store.register_late_pass(|_| Box::new(stringified_error::StringifiedError));
     lint_store.register_late_pass(move |_| Box::new(exclusive_options::ExclusiveOptions::new(&c3)));
     lint_store.register_late_pass(|_| Box::new(parallel_bools::ParallelBools::new()));
+    let c4 = config.clone();
+    lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster::new(&c4)));
     lint_store.register_late_pass(|_| Box::new(bypassed_validator::BypassedValidator::new()));
     lint_store.register_late_pass(|_| Box::new(unread_error_variant::UnreadErrorVariant::new()));
     lint_store.register_late_pass(|_| Box::new(guard_flag::GuardFlag::new()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,19 @@ mod variant_flow;
 mod wildcard_local_enum;
 
 /// Read from `dylint.toml` under `[mordant]` in the linted workspace root.
+///
+/// `flag_cluster` is allowed on this one struct, and it is the lawful-lattice
+/// case the lint's own help describes rather than an exemption from it. The
+/// bools are opt-ins belonging to *different* lints: all four combinations are
+/// reachable from a `dylint.toml` and each means what it says, so there is no
+/// invariant between them for a type to carry. The field set is also this
+/// pack's public interface — every field is a TOML key, and Scarlet's `xtask`
+/// gate reads these field names out of the pinned source to decide which keys
+/// it may set — so grouping them into sub-structs would rename user-visible
+/// keys to satisfy a lint about internal invariants.
 #[derive(Clone, Default, serde::Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
+#[cfg_attr(dylint_lib = "mordant", allow(flag_cluster))]
 pub struct MordantConfig {
     /// Fully qualified paths of types that are never a valid map key in this
     /// project (e.g. a span type with no file identity). Empty means silent.

--- a/src/nonidentity_key.rs
+++ b/src/nonidentity_key.rs
@@ -16,13 +16,36 @@ rustc_session::declare_lint! {
     "map keyed on a value that is not the canonical identity of what it names"
 }
 
+/// A key-expression form `nonidentity-key-forms` can opt into. These variants
+/// are the whole of the accepted vocabulary, so a spelling this lint honours
+/// exists in exactly one place; a name that is not one of them selects no form,
+/// as it did when this was a pair of string comparisons.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum KeyForm {
+    /// `f.to_bits()` where `f` is a float.
+    ToBits,
+    /// A raw pointer cast to an integer.
+    PtrCast,
+}
+
+impl KeyForm {
+    fn parse(name: &str) -> Option<Self> {
+        match name {
+            "to-bits" => Some(KeyForm::ToBits),
+            "ptr-cast" => Some(KeyForm::PtrCast),
+            _ => None,
+        }
+    }
+}
+
 pub struct NonidentityKey {
     deny_types: Vec<String>,
     deny_methods: Vec<String>,
     fix_types: Vec<String>,
     composite: bool,
-    form_to_bits: bool,
-    form_ptr_cast: bool,
+    /// The opted-in forms. Membership, not one flag per form: a form the
+    /// project did not name is absent rather than false.
+    forms: Vec<KeyForm>,
 }
 
 rustc_session::impl_lint_pass!(NonidentityKey => [NONIDENTITY_KEY]);
@@ -45,8 +68,11 @@ impl NonidentityKey {
             deny_methods: config.nonidentity_key_methods.clone(),
             fix_types: config.nonidentity_key_fixes.clone(),
             composite: config.nonidentity_key_composite,
-            form_to_bits: config.nonidentity_key_forms.iter().any(|f| f == "to-bits"),
-            form_ptr_cast: config.nonidentity_key_forms.iter().any(|f| f == "ptr-cast"),
+            forms: config
+                .nonidentity_key_forms
+                .iter()
+                .filter_map(|f| KeyForm::parse(f))
+                .collect(),
         }
     }
 
@@ -185,7 +211,7 @@ impl<'tcx> LateLintPass<'tcx> for NonidentityKey {
         let Some(key_expr) = args.first() else {
             return;
         };
-        if self.form_to_bits && is_float_to_bits(cx, key_expr) {
+        if self.forms.contains(&KeyForm::ToBits) && is_float_to_bits(cx, key_expr) {
             emit(
                 cx,
                 NONIDENTITY_KEY,
@@ -223,7 +249,7 @@ impl<'tcx> LateLintPass<'tcx> for NonidentityKey {
                 );
             }
         }
-        if self.form_ptr_cast && is_ptr_to_int_cast(cx, key_expr) {
+        if self.forms.contains(&KeyForm::PtrCast) && is_ptr_to_int_cast(cx, key_expr) {
             emit(
                 cx,
                 NONIDENTITY_KEY,

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -138,10 +138,15 @@ impl<'tcx> LateLintPass<'tcx> for WildcardLocalEnum {
         if !adt.is_enum() || !adt.did().is_local() {
             return;
         }
-        // `#[non_exhaustive]` already opted out of exhaustiveness.
-        if adt.is_variant_list_non_exhaustive() {
-            return;
-        }
+        // No `#[non_exhaustive]` exemption, deliberately. `is_local()` above
+        // means the enum is defined in the crate being compiled, and a
+        // `LateLintPass` only ever walks that same crate's bodies — so every
+        // match this lint can reach is a match in the defining crate, where
+        // `#[non_exhaustive]` has no effect and rustc checks exhaustiveness
+        // normally. It constrains downstream crates only. An earlier exemption
+        // here read "already opted out of exhaustiveness", which was false for
+        // every match the lint sees, and it silenced the lint on exactly the
+        // enums annotated *because* the author expects new variants.
         let n = adt.variants().len();
         if n > self.max_variants {
             return;

--- a/ui/flag_cluster.rs
+++ b/ui/flag_cluster.rs
@@ -1,0 +1,76 @@
+// Several independent bool fields are 2^n representable states.
+
+// Flagged: five bools is 32 states.
+struct ShareVerdict {
+    share_bp: u64,
+    fair: bool,
+    rr: bool,
+    census: bool,
+    stacks: bool,
+    counters: bool,
+}
+
+// Flagged: three bools is 8 states, and the threshold is three.
+struct Refusals {
+    too_big: bool,
+    exhausted: bool,
+    fragmented: bool,
+    slots_leaked: u64,
+}
+
+// Fine: two bools is under the threshold.
+struct Pair {
+    a: bool,
+    b: bool,
+}
+
+// Fine: an explicit repr means the layout is fixed outside Rust, so all eight
+// states may genuinely be reachable.
+#[repr(C)]
+struct HwFlags {
+    enabled: bool,
+    pending: bool,
+    masked: bool,
+}
+
+// Fine: a tuple struct has no field names to report.
+struct Positional(bool, bool, bool);
+
+fn main() {
+    let v = ShareVerdict {
+        share_bp: 5000,
+        fair: true,
+        rr: true,
+        census: true,
+        stacks: true,
+        counters: true,
+    };
+    println!(
+        "{} {} {} {} {} {}",
+        v.share_bp, v.fair, v.rr, v.census, v.stacks, v.counters
+    );
+
+    let r = Refusals {
+        too_big: false,
+        exhausted: false,
+        fragmented: true,
+        slots_leaked: 0,
+    };
+    println!(
+        "{} {} {} {}",
+        r.too_big, r.exhausted, r.fragmented, r.slots_leaked
+    );
+
+    let p = Pair { a: true, b: false };
+    println!("{} {}", p.a, p.b);
+
+    let h = HwFlags {
+        enabled: true,
+        pending: false,
+        masked: false,
+    };
+    println!("{} {} {}", h.enabled, h.pending, h.masked);
+
+    let t = Positional(true, false, true);
+    println!("{} {} {}", t.0, t.1, t.2);
+}

--- a/ui/flag_cluster.stderr
+++ b/ui/flag_cluster.stderr
@@ -1,0 +1,19 @@
+warning: the 5 bool fields `fair`, `rr`, `census`, `stacks`, `counters` of `ShareVerdict` are 32 representable states
+  --> $DIR/flag_cluster.rs:4:1
+   |
+LL | struct ShareVerdict {
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if fewer are legal, name them in an enum; if the layout is fixed elsewhere, give it a repr
+   = note: `#[warn(flag_cluster)]` on by default
+
+warning: the 3 bool fields `too_big`, `exhausted`, `fragmented` of `Refusals` are 8 representable states
+  --> $DIR/flag_cluster.rs:14:1
+   |
+LL | struct Refusals {
+   | ^^^^^^^^^^^^^^^
+   |
+   = help: if fewer are legal, name them in an enum; if the layout is fixed elsewhere, give it a repr
+
+warning: 2 warnings emitted
+

--- a/ui/wildcard_local_enum.rs
+++ b/ui/wildcard_local_enum.rs
@@ -48,6 +48,34 @@ fn extractor_false_is_fine(o: &Op) -> bool {
     }
 }
 
+// `#[non_exhaustive]` constrains downstream crates only. In the defining crate
+// — the only place this lint can see a match — rustc still checks
+// exhaustiveness, so a wildcard here absorbs future variants exactly as it does
+// over an ordinary enum, and on an enum annotated because new variants are
+// expected.
+#[non_exhaustive]
+pub enum Entry {
+    Cpu,
+    Memory,
+    Irq,
+}
+
+fn non_exhaustive_wild_is_flagged(e: Entry) -> i32 {
+    match e {
+        Entry::Cpu => 1,
+        _ => 0,
+    }
+}
+
+// Listing the variants is the fix, and it compiles in the defining crate.
+fn non_exhaustive_listed_is_fine(e: Entry) -> i32 {
+    match e {
+        Entry::Cpu => 1,
+        Entry::Memory => 2,
+        Entry::Irq => 3,
+    }
+}
+
 fn foreign_enum_is_fine(x: Option<u32>) -> u32 {
     match x {
         Some(v) => v,
@@ -68,6 +96,9 @@ fn main() {
     let _ = exhaustive_is_fine(Op::Mul);
     let _ = extractor_none_is_fine(&Op::Add);
     let _ = extractor_false_is_fine(&Op::Sub);
+    let _ = non_exhaustive_wild_is_flagged(Entry::Cpu);
+    let _ = non_exhaustive_listed_is_fine(Entry::Memory);
+    let _ = non_exhaustive_listed_is_fine(Entry::Irq);
     let _ = foreign_enum_is_fine(Some(1));
     let _ = non_enum_is_fine(1);
 }

--- a/ui/wildcard_local_enum.stderr
+++ b/ui/wildcard_local_enum.stderr
@@ -22,5 +22,17 @@ help: list the remaining variants; the compiler then flags every new one added
 LL |         other @ (Op::Sub | Op::Mul) => cost(other),
    |               +++++++++++++++++++++
 
-warning: 2 warnings emitted
+warning: this arm absorbs every future variant of `Entry` (3 variants today)
+  --> $DIR/wildcard_local_enum.rs:66:9
+   |
+LL |         _ => 0,
+   |         ^
+   |
+help: list the remaining variants; the compiler then flags every new one added
+   |
+LL -         _ => 0,
+LL +         Entry::Memory | Entry::Irq => 0,
+   |
+
+warning: 3 warnings emitted
 


### PR DESCRIPTION
`t117-non-exhaustive` was never merged, and Scarlet has been pinning its tip (`985a3d0`) as its lint pack — 2 ahead of master, **16 behind**. This merges it forward. `mw6-2-flag-cluster` (`ee44bb9`) is an ancestor, so both feature branches are subsumed and deletable.

Two conflicts, both mechanical unions: `src/lib.rs` (mod list plus registration — `flag_cluster` took a fresh `c6`, since master had spent `c4` on `forbidden_reach` and `c5` on `bypassed_validator`) and `ui/wildcard_local_enum.rs` (both sides appended at the same anchor).

## `985a3d0`'s change is kept, and it was never actually contested

`src/wildcard_local_enum.rs` **auto-merges** — the hunks are disjoint — so nothing prompts a human, which is why this needed checking rather than trusting.

`d652889` and `985a3d0` branch from the **same blob** `bd04302`, and `d652889` touches the `#[non_exhaustive]` guard **zero** times. Master has the exemption only because master never removed it; nobody rebutted the removal, the two lines of development simply never met.

The argument stands on its own: `is_local()` means the enum is in the crate being compiled, a `LateLintPass` only walks that crate's bodies, and `#[non_exhaustive]` has no effect there — so the exemption silenced the lint on precisely the enums annotated *because* new variants are expected.

## Verification

Pack tests on the merged tree: **21 ui passed, 3 unit passed, rc=0**.

Because the risk here was a silent auto-merge rather than a compile error, **both semantics were planted and watched red**:

1. Restore the `#[non_exhaustive]` exemption → 3 warnings drop to 2, the `Entry` finding gone, rc=101.
2. Revert `span_lint_hir_and_then`+`arm.hir_id` to span-only emission → 3 warnings become 4, the extra on the `#[allow]`-bearing arm, rc=101.

One `.stderr` line updated (the `Entry` case moved 66 → 96 when master's four cases were inserted above), fixed individually rather than blanket-blessed so other drift would still show.

Lint count **13 → 23**, calibrated against known figures: `985a3d0` = 13, `fa609c8` = 22, merged = 23.

## The Scarlet pin is NOT bumped with this, deliberately

The bump would be red: **41 findings across the three CLAUDE.md item-3 scopes, all `stale_safety_comment`** — the other nine new lints fire zero times. Every one names something that is not a Rust path: hardware register fields (`CR0`, `CR4`, `MXCSR`, `FPCR`), asm keywords and mnemonics (`nomem`, `sti`, `ud2`), constants owned by other specs (`EfiConventionalMemory`, `ExitBootServices`). The lint's premise looks wrong for arch code, where a SAFETY comment names the hardware bit that makes the operation sound. Tracked as T-215; none were silenced, because 41 baseline entries needing 41 copies of the same argument is the "lie that compiles" case.