### PR TITLE
Share the lint machinery, add three lints, tighten the rest against bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,15 @@ Mordant will not find every defect, but what it reports is real: a lint that can
 | `stringified_error`    | the destruction site: `.map_err(\|e\| e.to_string())` on a typed error                                                                                                    |
 | `exclusive_options`    | a struct whose `Option` fields are never populated together, so the valid combinations are really an enum                                                                 |
 | `parallel_bools`       | bool fields only ever assigned as a pair, which together encode a state machine                                                                                           |
-| `flag_cluster`         | a named-field struct with several independent bools: n bools is 2^n representable states, and if fewer are legal an enum names the ones that are                          |
+| `flag_cluster`         | opt-in via `flag-cluster-enabled`: a named-field struct with several independent bools, 2^n representable states; if fewer are legal an enum names the ones that are      |
 | `nonidentity_key`      | a map keyed on something that is not the canonical identity of what it names: a span, a pointer's bits, an unresolved path                                                |
-| `bypassed_validator`   | a struct literal that skips a constructor whose body rejects some value it then stores in a field                                                                         |
+| `bypassed_validator`   | a literal, a write to a checked field, or `mem::zeroed`/`transmute` outside a validated type's module and impls, none of which runs the constructor's check               |
 | `guard_flag`           | a bool field that several methods test and bail on at entry, enforcing an ordering invariant at runtime                                                                   |
 | `wildcard_local_enum`  | a `_` arm over a small crate-local enum, which absorbs every future variant without a compile error                                                                       |
 | `discarded_error`      | `.ok();` in statement position, which reads like handling and makes the error unobservable                                                                                |
 | `unread_error_variant` | a private enum variant that is constructed but never named by a pattern outside the enum's own impls, so its structure is never read                                      |
-| `pub_invariant_fields` | a field whose value a constructor checks before storing, but which is assignable outside its module, so any holder can write around the check                             |
 | `asymmetric_guard`     | `self.can_x()` gating a mutation that touches state the guard never reads, so the guard cannot be sound                                                                   |
-| `stale_safety_comment` | a `SAFETY:` comment naming an identifier that no longer exists in the file or any linked crate                                                                            |
+| `stale_safety_comment` | opt-in via `stale-safety-comment-enabled`: a `SAFETY:` comment naming an identifier that no longer exists in the file or any linked crate                                 |
 | `unit_mismatch`        | `timeout_ms + deadline_ns`: addition or comparison between names that claim different units                                                                               |
 | `stale_panic_message`  | a panic, assert, or `expect` message naming an identifier that no longer exists                                                                                           |
 | `lock_order`           | two locks the crate acquires in both orders, with both locations named: the shape of a deadlock                                                                           |
@@ -39,6 +38,9 @@ Mordant will not find every defect, but what it reports is real: a lint that can
 | `stored_projection`    | two fields whose constant values agree one-for-one at every construction site: one is a projection of the other, so the type admits pairings the constructors never make  |
 | `overwide_parameter`   | a panicking arm for a variant no existing call site passes: the parameter type is wider than the function's domain, and narrowing it turns the panic into a compile error |
 | `narrowed_return`      | a panicking arm for a variant the callee provably never constructs: the return type promises more than the function delivers                                              |
+| `stale_across_reentry` | a length, flag, or pointer read off a field of `self`, then a call that can re-enter (closure, fn pointer, `dyn`, `.await`, configured), then the field used through it   |
+| `defaulted_failure`    | `f(x).unwrap_or(0)` or `let Ok(v) = f(x) else { return Ok(()) }` where `f`'s own body rejects some of `x`: the rejection becomes a value and processing carries on        |
+| `unchecked_input_len`  | opt-in via `unchecked-input-len-enabled`: a received integer bounded on one path and turned into memory (`split_at`, `set_len`, `ptr.add`) on a path no check dominates   |
 
 Each diagnostic states what the lint found, why the type is wrong, and the type that replaces it.
 
@@ -84,6 +86,15 @@ stored-projection-min-sites = 2
 # Opt-in: also count `Box<dyn Error>` as a stringly error type.
 stringly-error-include-box-dyn = true
 
+# Opt-in: `flag_cluster`, `stale_safety_comment` and `unchecked_input_len` are
+# surveys to run once over a codebase (most of what they name is legitimate
+# once the real cases are fixed; for the last, a length the caller vouches for
+# that the function also uses as some other value's limit), so they are off
+# until turned on here.
+flag-cluster-enabled = true
+stale-safety-comment-enabled = true
+unchecked-input-len-enabled = true
+
 # Opt-in: flag composite keys (tuples, structs one level deep) that carry a
 # denied type unless one of the fixing types sits beside it. With these two
 # lines, (Span, u32) is flagged and (FileId, Span) is accepted.
@@ -94,6 +105,23 @@ nonidentity-key-fixes = ["my_crate::span::FileId"]
 # on top of the std ones. A constructor failing with one of these is not
 # treated as validating any field it stores.
 validator-resource-errors = ["my_alloc::AllocError", "my_sys::Error"]
+
+# This project's own re-entry points for `stale_across_reentry`, on top of the
+# built-in set (calls through closures, fn pointers, and `dyn`, and `.await`).
+# Matched by `::`-segment suffix; a trailing `*` matches the rest of the name.
+# A method of a trait impl is matched under its type or its trait
+# (`Worker::run_job`, `Runner::run_job`) as well as by bare name.
+stale-across-reentry-callees = ["Vm::run_callback", "dispatch*"]
+
+# Callees `defaulted_failure` reports without reading their body: parsers in
+# other crates, or local ones returning Option or building their failure with
+# combinators. A local Result-returning callee whose body shows the check
+# needs no entry. Error types that are already recorded by the time they are
+# returned (an "exception pending" marker) are not worth reporting a default
+# of; both keys are spelled like validator-resource-errors, which this lint
+# honours too.
+defaulted-failure-callees = ["toml::from_str", "from_str_radix"]
+defaulted-failure-ignored-errors = ["my_jsc::JsError"]
 
 # Reachability bans. A finding prints the concrete call chain; dynamic
 # dispatch is invisible to the walk, so a clean run proves nothing, but every

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Mordant will not find every defect, but what it reports is real: a lint that can
 | `forbidden_reach`      | a config-declared ban ("from `sched::pick`, never reach `Vec::push`") violated by a concrete call path, printed as a witness chain                                        |
 | `unread_none`          | an `Option` field every reader unwraps and no reader handles: a state nobody survives, usually a two-phase object wanting two types                                       |
 | `insert_then_unwrap`   | `map.get(&k).unwrap()` re-fetching what `map.insert(k, ..)` just proved present, with nothing in between that could disturb either                                        |
-| `stored_projection`    | two fields whose constant values agree one-for-one at every construction site: one is a stored projection of the other, so the type admits pairings the constructors never make |
+| `stored_projection`    | two fields whose constant values agree one-for-one at every construction site: one is a projection of the other, so the type admits pairings the constructors never make  |
 | `overwide_parameter`   | a panicking arm for a variant no existing call site passes: the parameter type is wider than the function's domain, and narrowing it turns the panic into a compile error |
-| `narrowed_return`      | a panicking arm for a variant the callee provably never constructs: the return type promises more than the function delivers         |
+| `narrowed_return`      | a panicking arm for a variant the callee provably never constructs: the return type promises more than the function delivers                                              |
 
 Each diagnostic states what the lint found, why the type is wrong, and the type that replaces it.
 
@@ -77,8 +77,12 @@ nonidentity-key-types = ["my_crate::span::Span"]
 nonidentity-key-forms = ["ptr-cast"]
 nonidentity-key-methods = ["my_crate::value::Value::to_bits"]
 wildcard-local-enum-max-variants = 12
+exclusive-options-min-fields = 2
 flag-cluster-min-bools = 3
 stored-projection-min-sites = 2
+
+# Opt-in: also count `Box<dyn Error>` as a stringly error type.
+stringly-error-include-box-dyn = true
 
 # Opt-in: flag composite keys (tuples, structs one level deep) that carry a
 # denied type unless one of the fixing types sits beside it. With these two

--- a/src/adt_facts.rs
+++ b/src/adt_facts.rs
@@ -1,0 +1,119 @@
+//! Shared facts about the structs and enums a crate defines: which struct a
+//! type or an impl block is about, what a field's declared type is, what a
+//! struct literal constructs, and the shape questions (explicit `repr`,
+//! positional fields, `Result`'s error type) that several lints ask of the
+//! same definition. Every filter that makes a lint fire or not -- privacy,
+//! `is_struct`, the tail of a literal, a minimum field count -- stays in the
+//! lint, so this module only ever answers, never decides.
+
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Expr, ExprField, ExprKind, StructTailExpr};
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, AdtDef, FieldDef, Ty, TyCtxt, VariantDef};
+use rustc_span::{Symbol, sym};
+
+/// The struct behind `ty` (through any references) when this crate defines
+/// it and nothing outside the crate can name it: the structs whose every
+/// construction and field write the crate can see, which is what lets a lint
+/// claim "never" about them.
+pub(crate) fn private_local_struct<'tcx>(
+    cx: &LateContext<'tcx>,
+    ty: Ty<'tcx>,
+) -> Option<AdtDef<'tcx>> {
+    let ty::Adt(adt, _) = ty.peel_refs().kind() else {
+        return None;
+    };
+    if !adt.is_struct() || !adt.did().is_local() {
+        return None;
+    }
+    if cx
+        .effective_visibilities
+        .is_exported(adt.did().expect_local())
+    {
+        return None;
+    }
+    Some(*adt)
+}
+
+/// A field's declared type, with the struct's own generics left in place.
+pub(crate) fn field_ty<'tcx>(cx: &LateContext<'tcx>, f: &FieldDef) -> Ty<'tcx> {
+    cx.tcx
+        .type_of(f.did)
+        .instantiate_identity()
+        .skip_normalization()
+}
+
+/// The field of a struct (or union) called `name`.
+pub(crate) fn struct_field<'tcx>(adt: AdtDef<'tcx>, name: Symbol) -> Option<&'tcx FieldDef> {
+    adt.non_enum_variant()
+        .fields
+        .iter()
+        .find(|f| f.name == name)
+}
+
+/// The ADT an impl block is for, whatever its origin; a blanket or foreign
+/// impl, or one on a primitive, is None.
+pub(crate) fn impl_self_adt<'tcx>(cx: &LateContext<'tcx>, impl_did: DefId) -> Option<AdtDef<'tcx>> {
+    cx.tcx
+        .type_of(impl_did)
+        .instantiate_identity()
+        .skip_normalization()
+        .ty_adt_def()
+}
+
+/// A `Name { .. }` expression, resolved: the ADT it builds, the variant of it
+/// (the only one, for a struct or union), the fields it spells out, and its
+/// `..base` tail if any.
+pub(crate) struct StructLiteral<'tcx> {
+    pub(crate) adt: AdtDef<'tcx>,
+    pub(crate) variant: &'tcx VariantDef,
+    pub(crate) fields: &'tcx [ExprField<'tcx>],
+    pub(crate) tail: StructTailExpr<'tcx>,
+}
+
+/// Resolve a struct expression; anything else, including a tuple-struct call,
+/// is None. The type comes from typeck rather than the path, so an alias or
+/// `Self` resolves to what it names.
+pub(crate) fn struct_literal<'tcx>(
+    cx: &LateContext<'tcx>,
+    e: &'tcx Expr<'tcx>,
+) -> Option<StructLiteral<'tcx>> {
+    let ExprKind::Struct(qpath, fields, tail) = e.kind else {
+        return None;
+    };
+    let adt = cx.typeck_results().expr_ty(e).ty_adt_def()?;
+    let variant = adt.variant_of_res(cx.qpath_res(qpath, e.hir_id));
+    Some(StructLiteral {
+        adt,
+        variant,
+        fields,
+        tail,
+    })
+}
+
+pub(crate) fn is_option_ty(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
+    matches!(ty.kind(), ty::Adt(adt, _) if cx.tcx.is_diagnostic_item(sym::Option, adt.did()))
+}
+
+/// An explicit `repr` means something outside Rust fixes the layout, so the
+/// value combinations a lint would call unreachable may all be real.
+pub(crate) fn has_fixed_repr(adt: AdtDef<'_>) -> bool {
+    let repr = adt.repr();
+    repr.c() || repr.packed() || repr.transparent() || repr.simd() || repr.int.is_some()
+}
+
+/// Tuple fields are named "0", "1", ...; a message that wants field names has
+/// nothing to say about them.
+pub(crate) fn has_positional_fields(v: &VariantDef) -> bool {
+    v.fields
+        .iter()
+        .any(|f| f.name.as_str().starts_with(|c: char| c.is_ascii_digit()))
+}
+
+/// `Result<_, E>` -> `E`; anything else, `Option` included, is None.
+pub(crate) fn result_err_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+    let ty::Adt(adt, args) = ty.kind() else {
+        return None;
+    };
+    (tcx.is_diagnostic_item(sym::Result, adt.did()) && args.len() == 2).then(|| args.type_at(1))
+}

--- a/src/asymmetric_guard.rs
+++ b/src/asymmetric_guard.rs
@@ -3,14 +3,15 @@ use std::collections::{HashMap, HashSet};
 use clippy_utils::visitors::{Descend, for_each_expr};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Block, Body, Expr, ExprKind, FnDecl, QPath, Stmt, StmtKind, UnOp};
+use rustc_hir::{Block, Body, Expr, ExprKind, FnDecl, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::def_id::LocalDefId;
-use rustc_span::symbol::kw;
 use rustc_span::{Span, Symbol};
 
+use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit;
+use crate::hir_shapes::{Callee, callee_of, ends_in_return, is_self_path, peel_not, self_field};
 
 rustc_session::declare_lint! {
     /// Flags a guarded call whose guard cannot be sound: `self.can_x()` gates
@@ -57,21 +58,18 @@ impl AsymmetricGuard {
     }
 }
 
-fn is_self_path(e: &Expr<'_>) -> bool {
-    matches!(&e.kind, ExprKind::Path(QPath::Resolved(None, p))
-        if p.segments.len() == 1 && p.segments[0].ident.name == kw::SelfLower)
-}
-
 /// The inherent method a `self.m(..)` call resolves to, with its self type,
 /// when that type is a crate-local ADT.
-fn self_method_call(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<(DefId, DefId)> {
-    let ExprKind::MethodCall(_, recv, ..) = &e.kind else {
+fn self_method_call<'tcx>(cx: &LateContext<'tcx>, e: &Expr<'tcx>) -> Option<(DefId, DefId)> {
+    let Some(Callee::Method {
+        def: method, recv, ..
+    }) = callee_of(cx, e)
+    else {
         return None;
     };
     if !is_self_path(recv) {
         return None;
     }
-    let method = cx.typeck_results().type_dependent_def_id(e.hir_id)?;
     let impl_did = cx.tcx.impl_of_assoc(method)?;
     if !matches!(
         cx.tcx.def_kind(impl_did),
@@ -79,18 +77,8 @@ fn self_method_call(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<(DefId, DefId)
     ) {
         return None;
     }
-    let self_ty = cx
-        .tcx
-        .type_of(impl_did)
-        .instantiate_identity()
-        .skip_normalization();
-    if let ty::Adt(adt, _) = self_ty.kind()
-        && adt.did().is_local()
-    {
-        Some((method, adt.did()))
-    } else {
-        None
-    }
+    let adt = impl_self_adt(cx, impl_did)?;
+    adt.did().is_local().then(|| (method, adt.did()))
 }
 
 /// A guard is a permission-flavored boolean method: the names that promise
@@ -99,36 +87,6 @@ fn is_guard_name(cx: &LateContext<'_>, method: DefId) -> bool {
     let name = cx.tcx.item_name(method);
     let n = name.as_str();
     n.starts_with("can_") || n.starts_with("may_") || n.starts_with("check_")
-}
-
-/// Peel `!` and grouping to the guard call, if the condition is exactly one.
-fn guard_call_of<'tcx>(cond: &'tcx Expr<'tcx>) -> (&'tcx Expr<'tcx>, bool) {
-    match cond.kind {
-        ExprKind::Unary(UnOp::Not, inner) => {
-            let (e, _) = guard_call_of(inner);
-            (e, true)
-        }
-        ExprKind::DropTemps(inner) => guard_call_of(inner),
-        _ => (cond, false),
-    }
-}
-
-fn block_ends_in_return(e: &Expr<'_>) -> bool {
-    match e.kind {
-        ExprKind::Ret(_) => true,
-        ExprKind::Block(b, _) => match (b.stmts.last(), b.expr) {
-            (_, Some(tail)) => block_ends_in_return(tail),
-            (
-                Some(Stmt {
-                    kind: StmtKind::Expr(s) | StmtKind::Semi(s),
-                    ..
-                }),
-                None,
-            ) => block_ends_in_return(s),
-            _ => false,
-        },
-        _ => false,
-    }
 }
 
 impl AsymmetricGuard {
@@ -182,15 +140,10 @@ impl<'tcx> LateLintPass<'tcx> for AsymmetricGuard {
         let method = def_id.to_def_id();
         let mut facts = MethodFacts::default();
         for_each_expr(cx, body.value, |e: &Expr<'_>| {
-            match &e.kind {
-                ExprKind::Field(base, ident) if is_self_path(base) => {
-                    facts.touched.insert(ident.name);
-                }
-                _ => {
-                    if let Some((m, _)) = self_method_call(cx, e) {
-                        facts.calls.insert(m);
-                    }
-                }
+            if let Some((_, ident)) = self_field(e) {
+                facts.touched.insert(ident.name);
+            } else if let Some((m, _)) = self_method_call(cx, e) {
+                facts.calls.insert(m);
             }
             std::ops::ControlFlow::<()>::Continue(())
         });
@@ -207,14 +160,14 @@ impl<'tcx> LateLintPass<'tcx> for AsymmetricGuard {
             let ExprKind::If(cond, then, None) = e.kind else {
                 continue;
             };
-            let (gexpr, negated) = guard_call_of(cond);
+            let (gexpr, negated) = peel_not(cond);
             let Some((guard, adt)) = self_method_call(cx, gexpr) else {
                 continue;
             };
             if !is_guard_name(cx, guard) {
                 continue;
             }
-            if negated && block_ends_in_return(then) {
+            if negated && ends_in_return(then) {
                 for later in &block.stmts[i + 1..] {
                     match later.kind {
                         StmtKind::Expr(le) | StmtKind::Semi(le) => {

--- a/src/asymmetric_guard.rs
+++ b/src/asymmetric_guard.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use clippy_utils::visitors::{Descend, for_each_expr};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Block, Body, Expr, ExprKind, FnDecl, StmtKind};
+use rustc_hir::{Block, Body, Expr, ExprKind, FnDecl, HirId, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::def_id::LocalDefId;
@@ -24,7 +24,14 @@ rustc_session::declare_lint! {
     /// Only calls at the guard's own level count as its actions. A call
     /// nested under a further `if`, `match` or loop is gated by that
     /// condition; typically it is a state transition of its own that happens
-    /// to sit in a method the guard opened.
+    /// to sit in a method the guard opened. The exception is a further guard:
+    /// a call approved by `can_x()` and then `can_y()` is judged against what
+    /// the two read together, and is reported once, naming both.
+    ///
+    /// A guard is followed through the fields it reads and the same-type
+    /// methods it calls. One that hands `self` to anything else (a free
+    /// function, a trait method) reads who knows what, and gates nothing as
+    /// far as this lint is concerned: silence, not a guess.
     pub ASYMMETRIC_GUARD,
     Warn,
     "guarded call touches state its guard never reads"
@@ -36,10 +43,15 @@ struct MethodFacts {
     touched: HashSet<Symbol>,
     /// Same-type inherent methods called on `self`.
     calls: HashSet<DefId>,
+    /// `self` handed whole to something the two sets above do not follow (a
+    /// free function, a trait method, a closure): what gets read behind it
+    /// is unknown, so this method's coverage is not computable.
+    escapes: bool,
 }
 
+/// One guarded call site and every guard that approved it.
 struct Gate {
-    guard: DefId,
+    guards: Vec<DefId>,
     action: DefId,
     span: Span,
 }
@@ -47,7 +59,10 @@ struct Gate {
 #[derive(Default)]
 pub struct AsymmetricGuard {
     facts: HashMap<DefId, MethodFacts>,
+    /// In the order the sites were first seen, so findings come out in
+    /// source order; `site_index` folds a second guard into the same entry.
     gates: Vec<Gate>,
+    site_index: HashMap<Span, usize>,
 }
 
 rustc_session::impl_lint_pass!(AsymmetricGuard => [ASYMMETRIC_GUARD]);
@@ -89,7 +104,45 @@ fn is_guard_name(cx: &LateContext<'_>, method: DefId) -> bool {
     n.starts_with("can_") || n.starts_with("may_") || n.starts_with("check_")
 }
 
+/// `if self.can_y() { .. }` with no else: the then-branch is still the outer
+/// guard's territory, only more narrowly approved. Any other condition, or a
+/// denial branch, is a decision of its own.
+fn positive_guard_if<'tcx>(
+    cx: &LateContext<'tcx>,
+    e: &'tcx Expr<'tcx>,
+) -> Option<(DefId, DefId, &'tcx Expr<'tcx>)> {
+    let ExprKind::If(cond, then, None) = e.kind else {
+        return None;
+    };
+    let (gexpr, negated) = peel_not(cond);
+    let (guard, adt) = self_method_call(cx, gexpr)?;
+    (!negated && is_guard_name(cx, guard)).then_some((guard, adt, then))
+}
+
 impl AsymmetricGuard {
+    fn note_gate(&mut self, guards: &[DefId], action: DefId, span: Span) {
+        match self.site_index.get(&span) {
+            Some(&i) => {
+                let known = &mut self.gates[i].guards;
+                for &g in guards {
+                    if !known.contains(&g) {
+                        known.push(g);
+                    }
+                }
+            }
+            None => {
+                self.site_index.insert(span, self.gates.len());
+                self.gates.push(Gate {
+                    guards: guards.to_vec(),
+                    action,
+                    span,
+                });
+            }
+        }
+    }
+
+    /// Every same-type call in `scope` is approved by `guard`; below a further
+    /// positive guard it is approved by both.
     fn collect_actions<'tcx>(
         &mut self,
         cx: &LateContext<'tcx>,
@@ -97,29 +150,41 @@ impl AsymmetricGuard {
         guard: DefId,
         adt: DefId,
     ) {
-        let mut gates = Vec::new();
-        for_each_expr(cx, scope, |e: &Expr<'_>| {
-            // Anything below its own condition answers to that condition. (The
-            // then-branch form hands in the guard's own block, which is not one.)
-            if matches!(
-                e.kind,
-                ExprKind::If(..) | ExprKind::Match(..) | ExprKind::Loop(..) | ExprKind::Closure(..)
-            ) {
-                return std::ops::ControlFlow::<(), Descend>::Continue(Descend::No);
-            }
-            if let Some((m, m_adt)) = self_method_call(cx, e)
-                && m_adt == adt
-                && m != guard
-            {
-                gates.push(Gate {
-                    guard,
-                    action: m,
-                    span: e.span,
-                });
-            }
-            std::ops::ControlFlow::<(), Descend>::Continue(Descend::Yes)
-        });
-        self.gates.extend(gates);
+        let mut sites: Vec<(DefId, Span, Vec<DefId>)> = Vec::new();
+        let mut pending = vec![(scope, vec![guard])];
+        while let Some((scope, guards)) = pending.pop() {
+            for_each_expr(cx, scope, |e: &'tcx Expr<'tcx>| {
+                if let Some((inner, _, then)) = positive_guard_if(cx, e) {
+                    let mut below = guards.clone();
+                    if !below.contains(&inner) {
+                        below.push(inner);
+                    }
+                    pending.push((then, below));
+                    return std::ops::ControlFlow::<(), Descend>::Continue(Descend::No);
+                }
+                // Anything below its own condition answers to that condition. (The
+                // then-branch form hands in the guard's own block, which is not one.)
+                if matches!(
+                    e.kind,
+                    ExprKind::If(..)
+                        | ExprKind::Match(..)
+                        | ExprKind::Loop(..)
+                        | ExprKind::Closure(..)
+                ) {
+                    return std::ops::ControlFlow::<(), Descend>::Continue(Descend::No);
+                }
+                if let Some((m, m_adt)) = self_method_call(cx, e)
+                    && m_adt == adt
+                    && !guards.contains(&m)
+                {
+                    sites.push((m, e.span, guards.clone()));
+                }
+                std::ops::ControlFlow::<(), Descend>::Continue(Descend::Yes)
+            });
+        }
+        for (action, span, guards) in sites {
+            self.note_gate(&guards, action, span);
+        }
     }
 }
 
@@ -139,11 +204,21 @@ impl<'tcx> LateLintPass<'tcx> for AsymmetricGuard {
         // Facts: which self-fields this method touches, and what it calls.
         let method = def_id.to_def_id();
         let mut facts = MethodFacts::default();
+        // The walk is pre-order, so a `self` that is the base of a field or
+        // the receiver of a followed call is marked before it is visited; any
+        // other `self` reaching the walk is one that got away.
+        let mut followed: HashSet<HirId> = HashSet::new();
         for_each_expr(cx, body.value, |e: &Expr<'_>| {
-            if let Some((_, ident)) = self_field(e) {
+            if let Some((base, ident)) = self_field(e) {
                 facts.touched.insert(ident.name);
-            } else if let Some((m, _)) = self_method_call(cx, e) {
+                followed.insert(base.hir_id);
+            } else if let Some((m, _)) = self_method_call(cx, e)
+                && let ExprKind::MethodCall(_, recv, ..) = e.kind
+            {
                 facts.calls.insert(m);
+                followed.insert(recv.hir_id);
+            } else if is_self_path(e) && !followed.contains(&e.hir_id) {
+                facts.escapes = true;
             }
             std::ops::ControlFlow::<()>::Continue(())
         });
@@ -151,6 +226,13 @@ impl<'tcx> LateLintPass<'tcx> for AsymmetricGuard {
     }
 
     fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        // `if self.can_x() { self.y() }` as the block's tail gates the same
+        // way it does as a statement; with nothing after it, only that form.
+        if let Some(tail) = block.expr
+            && let Some((guard, adt, then)) = positive_guard_if(cx, tail)
+        {
+            self.collect_actions(cx, then, guard, adt);
+        }
         // `if !self.can_x() { return } ... self.y()` — the guard covers the
         // rest of the block.
         for (i, stmt) in block.stmts.iter().enumerate() {
@@ -212,20 +294,26 @@ impl<'tcx> LateLintPass<'tcx> for AsymmetricGuard {
             if !mutates {
                 continue;
             }
-            // The guard's coverage is everything it touches transitively
+            // The guards' coverage is everything they touch transitively
             // through same-type calls, so a guard delegating to helpers is
-            // never accused falsely.
+            // never accused falsely; one delegating to something the walk
+            // cannot follow has no computable coverage, and is not judged.
             let mut covered: HashSet<Symbol> = HashSet::new();
-            let mut queue = vec![gate.guard];
+            let mut queue = gate.guards.clone();
             let mut seen: HashSet<DefId> = HashSet::new();
+            let mut computable = true;
             while let Some(m) = queue.pop() {
                 if !seen.insert(m) {
                     continue;
                 }
                 if let Some(f) = self.facts.get(&m) {
+                    computable &= !f.escapes;
                     covered.extend(f.touched.iter().copied());
                     queue.extend(f.calls.iter().copied());
                 }
+            }
+            if !computable {
+                continue;
             }
             let mut missed: Vec<&Symbol> = action
                 .touched
@@ -237,14 +325,23 @@ impl<'tcx> LateLintPass<'tcx> for AsymmetricGuard {
             }
             missed.sort_by_key(|s| s.as_str().to_owned());
             let fields: Vec<String> = missed.iter().map(|s| format!("`{s}`")).collect();
+            let mut guards: Vec<String> = gate
+                .guards
+                .iter()
+                .map(|&g| format!("`{}`", cx.tcx.item_name(g)))
+                .collect();
+            guards.sort();
+            let (guards, reader) = match guards.as_slice() {
+                [one] => (one.clone(), "the guard never reads"),
+                many => (many.join(" and "), "none of the guards read"),
+            };
             emit(
                 cx,
                 ASYMMETRIC_GUARD,
                 gate.span,
                 format!(
-                    "`{}` is gated by `{}`, but touches {} which the guard never reads",
+                    "`{}` is gated by {guards}, but touches {} which {reader}",
                     cx.tcx.item_name(gate.action),
-                    cx.tcx.item_name(gate.guard),
                     fields.join(", "),
                 ),
                 "a guard blind to part of the state its action manipulates cannot be sound; align what the pair reads",

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -11,28 +11,51 @@
 //! is the only key that survives normal development. Moving a finding between
 //! files consumes allowance in one file and overflows in the other, which is
 //! the desired ratchet behavior.
+//!
+//! Every diagnostic a mordant lint produces goes through one of the three
+//! entry points here (`emit`, `emit_with_note`, `emit_hir_then`), so each
+//! finding is weighed against the baseline exactly once.
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::io::{Read, Seek, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then, span_lint_hir_and_then};
+use rustc_errors::Diag;
+use rustc_hir::HirId;
 use rustc_lint::{LateContext, LateLintPass, Lint};
 use rustc_span::{FileName, Span};
 
+/// (lint, file relative to the workspace root): the unit the baseline counts.
+type Key = (String, String);
+
+/// What this process does with each finding; fixed for the whole run at
+/// `setup`, since the environment variable that selects it cannot change
+/// while rustc is running.
+enum Mode {
+    /// Consume the accepted count for each key and let the overflow through.
+    Ratchet {
+        /// Remaining suppressions this run.
+        allowance: Mutex<HashMap<Key, usize>>,
+    },
+    /// Emit nothing; collect every finding and rewrite this crate's section of
+    /// the file at `path` from `BaselineWriter::check_crate_post`.
+    Record {
+        path: PathBuf,
+        recorded: Mutex<Vec<Key>>,
+    },
+}
+
 pub struct Baseline {
     root: PathBuf,
-    path: PathBuf,
-    /// (lint, relative file) -> remaining suppressions this run.
-    allowance: Mutex<HashMap<(String, String), usize>>,
+    mode: Mode,
 }
 
 static STATE: OnceLock<Option<Baseline>> = OnceLock::new();
-static RECORDED: Mutex<Vec<(String, String)>> = Mutex::new(Vec::new());
 
-pub fn write_mode() -> bool {
+fn write_mode() -> bool {
     std::env::var_os("MORDANT_BASELINE_WRITE").is_some()
 }
 
@@ -48,35 +71,48 @@ pub fn setup(file_name: &Option<String>) {
 }
 
 fn init(file_name: &str) -> Option<Baseline> {
+    let record = write_mode();
     let mut dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR")?);
     loop {
         let cand = dir.join(file_name);
         // In write mode the file may not exist yet; anchor at the workspace
         // root, which is where dylint.toml (the config that named us) lives.
-        if cand.exists() || (write_mode() && dir.join("dylint.toml").exists()) {
-            let doc = std::fs::read_to_string(&cand)
-                .map(|s| read_doc(&s))
-                .unwrap_or_default();
-            let mut counts: HashMap<(String, String), usize> = HashMap::new();
-            for section in doc.values() {
-                for (key, n) in section {
-                    if let Some((lint, file)) = key.split_once(':') {
-                        *counts
-                            .entry((lint.to_string(), file.to_string()))
-                            .or_default() += *n as usize;
-                    }
+        if cand.exists() || (record && dir.join("dylint.toml").exists()) {
+            let mode = if record {
+                Mode::Record {
+                    path: cand,
+                    recorded: Mutex::new(Vec::new()),
                 }
-            }
-            return Some(Baseline {
-                root: dir,
-                path: cand,
-                allowance: Mutex::new(counts),
-            });
+            } else {
+                Mode::Ratchet {
+                    allowance: Mutex::new(read_allowance(&cand)),
+                }
+            };
+            return Some(Baseline { root: dir, mode });
         }
         if !dir.pop() {
             return None;
         }
     }
+}
+
+/// Sums every crate section of the file, since a (lint, file) key can appear
+/// under more than one crate (a file shared by a lib and a bin target).
+fn read_allowance(path: &Path) -> HashMap<Key, usize> {
+    let doc = std::fs::read_to_string(path)
+        .map(|s| read_doc(&s))
+        .unwrap_or_default();
+    let mut counts: HashMap<Key, usize> = HashMap::new();
+    for section in doc.values() {
+        for (key, n) in section {
+            if let Some((lint, file)) = key.split_once(':') {
+                *counts
+                    .entry((lint.to_string(), file.to_string()))
+                    .or_default() += *n as usize;
+            }
+        }
+    }
+    counts
 }
 
 fn rel_file(cx: &LateContext<'_>, b: &Baseline, span: Span) -> Option<String> {
@@ -89,8 +125,9 @@ fn rel_file(cx: &LateContext<'_>, b: &Baseline, span: Span) -> Option<String> {
 }
 
 /// True when this finding is consumed by the baseline (or recorded, in write
-/// mode) and must not be emitted.
-pub fn suppressed(cx: &LateContext<'_>, lint: &'static Lint, span: Span) -> bool {
+/// mode) and must not be emitted. Consumes one unit of allowance, so each
+/// finding must pass through here exactly once.
+fn suppressed(cx: &LateContext<'_>, lint: &'static Lint, span: Span) -> bool {
     let Some(Some(b)) = STATE.get().map(Option::as_ref) else {
         return false;
     };
@@ -98,17 +135,18 @@ pub fn suppressed(cx: &LateContext<'_>, lint: &'static Lint, span: Span) -> bool
         return false;
     };
     let key = (lint.name_lower(), file);
-    if write_mode() {
-        RECORDED.lock().unwrap().push(key);
-        return true;
-    }
-    let mut allowance = b.allowance.lock().unwrap();
-    match allowance.get_mut(&key) {
-        Some(n) if *n > 0 => {
-            *n -= 1;
+    match &b.mode {
+        Mode::Record { recorded, .. } => {
+            recorded.lock().unwrap().push(key);
             true
         }
-        _ => false,
+        Mode::Ratchet { allowance } => match allowance.lock().unwrap().get_mut(&key) {
+            Some(n) if *n > 0 => {
+                *n -= 1;
+                true
+            }
+            _ => false,
+        },
     }
 }
 
@@ -146,28 +184,38 @@ pub fn emit_with_note(
     });
 }
 
-// Registered last: flushes write-mode recordings for this crate into the
-// baseline file, replacing only this crate's section.
-rustc_session::declare_lint! {
-    /// Never fires; the pass exists for its `check_crate_post` hook. Declared
-    /// `Warn` because rustc skips a pass whose lints are all allowed, and this
-    /// pass must run.
-    pub MORDANT_BASELINE,
-    Warn,
-    "internal pass that writes the ratchet baseline"
+/// `emit` for a finding whose lint level is read at `hir_id` rather than at
+/// the enclosing item, so an `#[allow]` on that node alone (a match arm, say)
+/// is honored; `decorate` attaches the suggestion or help.
+pub fn emit_hir_then(
+    cx: &LateContext<'_>,
+    lint: &'static Lint,
+    hir_id: HirId,
+    span: Span,
+    msg: impl Into<String>,
+    decorate: impl FnOnce(&mut Diag<'_, ()>),
+) {
+    if suppressed(cx, lint, span) {
+        return;
+    }
+    span_lint_hir_and_then(cx, lint, hir_id, span, msg.into(), decorate);
 }
 
-rustc_session::declare_lint_pass!(BaselineWriter => [MORDANT_BASELINE]);
+// Registered last: flushes write-mode recordings for this crate into the
+// baseline file, replacing only this crate's section. It declares no lint of
+// its own; rustc always runs a lintless pass, so nothing can `allow` it away.
+rustc_session::declare_lint_pass!(BaselineWriter => []);
 
 impl<'tcx> LateLintPass<'tcx> for BaselineWriter {
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        if !write_mode() {
-            return;
-        }
-        let Some(Some(b)) = STATE.get().map(Option::as_ref) else {
+        let Some(Some(Baseline {
+            mode: Mode::Record { path, recorded },
+            ..
+        })) = STATE.get().map(Option::as_ref)
+        else {
             return;
         };
-        let recorded: Vec<_> = std::mem::take(&mut *RECORDED.lock().unwrap());
+        let recorded: Vec<Key> = std::mem::take(&mut *recorded.lock().unwrap());
         let mut section: BTreeMap<String, u64> = BTreeMap::new();
         for (lint, file) in recorded {
             *section.entry(format!("{lint}:{file}")).or_default() += 1;
@@ -188,7 +236,7 @@ impl<'tcx> LateLintPass<'tcx> for BaselineWriter {
             .truncate(false)
             .read(true)
             .write(true)
-            .open(&b.path)
+            .open(path)
         else {
             return;
         };

--- a/src/bypassed_validator.rs
+++ b/src/bypassed_validator.rs
@@ -5,58 +5,122 @@ use crate::baseline::emit_with_note;
 use crate::ctor_flow::{self, FieldCheck};
 use clippy_utils::ty::ty_from_hir_ty;
 use rustc_abi::FieldIdx;
+use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind, FnRetTy, ImplItem, ImplItemKind, ItemKind};
+use rustc_hir::{
+    Expr, ExprKind, FnRetTy, HirId, ImplItem, ImplItemKind, ItemKind, StructTailExpr, UnOp,
+};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::{Span, Symbol, sym};
 
 rustc_session::declare_lint! {
-    /// Flags struct literals that bypass a validating constructor: a
-    /// receiver-less associated function returning `Result<Self, _>` or
+    /// Flags a value of a validated type made or changed without its
+    /// validating constructor running. A validating constructor is a
+    /// receiver-less inherent function returning `Result<Self, _>` or
     /// `Option<Self>` whose body rejects some value it then stores in a field
-    /// (see `ctor_flow`). A literal outside the type's own module constructs
-    /// it without that check ever running. Constructors that only fail
-    /// because their input did not parse or a resource ran out check nothing
-    /// about the fields and are not validators.
+    /// (see `ctor_flow`). Outside the type's own module and impls, each of
+    /// these skips that check:
+    ///
+    /// * a struct literal, `S(x)` on a tuple struct included -- one with a
+    ///   `..base` tail only when it names a field some validator checks,
+    ///   since the fields it takes from `base` were checked when `base` was
+    ///   made;
+    /// * an assignment, plain or compound, to a checked field;
+    /// * `mem::zeroed`, `mem::transmute` or `MaybeUninit::assume_init`
+    ///   producing the type.
+    ///
+    /// Silent on: anything in the type's module or in any impl of it, trait
+    /// impls included, so a written or derived `Default`, `From` or `Clone`
+    /// is the type's own business; any site in a crate other than the one
+    /// defining the type, since validators are only known for local impls,
+    /// so a `pub` checked field of an exported type is not covered; writes to
+    /// fields no constructor checks; `T::default()` and every other call
+    /// (whatever literal it ends in is wherever the callee is), and a tuple
+    /// constructor passed as a value rather than called; a `transmute` that
+    /// only changes the lifetimes of a value already of the type; and
+    /// `&mut s.f` handed to something else, which is not an assignment here.
+    /// Constructors that only fail because their input did not parse or a
+    /// resource ran out check nothing about the fields and are not
+    /// validators.
     pub BYPASSED_VALIDATOR,
     Warn,
-    "struct literal bypasses the type's validating constructor"
+    "value of a validated type made or changed without its validating constructor"
 }
 
 struct Validator {
     ctor: Symbol,
-    checks: Vec<FieldCheck>,
+    /// A validator checks at least one field; a finding about a whole value
+    /// points at this one's check.
+    first: FieldCheck,
+    rest: Vec<FieldCheck>,
+}
+
+impl Validator {
+    fn checks(&self) -> impl Iterator<Item = &FieldCheck> {
+        std::iter::once(&self.first).chain(&self.rest)
+    }
+}
+
+/// Which fields a literal supplies itself.
+enum Literal {
+    All,
+    /// A `..base` (or `..` default-fields) literal: only these are new values.
+    Only(Vec<FieldIdx>),
+}
+
+enum SiteKind {
+    Literal(Literal),
+    Write(FieldIdx),
+    /// `mem::zeroed` and friends, named the way the message shows them.
+    Conjured(&'static str),
+}
+
+/// Something done to a crate-local struct outside its own module and impls.
+/// Resolved against `validators` at the end of the crate: the impl holding
+/// the constructor may be visited after the code that goes around it.
+struct Site {
+    adt: DefId,
+    span: Span,
+    kind: SiteKind,
 }
 
 pub struct BypassedValidator {
     extra_resource_errors: Vec<String>,
     /// struct -> constructors that check at least one stored field.
     validators: HashMap<DefId, Vec<Validator>>,
-    /// Literal constructions outside the struct's own module and impls.
-    literals: Vec<(DefId, Span)>,
+    sites: Vec<Site>,
 }
 
-rustc_session::declare_lint! {
-    /// Flags a field whose value a validating constructor checks (see
-    /// `ctor_flow`) but which is visible outside the type's own module. Any
-    /// holder can assign the field directly, so the constructor's check holds
-    /// only until the first write. Fields the constructor never inspects are
-    /// not reported, whatever their visibility.
-    pub PUB_INVARIANT_FIELDS,
-    Warn,
-    "checked field assignable outside its module"
-}
-
-rustc_session::impl_lint_pass!(BypassedValidator => [BYPASSED_VALIDATOR, PUB_INVARIANT_FIELDS]);
+rustc_session::impl_lint_pass!(BypassedValidator => [BYPASSED_VALIDATOR]);
 
 impl BypassedValidator {
     pub fn new(config: &crate::MordantConfig) -> Self {
         Self {
             extra_resource_errors: config.validator_resource_errors.clone(),
             validators: HashMap::new(),
-            literals: Vec::new(),
+            sites: Vec::new(),
         }
+    }
+
+    fn note_site(
+        &mut self,
+        cx: &LateContext<'_>,
+        expr: &Expr<'_>,
+        adt: ty::AdtDef<'_>,
+        kind: SiteKind,
+    ) {
+        if !adt.is_struct()
+            || !adt.did().is_local()
+            || is_types_own_code(cx, expr.hir_id, adt.did())
+        {
+            return;
+        }
+        self.sites.push(Site {
+            adt: adt.did(),
+            span: expr.span,
+            kind,
+        });
     }
 }
 
@@ -64,6 +128,68 @@ impl BypassedValidator {
 fn impl_self_struct(cx: &LateContext<'_>, impl_did: DefId) -> Option<DefId> {
     let adt = impl_self_adt(cx, impl_did)?;
     (adt.is_struct() && adt.did().is_local()).then(|| adt.did())
+}
+
+/// The type's own module can build and write it whatever the field
+/// visibility (a static table its `Option<Self>` lookup searches, a sibling
+/// helper), and so can any impl of it from any module (constructors,
+/// `Default`, builders): that code is the implementation, not a caller going
+/// around it.
+fn is_types_own_code(cx: &LateContext<'_>, at: HirId, struct_did: DefId) -> bool {
+    if cx.tcx.parent_module(at) == cx.tcx.parent_module_from_def_id(struct_did.expect_local()) {
+        return true;
+    }
+    let mut cur = cx.tcx.hir_enclosing_body_owner(at).to_def_id();
+    while let Some(parent) = cx.tcx.opt_parent(cur) {
+        if matches!(cx.tcx.def_kind(parent), DefKind::Impl { .. })
+            && impl_self_struct(cx, parent) == Some(struct_did)
+        {
+            return true;
+        }
+        cur = parent;
+    }
+    false
+}
+
+/// What a call expression, path or method, invokes.
+fn callee(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
+    match expr.kind {
+        ExprKind::Call(f, _) => {
+            let ExprKind::Path(ref qpath) = f.kind else {
+                return None;
+            };
+            cx.qpath_res(qpath, f.hir_id).opt_def_id()
+        }
+        ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
+        _ => None,
+    }
+}
+
+fn is_tuple_ctor_call(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    let ExprKind::Call(f, _) = expr.kind else {
+        return false;
+    };
+    let ExprKind::Path(ref qpath) = f.kind else {
+        return false;
+    };
+    matches!(
+        cx.qpath_res(qpath, f.hir_id),
+        Res::Def(DefKind::Ctor(CtorOf::Struct, CtorKind::Fn), _)
+    )
+}
+
+/// The name a finding gives a callee that produces a value out of nothing.
+fn conjurer(cx: &LateContext<'_>, callee: DefId) -> Option<&'static str> {
+    let name = cx.tcx.get_diagnostic_name(callee)?;
+    if name == sym::mem_zeroed {
+        Some("mem::zeroed")
+    } else if name == sym::transmute {
+        Some("mem::transmute")
+    } else if name == sym::assume_init {
+        Some("MaybeUninit::assume_init")
+    } else {
+        None
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for BypassedValidator {
@@ -104,126 +230,171 @@ impl<'tcx> LateLintPass<'tcx> for BypassedValidator {
         if !wraps_self {
             return;
         }
-        let checks = ctor_flow::checked_fields(
+        let mut checks = ctor_flow::checked_fields(
             cx,
             item.owner_id.def_id,
             struct_did,
             &self.extra_resource_errors,
-        );
-        if !checks.is_empty() {
-            self.validators
-                .entry(struct_did)
-                .or_default()
-                .push(Validator {
-                    ctor: item.ident.name,
-                    checks,
-                });
-        }
+        )
+        .into_iter();
+        let Some(first) = checks.next() else {
+            return;
+        };
+        self.validators
+            .entry(struct_did)
+            .or_default()
+            .push(Validator {
+                ctor: item.ident.name,
+                first,
+                rest: checks.collect(),
+            });
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        if !matches!(expr.kind, ExprKind::Struct(..)) {
-            return;
-        }
-        let ty = cx.typeck_results().expr_ty(expr);
-        let ty::Adt(adt, _) = ty.kind() else {
-            return;
-        };
-        let Some(struct_local) = adt.did().as_local() else {
-            return;
-        };
-        if !adt.is_struct() {
-            return;
-        }
-        // The type's own module can write the literal whatever the field
-        // visibility, so a literal there is the author's (a static table the
-        // `Option<Self>` lookup searches, a sibling helper), not a bypass.
-        // This is the same boundary `pub_invariant_fields` holds fields to.
-        if cx.tcx.parent_module(expr.hir_id) == cx.tcx.parent_module_from_def_id(struct_local) {
-            return;
-        }
-        // Literals inside the type's own impls (constructors, Default,
-        // builders) are the implementation even from another module.
-        let owner = cx.tcx.hir_enclosing_body_owner(expr.hir_id);
-        let mut cur = owner.to_def_id();
-        while let Some(parent) = cx.tcx.opt_parent(cur) {
-            if matches!(
-                cx.tcx.def_kind(parent),
-                rustc_hir::def::DefKind::Impl { .. }
-            ) && impl_self_struct(cx, parent) == Some(adt.did())
-            {
-                return;
+        let results = cx.typeck_results();
+        match expr.kind {
+            ExprKind::Struct(_, fields, tail) => {
+                let Some(adt) = results.expr_ty(expr).ty_adt_def() else {
+                    return;
+                };
+                let literal = match tail {
+                    StructTailExpr::None => Literal::All,
+                    _ => Literal::Only(
+                        fields
+                            .iter()
+                            .filter_map(|f| results.opt_field_index(f.hir_id))
+                            .collect(),
+                    ),
+                };
+                self.note_site(cx, expr, adt, SiteKind::Literal(literal));
             }
-            cur = parent;
+            ExprKind::Assign(place, ..) | ExprKind::AssignOp(_, place, _) => {
+                // `*s.f = ..` and `(*b).f = ..` both write `f`; the base's
+                // type after auto-deref says whose `f`, so a write through a
+                // `Box` or a guard counts.
+                let mut place = place;
+                while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) =
+                    place.kind
+                {
+                    place = inner;
+                }
+                let ExprKind::Field(base, _) = place.kind else {
+                    return;
+                };
+                let Some(adt) = results.expr_ty_adjusted(base).peel_refs().ty_adt_def() else {
+                    return;
+                };
+                let Some(field) = results.opt_field_index(place.hir_id) else {
+                    return;
+                };
+                self.note_site(cx, expr, adt, SiteKind::Write(field));
+            }
+            ExprKind::Call(..) | ExprKind::MethodCall(..) => {
+                let Some(adt) = results.expr_ty(expr).ty_adt_def() else {
+                    return;
+                };
+                // `S(x)` has no callee body: the call is the literal.
+                if is_tuple_ctor_call(cx, expr) {
+                    self.note_site(cx, expr, adt, SiteKind::Literal(Literal::All));
+                    return;
+                }
+                let Some(what) = callee(cx, expr).and_then(|c| conjurer(cx, c)) else {
+                    return;
+                };
+                // `transmute::<S<'a>, S<'static>>(s)` re-types a value that
+                // already went through the constructor; it makes nothing.
+                // Changing a type parameter (`S<Unchecked>` to `S<Checked>`)
+                // is what a validator returning the latter exists to gate.
+                if let ExprKind::Call(_, [arg]) = expr.kind
+                    && cx.tcx.erase_and_anonymize_regions(results.expr_ty(arg))
+                        == cx.tcx.erase_and_anonymize_regions(results.expr_ty(expr))
+                {
+                    return;
+                }
+                self.note_site(cx, expr, adt, SiteKind::Conjured(what));
+            }
+            _ => {}
         }
-        self.literals.push((adt.did(), expr.span));
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut validators: Vec<_> = self.validators.iter().collect();
-        validators.sort_by_key(|(did, _)| cx.tcx.def_span(**did).lo());
-        for (did, ctors) in validators {
-            let parent_mod = cx.tcx.parent_module_from_def_id(did.expect_local());
-            let fields = &cx.tcx.adt_def(*did).non_enum_variant().fields;
-            let mut reported: Vec<FieldIdx> = Vec::new();
-            for v in ctors {
-                for check in &v.checks {
-                    if reported.contains(&check.field) {
-                        continue;
-                    }
-                    let field = &fields[check.field];
-                    // A private field is Restricted to exactly the parent
-                    // module; anything else widens the write surface past
-                    // the check.
-                    if cx.tcx.visibility(field.did)
-                        == ty::Visibility::Restricted(parent_mod.to_def_id())
-                    {
-                        continue;
-                    }
-                    reported.push(check.field);
-                    emit_with_note(
-                        cx,
-                        PUB_INVARIANT_FIELDS,
-                        cx.tcx.def_span(field.did),
-                        format!(
-                            "`{}::{}` rejects some values of `{}` before storing it, but the field is assignable outside its module",
-                            cx.tcx.item_name(*did),
-                            v.ctor,
-                            field.name,
-                        ),
-                        check.check,
-                        "the check a direct write skips",
-                        "make the field private; the checked invariant otherwise holds only until the first outside write",
-                    );
-                }
-            }
-        }
-        for (did, span) in &self.literals {
-            let Some(ctors) = self.validators.get(did) else {
+        for site in &self.sites {
+            let Some(ctors) = self.validators.get(&site.adt) else {
                 continue;
             };
-            let fields = &cx.tcx.adt_def(*did).non_enum_variant().fields;
-            let v = &ctors[0];
-            let names: Vec<String> = v
-                .checks
-                .iter()
-                .map(|c| format!("`{}`", fields[c.field].name))
-                .collect();
-            emit_with_note(
-                cx,
-                BYPASSED_VALIDATOR,
-                *span,
-                format!(
-                    "`{}` is constructed by literal here, but `{}::{}` checks {} before constructing one",
-                    cx.tcx.def_path_str(*did),
-                    cx.tcx.item_name(*did),
-                    v.ctor,
-                    names.join(", "),
-                ),
-                v.checks[0].check,
-                "the check this literal never runs",
-                "construct through the validating function, or move this literal into the type's module",
-            );
+            let fields = &cx.tcx.adt_def(site.adt).non_enum_variant().fields;
+            let checked = |v: &Validator| {
+                v.checks()
+                    .map(|c| format!("`{}`", fields[c.field].name))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            // Which constructor a site is charged to: for a whole value the
+            // first one, otherwise whichever checks a field the site touches,
+            // which is not necessarily the first.
+            let field_checker = |is_hit: &dyn Fn(FieldIdx) -> bool| {
+                ctors
+                    .iter()
+                    .find_map(|v| v.checks().find(|c| is_hit(c.field)).map(|c| (v, c)))
+            };
+            let (msg, check, note, help) = match &site.kind {
+                SiteKind::Literal(literal) => {
+                    let by = match literal {
+                        Literal::All => ctors.first().map(|v| (v, &v.first)),
+                        Literal::Only(supplied) => field_checker(&|f| supplied.contains(&f)),
+                    };
+                    let Some((by, check)) = by else {
+                        continue;
+                    };
+                    (
+                        format!(
+                            "`{}` is constructed by literal here, but `{}::{}` checks {} before constructing one",
+                            cx.tcx.def_path_str(site.adt),
+                            cx.tcx.item_name(site.adt),
+                            by.ctor,
+                            checked(by),
+                        ),
+                        check.check,
+                        "the check this literal never runs",
+                        "construct through the validating function, or move this literal into the type's module",
+                    )
+                }
+                SiteKind::Conjured(what) => {
+                    let Some(by) = ctors.first() else {
+                        continue;
+                    };
+                    (
+                        format!(
+                            "`{}` is produced by `{what}` here, but `{}::{}` checks {} before constructing one",
+                            cx.tcx.def_path_str(site.adt),
+                            cx.tcx.item_name(site.adt),
+                            by.ctor,
+                            checked(by),
+                        ),
+                        by.first.check,
+                        "the check this value never went through",
+                        "construct through the validating function",
+                    )
+                }
+                SiteKind::Write(field) => {
+                    let Some((by, check)) = field_checker(&|f| f == *field) else {
+                        continue;
+                    };
+                    let name = fields[*field].name;
+                    (
+                        format!(
+                            "`{}::{name}` is written directly here, but `{}::{}` rejects some values of `{name}` before storing one",
+                            cx.tcx.def_path_str(site.adt),
+                            cx.tcx.item_name(site.adt),
+                            by.ctor,
+                        ),
+                        check.check,
+                        "the check this write never runs",
+                        "change the value through the validating function, or make the field private and move this write into the type's module",
+                    )
+                }
+            };
+            emit_with_note(cx, BYPASSED_VALIDATOR, site.span, msg, check, note, help);
         }
     }
 }

--- a/src/bypassed_validator.rs
+++ b/src/bypassed_validator.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit_with_note;
 use crate::ctor_flow::{self, FieldCheck};
 use clippy_utils::ty::ty_from_hir_ty;
@@ -61,19 +62,8 @@ impl BypassedValidator {
 
 /// The struct an impl block is for, when it is a crate-local struct.
 fn impl_self_struct(cx: &LateContext<'_>, impl_did: DefId) -> Option<DefId> {
-    let self_ty = cx
-        .tcx
-        .type_of(impl_did)
-        .instantiate_identity()
-        .skip_normalization();
-    if let ty::Adt(adt, _) = self_ty.kind()
-        && adt.is_struct()
-        && adt.did().is_local()
-    {
-        Some(adt.did())
-    } else {
-        None
-    }
+    let adt = impl_self_adt(cx, impl_did)?;
+    (adt.is_struct() && adt.did().is_local()).then(|| adt.did())
 }
 
 impl<'tcx> LateLintPass<'tcx> for BypassedValidator {

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,7 +1,10 @@
-//! Shared machinery for lints that treat prose as checkable claims: comment
-//! harvesting, backticked-name extraction, and the scopes a name can
-//! legitimately live in (the file's code, this crate's definitions, and the
-//! definitions of every crate it links).
+//! Shared machinery for lints that treat prose as checkable claims
+//! (`stale_safety_comment`, `stale_panic_message`). A claim is a backticked
+//! name in a comment or message; it holds if the name occurs in the file's
+//! code with comments removed, or is defined by this crate or any crate it
+//! links. Both callers run the same check: [`backticked_idents`] over the
+//! text, then [`word_in`] against [`file_code_only`] and [`DefNames::contains`]
+//! for each name.
 
 use std::cell::OnceCell;
 use std::collections::{HashMap, HashSet};
@@ -11,6 +14,8 @@ use rustc_lint::LateContext;
 use rustc_metadata::creader::CStore;
 use rustc_span::{BytePos, Span};
 
+/// Keywords, primitives, and prelude names. Every one of them is defined
+/// everywhere, so a claim naming one can never go stale and is not extracted.
 pub(crate) const IDENT_STOPLIST: &[&str] = &[
     "self", "Self", "mut", "true", "false", "None", "Some", "Ok", "Err", "Vec", "Box", "drop",
     "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64", "i128", "isize", "f32",
@@ -24,9 +29,11 @@ const FILE_EXTENSIONS: &[&str] = &[
     "js", "ts", "py", "go",
 ];
 
-/// Backticked mentions in text, reduced to their final identifier:
-/// `` `self.frames` `` and `` `VM::wake()` `` both yield their last segment,
-/// and anything that is not identifier-shaped after that reduction is skipped.
+/// Backticked mentions in `text`, reduced to their final identifier:
+/// `` `self.frames` `` and `` `VM::wake()` `` yield `frames` and `wake`.
+/// Skipped: file paths and names with a [`FILE_EXTENSIONS`] suffix, anything
+/// not identifier-shaped after the reduction, and the [`IDENT_STOPLIST`].
+/// Duplicates are kept.
 pub(crate) fn backticked_idents(text: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut rest = text;
@@ -60,8 +67,10 @@ pub(crate) fn backticked_idents(text: &str) -> Vec<String> {
     out
 }
 
-/// The contiguous run of `//` comment lines directly above `span`'s first
-/// line, joined, with the span covering those lines.
+/// The contiguous run of `//` lines directly above `span`'s first line (a
+/// blank line or code ends the run; nothing directly above means `None`),
+/// with the slashes stripped and the lines joined by `\n`, plus the span
+/// covering exactly those lines, which is what the callers report on.
 pub(crate) fn comment_above(cx: &LateContext<'_>, span: Span) -> Option<(String, Span)> {
     let sm = cx.tcx.sess.source_map();
     let lines = sm.span_to_lines(span).ok()?;
@@ -91,8 +100,10 @@ pub(crate) fn comment_above(cx: &LateContext<'_>, span: Span) -> Option<(String,
     ))
 }
 
-/// The source of `span`'s whole file with every `//` comment stripped, so a
-/// comment can never vouch for its own claims.
+/// The source of `span`'s whole file with the rest of every line cut at its
+/// first `//`, so a comment can never vouch for its own claims. The cut is
+/// textual: a `//` inside a string literal loses the rest of that line too,
+/// and `/* */` comments are left in.
 pub(crate) fn file_code_only(cx: &LateContext<'_>, span: Span) -> String {
     let file_src = cx
         .tcx
@@ -109,6 +120,8 @@ pub(crate) fn file_code_only(cx: &LateContext<'_>, span: Span) -> String {
         .join("\n")
 }
 
+/// Whether `ident` occurs in `haystack` as a whole identifier token, so
+/// `frame` does not match `frames` or `frame_count`.
 pub(crate) fn word_in(haystack: &str, ident: &str) -> bool {
     haystack
         .split(|c: char| !(c.is_alphanumeric() || c == '_'))
@@ -116,9 +129,11 @@ pub(crate) fn word_in(haystack: &str, ident: &str) -> bool {
 }
 
 /// The definition names a claim may point at beyond its own file: everything
-/// this crate defines, and everything any linked crate defines. The upstream
-/// set is large (std alone is tens of thousands of names) and most crates
-/// never need it, so it is built on the first lookup that misses locally.
+/// this crate defines, and everything any linked crate defines. Built once
+/// per crate in the callers' `check_crate`. The upstream set is large (std
+/// alone is tens of thousands of names) and a crate whose claims all resolve
+/// locally never needs it, so it is built on the first lookup that misses
+/// locally.
 pub(crate) struct DefNames {
     local: HashMap<String, Option<LocalDefId>>,
     upstream: OnceCell<HashSet<String>>,
@@ -141,7 +156,8 @@ impl DefNames {
     }
 }
 
-/// Every named definition in every crate this one links, std included. A
+/// Every named definition in every crate this one links, std included:
+/// items, variants, and fields alike, since all have a `def_key` name. A
 /// SAFETY comment in a workspace member routinely names the sibling crate or
 /// std type that owns the invariant, and none of those are in the local HIR.
 fn upstream_def_names(cx: &LateContext<'_>) -> HashSet<String> {
@@ -168,9 +184,11 @@ fn upstream_def_names(cx: &LateContext<'_>) -> HashSet<String> {
     names
 }
 
-/// Every definition name in the crate, mapped to one owning def. Names that
-/// several defs share map to `None`, so a consumer needing THE definition
-/// (fingerprinting, spans) skips ambiguous names instead of guessing.
+/// Every name this crate defines: each item, and every variant and field of
+/// each local ADT, since a claim usually names the field it guards. A name
+/// with exactly one owning item maps to that item; a name several defs share,
+/// and every variant and field, maps to `None`. [`DefNames::contains`] only
+/// asks whether the name is present.
 fn crate_def_index(cx: &LateContext<'_>) -> HashMap<String, Option<LocalDefId>> {
     let mut index: HashMap<String, Option<LocalDefId>> = HashMap::new();
     let mut insert = |name: String, def: Option<LocalDefId>| match index.entry(name) {

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -53,8 +53,8 @@ use rustc_span::{Span, sym};
 
 use crate::adt_facts::result_err_ty;
 use crate::mir_flow::{
-    ANY_ELEM, Atom, Exactness, build_cfg, control_deps, is_prefix, mir_for, operand_place,
-    place_info, post_dominators, switch_operand_atoms,
+    ANY_ELEM, Atom, Exactness, build_cfg, control_deps, direct_control_deps, is_prefix, mir_for,
+    operand_place, place_info, post_dominators, switch_operand_atoms,
 };
 
 /// Error types that report the environment refusing, not the value being
@@ -100,6 +100,65 @@ pub(crate) fn checked_fields(
         .collect();
     v.sort_by_key(|f| f.field);
     v
+}
+
+/// The branch in `callee` whose outcome sends it to a non-resource
+/// `Err`/`None` and whose condition reads back to one of its arguments other
+/// than a `self` receiver: the check a caller discards when it replaces the
+/// failure with a default. Only the branches an exit is directly
+/// control-dependent on are read: an argument test that merely stands in
+/// front of a receiver-decided exit (`if s.is_empty() { return Ok(0) }`
+/// before `if self.closed { return Err(..) }`) accepts the argument, it does
+/// not reject it. None when the body always succeeds, fails only on
+/// resources, on its receiver's own state (an empty queue, a lexer at the
+/// wrong token) or on state it was not handed at all, or builds its failure
+/// with combinators instead of a branch of its own.
+pub(crate) fn argument_decided_failure(
+    tcx: TyCtxt<'_>,
+    callee: LocalDefId,
+    extra_resource_errors: &[String],
+) -> Option<Span> {
+    let first_argument = if tcx
+        .opt_associated_item(callee.to_def_id())
+        .is_some_and(|item| item.is_method())
+    {
+        2
+    } else {
+        1
+    };
+    let body = mir_for(tcx, callee)?;
+    if body.tainted_by_errors.is_some() {
+        return None;
+    }
+    if let Some(e) = result_err_ty(tcx, body.local_decls[RETURN_PLACE].ty)
+        && is_resource_error(tcx, e, extra_resource_errors)
+    {
+        return None;
+    }
+    let facts = gather(tcx, &body, None, extra_resource_errors);
+    if facts.failure_blocks.is_empty() {
+        return None;
+    }
+    let cfg = build_cfg(&body);
+    let pdom = post_dominators(&cfg);
+    let mut visited: HashSet<BasicBlock> = HashSet::new();
+    for &fb in &facts.failure_blocks {
+        for branch in direct_control_deps(&cfg, &pdom, fb) {
+            if !visited.insert(branch)
+                || decides_on_resource(tcx, &body, &facts, branch, extra_resource_errors)
+            {
+                continue;
+            }
+            let decision = decision_slice(&facts.defs, &switch_operand_atoms(&body, branch), &[]);
+            if decision
+                .iter()
+                .any(|a| (first_argument..=body.arg_count).contains(&a.local.as_usize()))
+            {
+                return Some(body.basic_blocks[branch].terminator().source_info.span);
+            }
+        }
+    }
+    None
 }
 
 // ── def facts ────────────────────────────────────────────────────────────────
@@ -240,10 +299,13 @@ fn reads_of_operand(op: &Operand<'_>, same: bool, out: &mut Vec<Read>) {
     }
 }
 
+/// `self_did` is the type under construction; None for a body whose failure
+/// exits are the question and whose return value is not (no `Self` roots, no
+/// closures to follow).
 fn gather<'tcx>(
     tcx: TyCtxt<'tcx>,
     body: &Body<'tcx>,
-    self_did: DefId,
+    self_did: Option<DefId>,
     extra_resource_errors: &[String],
 ) -> Facts {
     let n = body.local_decls.len();
@@ -349,7 +411,7 @@ fn gather<'tcx>(
                         }
                         AggregateKind::Closure(cdid, args) => {
                             let out = args.as_closure().sig().output().skip_binder();
-                            if mentions_self(out, self_did)
+                            if self_did.is_some_and(|s| mentions_self(out, s))
                                 && let Some(l) = cdid.as_local()
                             {
                                 closures.push(l);
@@ -495,7 +557,7 @@ fn gather<'tcx>(
     }
     // A body returning bare `Self` (a helper, a closure): the return place
     // itself is the self value.
-    if is_self_ty(body.local_decls[RETURN_PLACE].ty, self_did) {
+    if self_did.is_some_and(|s| is_self_ty(body.local_decls[RETURN_PLACE].ty, s)) {
         self_roots.push(Atom::whole(RETURN_PLACE));
     }
     failure_blocks.sort();
@@ -684,7 +746,7 @@ fn helper_summary<'tcx>(
     }
     memo.insert(def, None);
     let body = mir_for(tcx, def)?;
-    let facts = gather(tcx, &body, self_did, &[]);
+    let facts = gather(tcx, &body, Some(self_did), &[]);
     let nfields = tcx.adt_def(self_did).non_enum_variant().fields.len();
     let roots = field_roots(tcx, &body, &facts, self_did, nfields, memo, depth + 1);
     let argc = body.arg_count;
@@ -794,7 +856,7 @@ fn analyze_body<'tcx>(
     {
         return;
     }
-    let facts = gather(tcx, &body, self_did, extra_resource_errors);
+    let facts = gather(tcx, &body, Some(self_did), extra_resource_errors);
     let closures = facts.closures.clone();
     if !facts.failure_blocks.is_empty() {
         let nfields = tcx.adt_def(self_did).non_enum_variant().fields.len();

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -31,6 +31,11 @@
 //! n }` reads and stores `n`. Exits whose error type is a resource error
 //! (`AllocError`, `io::Error`, ...) are dropped up front, since "the allocator
 //! said no" and "the helper said no" have the same shape.
+//!
+//! The parts of this that know nothing about constructors -- which MIR to
+//! read, places as atoms, the pruned CFG and control dependence -- live in
+//! `mir_flow`; this module owns the def facts, the two slices, the resource
+//! error list, helper summaries and the per-field verdict.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -40,11 +45,17 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
 use rustc_lint::LateContext;
 use rustc_middle::mir::{
-    AggregateKind, BasicBlock, Body, BorrowKind, Local, Operand, Place, ProjectionElem,
-    RETURN_PLACE, RawPtrKind, Rvalue, StatementKind, TerminatorKind,
+    AggregateKind, BasicBlock, Body, BorrowKind, Local, Operand, Place, RETURN_PLACE, RawPtrKind,
+    Rvalue, StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::{Span, sym};
+
+use crate::adt_facts::result_err_ty;
+use crate::mir_flow::{
+    ANY_ELEM, Atom, Exactness, build_cfg, control_deps, is_prefix, mir_for, operand_place,
+    place_info, post_dominators, switch_operand_atoms,
+};
 
 /// Error types that report the environment refusing, not the value being
 /// wrong. An exit failing with one of these is never a validation.
@@ -89,159 +100,6 @@ pub(crate) fn checked_fields(
         .collect();
     v.sort_by_key(|f| f.field);
     v
-}
-
-// ── MIR access ───────────────────────────────────────────────────────────────
-
-pub(crate) fn mir_for<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> Option<MirRef<'tcx>> {
-    if !tcx.def_kind(def).is_fn_like() || !tcx.is_mir_available(def.to_def_id()) {
-        return None;
-    }
-    // The pre-optimization body keeps `?` as `Try::branch` calls and every
-    // aggregate intact regardless of the build's opt level. It is stolen once
-    // `optimized_mir` runs, which nothing before codegen asks for; fall back
-    // if some other driver did.
-    let steal = tcx.mir_drops_elaborated_and_const_checked(def);
-    if steal.is_stolen() {
-        Some(MirRef::Opt(tcx.optimized_mir(def.to_def_id())))
-    } else {
-        Some(MirRef::Steal(steal.borrow()))
-    }
-}
-
-pub(crate) enum MirRef<'tcx> {
-    Steal(rustc_data_structures::sync::MappedReadGuard<'tcx, Body<'tcx>>),
-    Opt(&'tcx Body<'tcx>),
-}
-
-impl<'tcx> std::ops::Deref for MirRef<'tcx> {
-    type Target = Body<'tcx>;
-    fn deref(&self) -> &Body<'tcx> {
-        match self {
-            MirRef::Steal(g) => g,
-            MirRef::Opt(b) => b,
-        }
-    }
-}
-
-// ── places as atoms ──────────────────────────────────────────────────────────
-
-/// A local plus the leading run of field projections: `_3.1.0`. Anything past
-/// the first deref/index/downcast is folded into the prefix before it.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-struct Atom {
-    local: Local,
-    path: Vec<u32>,
-}
-
-/// Path component for "some element of": indexing conflates positions but
-/// keeps the container distinct from its elements, so a length check on a
-/// slice is not a check on the element later stored out of it.
-const ANY_ELEM: u32 = u32::MAX;
-
-impl Atom {
-    fn whole(local: Local) -> Self {
-        Atom {
-            local,
-            path: Vec::new(),
-        }
-    }
-    fn extended(&self, tail: &[u32]) -> Self {
-        // `node = node.next` in a loop composes without bound; past a few
-        // levels the distinction stops mattering, so the path saturates.
-        const MAX_PATH: usize = 6;
-        let mut path = self.path.clone();
-        let room = MAX_PATH.saturating_sub(path.len());
-        path.extend_from_slice(&tail[..tail.len().min(room)]);
-        Atom {
-            local: self.local,
-            path,
-        }
-    }
-    fn overlaps(&self, other: &Atom) -> bool {
-        self.local == other.local && self.path.iter().zip(&other.path).all(|(a, b)| a == b)
-    }
-    /// `self` (a decision atom) reads `stored` or a part of it. The reverse,
-    /// a decision on the whole of something only part of which is stored
-    /// (`lexer.next()?` then `log: lexer.log`), is not evidence about the part.
-    fn inspects(&self, stored: &Atom) -> bool {
-        self.local == stored.local && is_prefix(&stored.path, &self.path)
-    }
-}
-
-/// How well `PlaceInfo::atom` names what the projection actually read.
-///
-/// A `Downcast` is absorbing: it ends the exact field path and no later
-/// projection puts it back, so "payload" and "exact" cannot hold at once and
-/// every caller below branches payload-first. Three states, not four.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum Exactness {
-    /// Pure field access: the atom is exact.
-    Exact,
-    /// A `Downcast` appeared: this reads a variant payload of the atom.
-    VariantPayload,
-    /// Some other projection: the atom names more than was read.
-    Inexact,
-}
-
-impl Exactness {
-    /// A projection this does not model. It can only lose precision, and it
-    /// cannot un-see a `Downcast`.
-    fn blur(self) -> Self {
-        match self {
-            Exactness::Exact | Exactness::Inexact => Exactness::Inexact,
-            Exactness::VariantPayload => Exactness::VariantPayload,
-        }
-    }
-}
-
-struct PlaceInfo {
-    atom: Atom,
-    exactness: Exactness,
-    index_locals: Vec<Local>,
-}
-
-fn place_info(place: Place<'_>) -> PlaceInfo {
-    let mut path = Vec::new();
-    let mut exactness = Exactness::Exact;
-    let mut index_locals = Vec::new();
-    for elem in place.projection.iter() {
-        match elem {
-            ProjectionElem::Field(f, _) if exactness == Exactness::Exact => path.push(f.as_u32()),
-            ProjectionElem::Field(..) => {}
-            // `(*r).f`: the reference is the value for slicing purposes, so
-            // a deref neither ends the field path nor makes it inexact.
-            ProjectionElem::Deref => {}
-            ProjectionElem::Downcast(..) => exactness = Exactness::VariantPayload,
-            ProjectionElem::Index(v) => {
-                index_locals.push(v);
-                if exactness == Exactness::Exact {
-                    path.push(ANY_ELEM);
-                }
-            }
-            ProjectionElem::ConstantIndex { .. } | ProjectionElem::Subslice { .. }
-                if exactness == Exactness::Exact =>
-            {
-                path.push(ANY_ELEM);
-            }
-            _ => exactness = exactness.blur(),
-        }
-    }
-    PlaceInfo {
-        atom: Atom {
-            local: place.local,
-            path,
-        },
-        exactness,
-        index_locals,
-    }
-}
-
-fn operand_place<'tcx>(op: &Operand<'tcx>) -> Option<Place<'tcx>> {
-    match op {
-        Operand::Copy(p) | Operand::Move(p) => Some(*p),
-        Operand::Constant(_) | Operand::RuntimeChecks(_) => None,
-    }
 }
 
 // ── def facts ────────────────────────────────────────────────────────────────
@@ -329,14 +187,6 @@ fn is_resource_error(tcx: TyCtxt<'_>, ty: Ty<'_>, extra: &[String]) -> bool {
                     Some((k, n)) => !k.contains("::") && krate.as_str() == k && name.as_str() == n,
                 }
         })
-}
-
-/// `Result<_, E>` -> `E`; `Option<_>` -> None.
-fn error_type<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
-    let ty::Adt(adt, args) = ty.kind() else {
-        return None;
-    };
-    (tcx.is_diagnostic_item(sym::Result, adt.did()) && args.len() == 2).then(|| args.type_at(1))
 }
 
 /// Trait methods whose result is the receiver's value seen differently.
@@ -588,7 +438,7 @@ fn gather<'tcx>(
                         .or_else(|| args.first().map(|a| a.node.ty(&body.local_decls, tcx)));
                     residual_calls.push((
                         destination.local,
-                        residual.and_then(|r| error_type(tcx, r)),
+                        residual.and_then(|r| result_err_ty(tcx, r)),
                         bb,
                     ));
                 } else if tcx.is_lang_item(callee, LangItem::TryTraitBranch) {
@@ -674,10 +524,6 @@ fn closure_over(start: Local, mut succ: impl FnMut(Local) -> Vec<Local>) -> Hash
 }
 
 // ── slices ───────────────────────────────────────────────────────────────────
-
-fn is_prefix(a: &[u32], b: &[u32]) -> bool {
-    a.len() <= b.len() && a.iter().zip(b).all(|(x, y)| x == y)
-}
 
 /// Storage slice from `roots`: every atom whose value ends up (as itself, or
 /// arithmetically combined) in a root. Returns the slice and the atoms whose
@@ -784,168 +630,6 @@ fn slices_meet(storage: &[Atom], decision: &[Atom]) -> bool {
 
 // ── control dependence ───────────────────────────────────────────────────────
 
-/// The body's CFG over normal (non-unwind) edges, with every block that
-/// cannot reach a `return` pruned: a panic, abort or `unreachable!()` is
-/// "does not happen" here, otherwise everything after `assert!(x)` would be
-/// control-dependent on `x`.
-struct Cfg {
-    succs: Vec<Vec<usize>>,
-    /// Index of the virtual exit node.
-    exit: usize,
-}
-
-fn raw_successors(body: &Body<'_>, bb: BasicBlock) -> Vec<BasicBlock> {
-    let Some(term) = &body.basic_blocks[bb].terminator else {
-        return Vec::new();
-    };
-    let mut v = match &term.kind {
-        TerminatorKind::Goto { target } => vec![*target],
-        TerminatorKind::SwitchInt { targets, .. } => targets.all_targets().to_vec(),
-        TerminatorKind::Drop { target, .. } | TerminatorKind::Assert { target, .. } => {
-            vec![*target]
-        }
-        TerminatorKind::Call { target, .. } => target.iter().copied().collect(),
-        TerminatorKind::Yield { resume, .. } => vec![*resume],
-        TerminatorKind::FalseEdge { real_target, .. }
-        | TerminatorKind::FalseUnwind { real_target, .. } => {
-            vec![*real_target]
-        }
-        TerminatorKind::InlineAsm { targets, .. } => targets.to_vec(),
-        TerminatorKind::Return
-        | TerminatorKind::Unreachable
-        | TerminatorKind::UnwindResume
-        | TerminatorKind::UnwindTerminate(_)
-        | TerminatorKind::CoroutineDrop
-        | TerminatorKind::TailCall { .. } => Vec::new(),
-    };
-    v.retain(|b| !body.basic_blocks[*b].is_cleanup);
-    v.sort();
-    v.dedup();
-    v
-}
-
-fn build_cfg(body: &Body<'_>) -> Cfg {
-    let n = body.basic_blocks.len();
-    let raw: Vec<Vec<usize>> = (0..n)
-        .map(|i| {
-            let bb = BasicBlock::from_usize(i);
-            if body.basic_blocks[bb].is_cleanup {
-                Vec::new()
-            } else {
-                raw_successors(body, bb)
-                    .into_iter()
-                    .map(|b| b.as_usize())
-                    .collect()
-            }
-        })
-        .collect();
-    let mut can_return: Vec<bool> = (0..n)
-        .map(|i| {
-            matches!(
-                body.basic_blocks[BasicBlock::from_usize(i)]
-                    .terminator
-                    .as_ref()
-                    .map(|t| &t.kind),
-                Some(TerminatorKind::Return | TerminatorKind::TailCall { .. })
-            )
-        })
-        .collect();
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for b in 0..n {
-            if !can_return[b] && raw[b].iter().any(|s| can_return[*s]) {
-                can_return[b] = true;
-                changed = true;
-            }
-        }
-    }
-    let succs = (0..n)
-        .map(|b| {
-            let live: Vec<usize> = raw[b].iter().copied().filter(|s| can_return[*s]).collect();
-            if live.is_empty() { vec![n] } else { live }
-        })
-        .collect();
-    Cfg { succs, exit: n }
-}
-
-struct Bits(Vec<u64>);
-impl Bits {
-    fn full(n: usize) -> Self {
-        let mut v = vec![!0u64; n.div_ceil(64)];
-        if !n.is_multiple_of(64) {
-            *v.last_mut().unwrap() = (1u64 << (n % 64)) - 1;
-        }
-        Bits(v)
-    }
-    fn empty(n: usize) -> Self {
-        Bits(vec![0; n.div_ceil(64)])
-    }
-    fn set(&mut self, i: usize) {
-        self.0[i / 64] |= 1 << (i % 64);
-    }
-    fn has(&self, i: usize) -> bool {
-        self.0[i / 64] & (1 << (i % 64)) != 0
-    }
-    fn and_assign(&mut self, o: &Bits) {
-        for (a, b) in self.0.iter_mut().zip(&o.0) {
-            *a &= *b;
-        }
-    }
-}
-
-/// Post-dominator sets over blocks plus the virtual exit.
-fn post_dominators(cfg: &Cfg) -> Vec<Bits> {
-    let n = cfg.exit;
-    let mut pdom: Vec<Bits> = (0..=n).map(|_| Bits::full(n + 1)).collect();
-    pdom[n] = Bits::empty(n + 1);
-    pdom[n].set(n);
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for b in 0..n {
-            let mut acc = Bits::full(n + 1);
-            for &s in &cfg.succs[b] {
-                acc.and_assign(&pdom[s]);
-            }
-            acc.set(b);
-            if acc.0 != pdom[b].0 {
-                pdom[b] = acc;
-                changed = true;
-            }
-        }
-    }
-    pdom
-}
-
-/// Branch blocks that `target` is transitively control-dependent on,
-/// innermost first.
-fn control_deps(cfg: &Cfg, pdom: &[Bits], target: BasicBlock) -> Vec<BasicBlock> {
-    let branches: Vec<usize> = (0..cfg.exit).filter(|a| cfg.succs[*a].len() >= 2).collect();
-    let direct = |t: usize| -> Vec<usize> {
-        branches
-            .iter()
-            .copied()
-            .filter(|a| {
-                let strictly = pdom[*a].has(t) && *a != t;
-                !strictly && cfg.succs[*a].iter().any(|s| pdom[*s].has(t))
-            })
-            .collect()
-    };
-    let mut seen = HashSet::new();
-    let mut q = VecDeque::from([target.as_usize()]);
-    let mut deps = Vec::new();
-    while let Some(t) = q.pop_front() {
-        for a in direct(t) {
-            if seen.insert(a) {
-                deps.push(BasicBlock::from_usize(a));
-                q.push_back(a);
-            }
-        }
-    }
-    deps
-}
-
 /// The branch at `bb` switches on the discriminant of a `Result<_, E>` whose
 /// `E` is a resource error: its outcome is the environment's, whatever the
 /// constructor then returns.
@@ -974,22 +658,8 @@ fn decides_on_resource<'tcx>(
         }
     }
     candidates.into_iter().any(|l| {
-        error_type(tcx, body.local_decls[l].ty).is_some_and(|e| is_resource_error(tcx, e, extra))
+        result_err_ty(tcx, body.local_decls[l].ty).is_some_and(|e| is_resource_error(tcx, e, extra))
     })
-}
-
-fn switch_operand_atoms(body: &Body<'_>, bb: BasicBlock) -> Vec<Atom> {
-    match &body.basic_blocks[bb].terminator().kind {
-        TerminatorKind::SwitchInt { discr, .. } => operand_place(discr)
-            .map(|p| {
-                let info = place_info(p);
-                let mut v: Vec<Atom> = info.index_locals.into_iter().map(Atom::whole).collect();
-                v.push(info.atom);
-                v
-            })
-            .unwrap_or_default(),
-        _ => Vec::new(),
-    }
 }
 
 // ── per-field roots, helpers, and the verdict ────────────────────────────────
@@ -1119,7 +789,7 @@ fn analyze_body<'tcx>(
     if body.tainted_by_errors.is_some() {
         return;
     }
-    if let Some(e) = error_type(tcx, body.local_decls[RETURN_PLACE].ty)
+    if let Some(e) = result_err_ty(tcx, body.local_decls[RETURN_PLACE].ty)
         && is_resource_error(tcx, e, extra_resource_errors)
     {
         return;

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -1,0 +1,430 @@
+use std::collections::HashMap;
+
+use rustc_hir::def::{CtorKind, DefKind, Res};
+use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::{Block, Expr, ExprKind, LetStmt, Stmt, StmtKind, StructTailExpr, UnOp};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
+use rustc_span::{Span, sym};
+
+use crate::adt_facts::result_err_ty;
+use crate::baseline::{emit, emit_with_note};
+use crate::enum_facts::{arm_variant, ctor_literal_variant};
+use crate::hir_shapes::{Callee, callee_of};
+
+rustc_session::declare_lint! {
+    /// Flags a call whose failure is replaced by a fixed value and never
+    /// looked at -- `f(x).unwrap_or(0)`, `.unwrap_or_default()`,
+    /// `.unwrap_or_else(|_| CONST)`, `.ok()` feeding one of those, `let
+    /// Ok(v) = f(x) else { return Ok(()) }` or `let Some(v) = f(x).ok() else {
+    /// return }` -- when `f` is a `Result`-returning function of this crate
+    /// whose body rejects some of what it is handed (see
+    /// `ctor_flow::argument_decided_failure`): the value that failed `f`'s
+    /// check goes on being processed as if it had passed. Callees the
+    /// analysis cannot see into (other crates, `Option` returners,
+    /// combinator-built failures) are covered only when listed in
+    /// `defaulted-failure-callees`.
+    ///
+    /// Silent on `Option` callees (absent-with-a-default is what `Option` is
+    /// for; a `Result` names a failure); on failures decided only by the
+    /// callee's receiver (its own state, not the caller's value), including
+    /// ones an argument test merely stands in front of; on error types in
+    /// `validator-resource-errors` or `defaulted-failure-ignored-errors` (the
+    /// environment refused, or the failure is already recorded somewhere
+    /// else); on a `bool` answer defaulted to `false` by any of the three
+    /// forms (the ordinary way to fold "could not tell" into "no"); on
+    /// failures handled by a `match`, `if let` or `?`; on a computed fallback
+    /// (`unwrap_or(prev)`); on a default in statement position (`f(x)
+    /// .unwrap_or_default();` carries nothing on -- like `.ok();`, it is a
+    /// discard, `discarded_error`'s shape); and on an else block returning
+    /// `None`/`false`, which still reports the failure.
+    pub DEFAULTED_FAILURE,
+    Warn,
+    "a callee's rejection of its argument is replaced by a default"
+}
+
+pub struct DefaultedFailure {
+    /// Error types whose failure exits do not count: the configured resource
+    /// errors plus the ones this lint is told are recorded elsewhere.
+    ignored_errors: Vec<String>,
+    /// Callees taken as failing on their argument without reading their body.
+    listed: Vec<String>,
+    /// callee -> the check it fails on, once per callee.
+    facts: HashMap<LocalDefId, Option<Span>>,
+}
+
+rustc_session::impl_lint_pass!(DefaultedFailure => [DEFAULTED_FAILURE]);
+
+impl DefaultedFailure {
+    pub fn new(config: &crate::MordantConfig) -> Self {
+        let mut ignored_errors = config.validator_resource_errors.clone();
+        ignored_errors.extend(config.defaulted_failure_ignored_errors.iter().cloned());
+        Self {
+            ignored_errors,
+            listed: config.defaulted_failure_callees.clone(),
+            facts: HashMap::new(),
+        }
+    }
+
+    fn fact(&mut self, cx: &LateContext<'_>, callee: LocalDefId) -> Option<Span> {
+        if let Some(f) = self.facts.get(&callee) {
+            return *f;
+        }
+        let f = crate::ctor_flow::argument_decided_failure(cx.tcx, callee, &self.ignored_errors);
+        self.facts.insert(callee, f);
+        f
+    }
+
+    fn is_listed(&self, cx: &LateContext<'_>, callee: DefId) -> bool {
+        if self.listed.is_empty() {
+            return false;
+        }
+        let path = cx.tcx.def_path_str(callee);
+        let name = cx.tcx.item_name(callee);
+        let krate = cx.tcx.crate_name(callee.krate);
+        // Same spellings as `validator-resource-errors`: a full path, a bare
+        // name, or `crate::name`.
+        self.listed.iter().any(|e| {
+            path == *e
+                || path.ends_with(&format!("::{e}"))
+                || match e.rsplit_once("::") {
+                    None => name.as_str() == e,
+                    Some((k, n)) => !k.contains("::") && krate.as_str() == k && name.as_str() == n,
+                }
+        })
+    }
+
+    /// `call` produces the `Result`/`Option` whose failure the caller
+    /// replaces; `replaced` says how. Reported when the callee is one this
+    /// lint knows rejects its argument.
+    fn report<'tcx>(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        call: &Expr<'tcx>,
+        at: Span,
+        replaced: &str,
+    ) {
+        let Some(FallibleCall { callee, wrapper }) = fallible_call(cx, call) else {
+            return;
+        };
+        let name = cx.tcx.def_path_str(callee);
+        let help =
+            "propagate the failure, or handle the failing arm where its cause is still visible";
+        if wrapper == Wrapper::Result
+            && let Some(local) = callee.as_local()
+            && let Some(check) = self.fact(cx, local)
+        {
+            emit_with_note(
+                cx,
+                DEFAULTED_FAILURE,
+                at,
+                format!(
+                    "`{name}` rejects some of what it is handed, and {replaced} in place of the rejection"
+                ),
+                check,
+                "the check whose failure is replaced",
+                help,
+            );
+        } else if self.is_listed(cx, callee) {
+            emit(
+                cx,
+                DEFAULTED_FAILURE,
+                at,
+                format!(
+                    "`{name}` is listed in `defaulted-failure-callees`, and {replaced} in place of its failure"
+                ),
+                help,
+            );
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Wrapper {
+    Result,
+    Option,
+}
+
+struct FallibleCall {
+    callee: DefId,
+    wrapper: Wrapper,
+}
+
+/// The function `call` invokes, when `call` produces a `Result` or `Option`
+/// and is not merely a constructor of one.
+fn fallible_call<'tcx>(cx: &LateContext<'tcx>, call: &Expr<'tcx>) -> Option<FallibleCall> {
+    let ty::Adt(adt, _) = cx.typeck_results().expr_ty(call).kind() else {
+        return None;
+    };
+    let wrapper = if cx.tcx.is_diagnostic_item(sym::Result, adt.did()) {
+        Wrapper::Result
+    } else if cx.tcx.is_diagnostic_item(sym::Option, adt.did()) {
+        Wrapper::Option
+    } else {
+        return None;
+    };
+    let callee = match callee_of(cx, call)? {
+        Callee::Path { def, .. } | Callee::Method { def, .. } => def,
+    };
+    matches!(cx.tcx.def_kind(callee), DefKind::Fn | DefKind::AssocFn)
+        .then_some(FallibleCall { callee, wrapper })
+}
+
+fn peel<'h>(mut e: &'h Expr<'h>) -> &'h Expr<'h> {
+    loop {
+        match e.kind {
+            ExprKind::DropTemps(inner) => e = inner,
+            ExprKind::Block(
+                Block {
+                    stmts: [],
+                    expr: Some(tail),
+                    ..
+                },
+                None,
+            ) => e = tail,
+            _ => return e,
+        }
+    }
+}
+
+/// `recv`, or the `Result` under a value-position `.ok()` on it.
+fn through_ok<'h>(cx: &LateContext<'_>, recv: &'h Expr<'h>) -> &'h Expr<'h> {
+    let recv = peel(recv);
+    if let ExprKind::MethodCall(seg, inner, [], _) = recv.kind
+        && seg.ident.as_str() == "ok"
+        && result_err_ty(cx.tcx, cx.typeck_results().expr_ty_adjusted(inner)).is_some()
+    {
+        return peel(inner);
+    }
+    recv
+}
+
+/// A fallback that is the same whatever failed: a literal, a constant, a
+/// unit value, `T::default()` / `T::new()`, or those assembled into a tuple,
+/// array or struct. A fallback computed from the surroundings is a decision
+/// this lint cannot judge.
+fn is_fixed_value(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+    let e = peel(e);
+    match e.kind {
+        ExprKind::Lit(_) => true,
+        ExprKind::Unary(UnOp::Neg, inner)
+        | ExprKind::Cast(inner, _)
+        | ExprKind::AddrOf(_, _, inner) => is_fixed_value(cx, inner),
+        ExprKind::Tup(items) | ExprKind::Array(items) => {
+            items.iter().all(|i| is_fixed_value(cx, i))
+        }
+        ExprKind::Path(ref qpath) => is_constant_res(cx.qpath_res(qpath, e.hir_id)),
+        ExprKind::Call(callee, args) => {
+            let ExprKind::Path(qpath) = &callee.kind else {
+                return false;
+            };
+            match cx.qpath_res(qpath, callee.hir_id) {
+                Res::Def(DefKind::Fn | DefKind::AssocFn, def) => {
+                    args.is_empty() && is_nullary_ctor_name(cx, def)
+                }
+                Res::Def(DefKind::Ctor(..), _) => args.iter().all(|a| is_fixed_value(cx, a)),
+                _ => false,
+            }
+        }
+        ExprKind::Struct(_, fields, tail) => {
+            fields.iter().all(|f| is_fixed_value(cx, f.expr))
+                && match tail {
+                    StructTailExpr::None | StructTailExpr::DefaultFields(_) => true,
+                    StructTailExpr::Base(base) => is_fixed_value(cx, base),
+                    _ => false,
+                }
+        }
+        _ => false,
+    }
+}
+
+fn is_constant_res(res: Res) -> bool {
+    matches!(
+        res,
+        Res::Def(
+            DefKind::Const { .. } | DefKind::AssocConst { .. } | DefKind::Ctor(_, CtorKind::Const),
+            _
+        )
+    )
+}
+
+fn is_nullary_ctor_name(cx: &LateContext<'_>, def: DefId) -> bool {
+    matches!(cx.tcx.item_name(def).as_str(), "default" | "new")
+}
+
+/// What a caller puts in place of the failure, when it is the same whatever
+/// failed.
+enum Fallback<'h> {
+    /// The type's own `default()` / `new()`: `unwrap_or_default()`, or
+    /// `unwrap_or_else(T::default)`.
+    Default,
+    /// The expression written out: `unwrap_or(v)`, or the body of the
+    /// closure in `unwrap_or_else(|_| v)`.
+    Value(&'h Expr<'h>),
+}
+
+/// The fallback of a `unwrap_or*` call named `name` with `args`, when it is
+/// fixed. A fallback computed from the surroundings (`unwrap_or(prev)`, a
+/// closure reading the error it is handed) is None.
+fn fixed_fallback<'tcx>(
+    cx: &LateContext<'tcx>,
+    name: &str,
+    args: &'tcx [Expr<'tcx>],
+) -> Option<Fallback<'tcx>> {
+    match (name, args) {
+        ("unwrap_or_default", []) => Some(Fallback::Default),
+        ("unwrap_or", [value]) => is_fixed_value(cx, value).then_some(Fallback::Value(value)),
+        ("unwrap_or_else", [thunk]) => {
+            let thunk = peel(thunk);
+            match thunk.kind {
+                ExprKind::Closure(c) => {
+                    let value = cx.tcx.hir_body(c.body).value;
+                    is_fixed_value(cx, value).then_some(Fallback::Value(value))
+                }
+                ExprKind::Path(ref qpath) => match cx.qpath_res(qpath, thunk.hir_id) {
+                    Res::Def(DefKind::Fn | DefKind::AssocFn, def)
+                        if is_nullary_ctor_name(cx, def) =>
+                    {
+                        Some(Fallback::Default)
+                    }
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// The else block of a `let .. else` reports success or nothing at all:
+/// `return`, `return ()` or `return Ok(())`, and nothing else in the block.
+fn else_reports_success(cx: &LateContext<'_>, els: &Block<'_>) -> bool {
+    let only = match (els.stmts, els.expr) {
+        ([], Some(e)) => e,
+        (
+            [
+                Stmt {
+                    kind: StmtKind::Semi(e) | StmtKind::Expr(e),
+                    ..
+                },
+            ],
+            None,
+        ) => e,
+        _ => return false,
+    };
+    let ExprKind::Ret(value) = peel(only).kind else {
+        return false;
+    };
+    match value {
+        None => true,
+        Some(v) => {
+            let v = peel(v);
+            match v.kind {
+                ExprKind::Tup([]) => true,
+                ExprKind::Call(_, [payload]) => {
+                    ctor_literal_variant(cx, v)
+                        .is_some_and(|variant| cx.tcx.item_name(variant) == sym::Ok)
+                        && matches!(peel(payload).kind, ExprKind::Tup([]))
+                }
+                _ => false,
+            }
+        }
+    }
+}
+
+/// A `bool` answer defaulted to `false`, whichever way it is spelled
+/// (`unwrap_or(false)`, `unwrap_or_default()`, `unwrap_or_else(|_| false)`,
+/// `|_| Default::default()`): on a `Result<bool, _>` this folds "could not
+/// tell" into "no", which is the answer's own vocabulary rather than a value
+/// smuggled past a check. `unwrap_or(true)` is not this: it answers "yes"
+/// unasked.
+fn folds_to_no(cx: &LateContext<'_>, unwrapped: &Expr<'_>, fallback: &Fallback<'_>) -> bool {
+    if !cx.typeck_results().expr_ty(unwrapped).is_bool() {
+        return false;
+    }
+    let value = match fallback {
+        Fallback::Default => return true,
+        Fallback::Value(value) => peel(value),
+    };
+    match value.kind {
+        ExprKind::Lit(lit) => lit.node == rustc_ast::LitKind::Bool(false),
+        ExprKind::Call(callee, []) => {
+            let ExprKind::Path(qpath) = &callee.kind else {
+                return false;
+            };
+            matches!(
+                cx.qpath_res(qpath, callee.hir_id),
+                Res::Def(DefKind::Fn | DefKind::AssocFn, def)
+                    if cx.tcx.item_name(def).as_str() == "default"
+            )
+        }
+        _ => false,
+    }
+}
+
+/// `expr` is a whole statement (`f(x).unwrap_or_default();`): the value is
+/// dropped, so nothing carries on with it. That is a discard, `.ok();`'s
+/// shape, not a default.
+fn is_discarded(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    matches!(
+        cx.tcx.parent_hir_node(expr.hir_id),
+        rustc_hir::Node::Stmt(Stmt {
+            kind: StmtKind::Semi(_),
+            ..
+        })
+    )
+}
+
+impl<'tcx> LateLintPass<'tcx> for DefaultedFailure {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let ExprKind::MethodCall(seg, recv, args, _) = expr.kind else {
+            return;
+        };
+        let name = seg.ident.name;
+        let Some(fallback) = fixed_fallback(cx, name.as_str(), args) else {
+            return;
+        };
+        if expr.span.from_expansion() || folds_to_no(cx, expr, &fallback) || is_discarded(cx, expr)
+        {
+            return;
+        }
+        let call = through_ok(cx, recv);
+        self.report(
+            cx,
+            call,
+            expr.span,
+            &format!("`{name}` carries on with a fixed value"),
+        );
+    }
+
+    /// `let Ok(v) = f(x) else { return Ok(()) };`, or the same with the
+    /// `Result` turned into an `Option` first: `let Some(v) = f(x).ok() else
+    /// { .. }`. A `Some` head over anything else is not taken: an `Option`
+    /// callee's `None` under a bare `return` is the ordinary "not this shape,
+    /// nothing to do", and a lint cannot tell that from a swallowed rejection.
+    fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'tcx>) {
+        let StmtKind::Let(LetStmt {
+            pat,
+            init: Some(init),
+            els: Some(els),
+            span,
+            ..
+        }) = stmt.kind
+        else {
+            return;
+        };
+        if span.from_expansion() {
+            return;
+        }
+        let init = peel(init);
+        let call = through_ok(cx, init);
+        let head_is_failure_of_call = arm_variant(cx, pat).is_some_and(|variant| {
+            let head = cx.tcx.item_name(variant);
+            head == sym::Ok || (head == sym::Some && !std::ptr::eq(call, init))
+        });
+        if !head_is_failure_of_call || !else_reports_success(cx, els) {
+            return;
+        }
+        self.report(cx, call, *span, "the `else` returns success");
+    }
+}

--- a/src/discarded_error.rs
+++ b/src/discarded_error.rs
@@ -1,8 +1,7 @@
+use crate::adt_facts::result_err_ty;
 use crate::baseline::emit;
 use rustc_hir::{ExprKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty;
-use rustc_span::sym;
 
 rustc_session::declare_lint! {
     /// Flags `.ok();` in statement position: the `Result` becomes an `Option`
@@ -27,15 +26,8 @@ impl<'tcx> LateLintPass<'tcx> for DiscardedError {
         if seg.ident.as_str() != "ok" {
             return;
         }
-        let ty::Adt(adt, _) = cx
-            .typeck_results()
-            .expr_ty_adjusted(recv)
-            .peel_refs()
-            .kind()
-        else {
-            return;
-        };
-        if !cx.tcx.is_diagnostic_item(sym::Result, adt.did()) {
+        let recv_ty = cx.typeck_results().expr_ty_adjusted(recv).peel_refs();
+        if result_err_ty(cx.tcx, recv_ty).is_none() {
             return;
         }
         emit(

--- a/src/enum_facts.rs
+++ b/src/enum_facts.rs
@@ -1,11 +1,49 @@
-//! Shared analysis for the panic-elimination lints: which variant a
-//! constructor literal builds, which variant a pattern head names, and
-//! whether a match arm is a panic rather than any other divergence.
+//! Shared analysis for the enum lints: which variant a resolution, a
+//! constructor literal or a pattern head names, which of those variants
+//! belong to a crate-private enum, and whether a match arm is a panic rather
+//! than any other divergence. Every lint that asks "which variant is this"
+//! goes through here, so the answer is the same in all of them.
 
 use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind, Pat, PatExpr, PatExprKind, PatKind};
+use rustc_hir::{Expr, ExprKind, Pat, PatExpr, PatExprKind, PatKind, QPath};
 use rustc_lint::LateContext;
+
+/// The variant `res` names, whether spelled as the variant itself (unit and
+/// struct variants) or as its constructor (tuple variants).
+pub(crate) fn variant_of_res(cx: &LateContext<'_>, res: Res) -> Option<DefId> {
+    match res {
+        Res::Def(DefKind::Variant, id) => Some(id),
+        Res::Def(DefKind::Ctor(CtorOf::Variant, _), id) => Some(cx.tcx.parent(id)),
+        _ => None,
+    }
+}
+
+/// The path at the head of a pattern that names something: `E::V`,
+/// `E::V(..)` or `E::V { .. }`. Bindings, wildcards, literals, ranges, ors,
+/// tuples and the rest have no head path.
+pub(crate) fn pat_head_qpath<'h>(pat: &'h Pat<'h>) -> Option<&'h QPath<'h>> {
+    match &pat.kind {
+        PatKind::TupleStruct(qpath, ..) | PatKind::Struct(qpath, ..) => Some(qpath),
+        PatKind::Expr(PatExpr {
+            kind: PatExprKind::Path(qpath),
+            ..
+        }) => Some(qpath),
+        _ => None,
+    }
+}
+
+/// The enum owning `variant`, when that enum is defined in this crate and not
+/// reachable from outside it; a variant an outside crate could name is not
+/// this crate's to account for.
+pub(crate) fn private_enum_of(cx: &LateContext<'_>, variant: DefId) -> Option<DefId> {
+    let enum_did = cx.tcx.parent(variant);
+    let local = enum_did.as_local()?;
+    if cx.effective_visibilities.is_exported(local) {
+        return None;
+    }
+    Some(enum_did)
+}
 
 /// The variant a constructor-literal argument passes, or None for anything
 /// short of a literal constructor.
@@ -21,28 +59,13 @@ pub(crate) fn ctor_literal_variant(cx: &LateContext<'_>, e: &Expr<'_>) -> Option
         ExprKind::Struct(qpath, ..) => cx.qpath_res(qpath, e.hir_id),
         _ => return None,
     };
-    match res {
-        Res::Def(DefKind::Variant, id) => Some(id),
-        Res::Def(DefKind::Ctor(CtorOf::Variant, _), id) => Some(cx.tcx.parent(id)),
-        _ => None,
-    }
+    variant_of_res(cx, res)
 }
 
 /// The variant a match-arm pattern names at its head.
 pub(crate) fn arm_variant(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<DefId> {
-    let qpath = match &pat.kind {
-        PatKind::TupleStruct(qpath, ..) | PatKind::Struct(qpath, ..) => qpath,
-        PatKind::Expr(PatExpr {
-            kind: PatExprKind::Path(qpath),
-            ..
-        }) => qpath,
-        _ => return None,
-    };
-    match cx.qpath_res(qpath, pat.hir_id) {
-        Res::Def(DefKind::Variant, id) => Some(id),
-        Res::Def(DefKind::Ctor(CtorOf::Variant, _), id) => Some(cx.tcx.parent(id)),
-        _ => None,
-    }
+    let qpath = pat_head_qpath(pat)?;
+    variant_of_res(cx, cx.qpath_res(qpath, pat.hir_id))
 }
 
 /// A diverging arm that is a panic, not a `return`/`continue`: never-typed

--- a/src/enum_facts.rs
+++ b/src/enum_facts.rs
@@ -4,7 +4,7 @@
 //! than any other divergence. Every lint that asks "which variant is this"
 //! goes through here, so the answer is the same in all of them.
 
-use rustc_hir::def::{CtorOf, DefKind, Res};
+use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, Pat, PatExpr, PatExprKind, PatKind, QPath};
 use rustc_lint::LateContext;
@@ -45,8 +45,10 @@ pub(crate) fn private_enum_of(cx: &LateContext<'_>, variant: DefId) -> Option<De
     Some(enum_did)
 }
 
-/// The variant a constructor-literal argument passes, or None for anything
-/// short of a literal constructor.
+/// The variant whose VALUE `e` is: `E::Unit`, `E::Tuple(..)` or
+/// `E::Struct { .. }` written out. None for anything else, including a bare
+/// `E::Tuple` passed along as a function value — that expression is a
+/// constructor, not a value of the enum, so it passes no variant anywhere.
 pub(crate) fn ctor_literal_variant(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<DefId> {
     let res = match &e.kind {
         ExprKind::Call(callee, _) => {
@@ -55,11 +57,26 @@ pub(crate) fn ctor_literal_variant(cx: &LateContext<'_>, e: &Expr<'_>) -> Option
             };
             cx.qpath_res(qpath, callee.hir_id)
         }
-        ExprKind::Path(qpath) => cx.qpath_res(qpath, e.hir_id),
+        ExprKind::Path(qpath) => match cx.qpath_res(qpath, e.hir_id) {
+            Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Fn), _) => return None,
+            res => res,
+        },
         ExprKind::Struct(qpath, ..) => cx.qpath_res(qpath, e.hir_id),
         _ => return None,
     };
     variant_of_res(cx, res)
+}
+
+/// The variant `e` constructs, now or later: everything
+/// [`ctor_literal_variant`] accepts, plus a bare `E::Tuple` handed to
+/// `map`/`map_err`/`ok_or_else`, which builds the variant when it is called.
+/// This is the question "does the crate ever make one of these"; the value
+/// question above is the one for "what does this argument pass".
+pub(crate) fn constructed_variant(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<DefId> {
+    if let ExprKind::Path(qpath) = &e.kind {
+        return variant_of_res(cx, cx.qpath_res(qpath, e.hir_id));
+    }
+    ctor_literal_variant(cx, e)
 }
 
 /// The variant a match-arm pattern names at its head.

--- a/src/exclusive_options.rs
+++ b/src/exclusive_options.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::adt_facts::{field_ty, is_option_ty, private_local_struct};
 use crate::baseline::emit;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind, StructTailExpr};
+use rustc_hir::{Expr, ExprKind, StructTailExpr, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
-use rustc_span::Symbol;
+use rustc_span::{Ident, Symbol};
 
 use crate::MordantConfig;
 
@@ -18,7 +18,8 @@ rustc_session::declare_lint! {
     ///
     /// Only fires on structs private to the crate, with every construction a
     /// literal `Some(..)`/`None` struct expression and no later field
-    /// assignment — anything else is unprovable and stays silent.
+    /// assignment, whether direct or through a `Box`, guard or other `Deref`
+    /// container — anything else is unprovable and stays silent.
     pub EXCLUSIVE_OPTIONS,
     Warn,
     "struct whose Option fields are never populated together"
@@ -68,6 +69,19 @@ fn relevant_adt<'tcx>(
     (opts.len() >= min_fields).then_some((adt, opts))
 }
 
+/// The `base.field` an assignment writes, through any number of derefs; the
+/// caller reads the ADJUSTED type of `base`, so a write through a `Box`, a
+/// guard or any other `Deref` container reaches the struct behind it.
+fn assigned_field<'h>(mut place: &'h Expr<'h>) -> Option<(&'h Expr<'h>, Ident)> {
+    while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) = place.kind {
+        place = inner;
+    }
+    match place.kind {
+        ExprKind::Field(base, ident) => Some((base, ident)),
+        _ => None,
+    }
+}
+
 enum Init {
     Some,
     None,
@@ -115,11 +129,11 @@ impl<'tcx> LateLintPass<'tcx> for ExclusiveOptions {
             }
             // A later `s.field = ...` write re-opens every combination; the
             // construction sites alone no longer prove anything.
-            ExprKind::Assign(lhs, _, _) => {
-                let ExprKind::Field(base, ident) = lhs.kind else {
+            ExprKind::Assign(place, _, _) | ExprKind::AssignOp(_, place, _) => {
+                let Some((base, ident)) = assigned_field(place) else {
                     return;
                 };
-                let ty = cx.typeck_results().expr_ty(base);
+                let ty = cx.typeck_results().expr_ty_adjusted(base);
                 let Some((adt, opts)) = relevant_adt(cx, ty, self.min_fields) else {
                     return;
                 };

--- a/src/exclusive_options.rs
+++ b/src/exclusive_options.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
+use crate::adt_facts::{field_ty, is_option_ty, private_local_struct};
 use crate::baseline::emit;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
-use rustc_span::{Symbol, sym};
+use rustc_span::Symbol;
 
 use crate::MordantConfig;
 
@@ -50,20 +51,8 @@ fn option_fields(cx: &LateContext<'_>, adt: ty::AdtDef<'_>) -> Vec<Symbol> {
     adt.non_enum_variant()
         .fields
         .iter()
-        .filter_map(|f| {
-            let ty = cx
-                .tcx
-                .type_of(f.did)
-                .instantiate_identity()
-                .skip_normalization();
-            if let ty::Adt(fadt, _) = ty.kind()
-                && cx.tcx.is_diagnostic_item(sym::Option, fadt.did())
-            {
-                Some(f.name)
-            } else {
-                None
-            }
-        })
+        .filter(|f| is_option_ty(cx, field_ty(cx, f)))
+        .map(|f| f.name)
         .collect()
 }
 
@@ -74,18 +63,9 @@ fn relevant_adt<'tcx>(
     ty: ty::Ty<'tcx>,
     min_fields: usize,
 ) -> Option<(ty::AdtDef<'tcx>, Vec<Symbol>)> {
-    let ty::Adt(adt, _) = ty.peel_refs().kind() else {
-        return None;
-    };
-    if !adt.is_struct() || !adt.did().is_local() {
-        return None;
-    }
-    let local = adt.did().expect_local();
-    if cx.effective_visibilities.is_exported(local) {
-        return None;
-    }
-    let opts = option_fields(cx, *adt);
-    (opts.len() >= min_fields).then_some((*adt, opts))
+    let adt = private_local_struct(cx, ty)?;
+    let opts = option_fields(cx, adt);
+    (opts.len() >= min_fields).then_some((adt, opts))
 }
 
 enum Init {

--- a/src/flag_cluster.rs
+++ b/src/flag_cluster.rs
@@ -1,3 +1,4 @@
+use crate::adt_facts::{field_ty, has_fixed_repr, has_positional_fields};
 use crate::baseline::emit;
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -39,30 +40,17 @@ impl<'tcx> LateLintPass<'tcx> for FlagCluster {
         };
         let did = item.owner_id.to_def_id();
         let adt = cx.tcx.adt_def(did);
-        let repr = adt.repr();
-        // An explicit repr means something outside Rust fixes the layout.
-        if repr.c() || repr.packed() || repr.transparent() || repr.simd() || repr.int.is_some() {
+        if has_fixed_repr(adt) {
             return;
         }
         let variant = adt.non_enum_variant();
-        // Tuple-struct fields are named "0", "1", …; the message wants names.
-        if variant
-            .fields
-            .iter()
-            .any(|f| f.name.as_str().starts_with(|c: char| c.is_ascii_digit()))
-        {
+        if has_positional_fields(variant) {
             return;
         }
         let bools: Vec<_> = variant
             .fields
             .iter()
-            .filter(|f| {
-                cx.tcx
-                    .type_of(f.did)
-                    .instantiate_identity()
-                    .skip_normalization()
-                    .is_bool()
-            })
+            .filter(|f| field_ty(cx, f).is_bool())
             .map(|f| f.name)
             .collect();
         if bools.len() < self.min_bools {

--- a/src/flag_cluster.rs
+++ b/src/flag_cluster.rs
@@ -14,6 +14,10 @@ rustc_session::declare_lint! {
     /// Silent on any struct with an explicit `repr` — its layout is dictated
     /// from outside Rust (a hardware register, a wire format), so all `2^n`
     /// states may genuinely be reachable.
+    ///
+    /// Runs only with `flag-cluster-enabled = true` in `dylint.toml`. Most
+    /// structs it names are option bags whose states are all legal, so it is
+    /// a survey to run once over a codebase, not a gate to keep on.
     pub FLAG_CLUSTER,
     Warn,
     "struct with several independent bool fields"

--- a/src/forbidden_reach.rs
+++ b/src/forbidden_reach.rs
@@ -3,13 +3,14 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use clippy_utils::visitors::for_each_expr;
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Body, Expr, ExprKind, FnDecl};
+use rustc_hir::{Body, Expr, FnDecl};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
 use crate::MordantConfig;
 use crate::baseline::emit;
+use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
     /// Config-declared reachability bans: "from `scheduler::pick`, no call
@@ -113,19 +114,8 @@ impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
         let caller = def_id.to_def_id();
         let mut edges = Vec::new();
         for_each_expr(cx, body.value, |e: &Expr<'tcx>| {
-            let callee = match &e.kind {
-                ExprKind::Call(callee, _) => {
-                    if let ExprKind::Path(qpath) = &callee.kind {
-                        cx.qpath_res(qpath, callee.hir_id).opt_def_id()
-                    } else {
-                        None
-                    }
-                }
-                ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(e.hir_id),
-                _ => None,
-            };
-            if let Some(callee) = callee {
-                edges.push((callee, e.span));
+            if let Some(Callee::Path { def, .. } | Callee::Method { def, .. }) = callee_of(cx, e) {
+                edges.push((def, e.span));
             }
             std::ops::ControlFlow::<()>::Continue(())
         });

--- a/src/guard_flag.rs
+++ b/src/guard_flag.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::adt_facts::{field_ty, struct_field};
 use crate::baseline::emit;
 use crate::hir_shapes::{ends_in_return, peel_not, self_field};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Body, Expr, ExprKind, FnDecl, Stmt, StmtKind};
+use rustc_hir::{Body, Expr, ExprKind, FnDecl, Mutability, Stmt, StmtKind, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::def_id::LocalDefId;
@@ -17,6 +17,11 @@ rustc_session::declare_lint! {
     /// invariant ("call X before Y") is enforced at runtime, per method, and
     /// only where someone remembered. A type per state enforces it at compile
     /// time everywhere.
+    ///
+    /// The field must also be written somewhere after construction: a flag
+    /// that is only ever set in a literal (`is_server`, `minify`) is a role
+    /// or an option, and the methods bailing on it are not enforcing an
+    /// order.
     pub GUARD_FLAG,
     Warn,
     "bool field enforcing an ordering invariant at runtime"
@@ -25,6 +30,9 @@ rustc_session::declare_lint! {
 #[derive(Default)]
 pub struct GuardFlag {
     guards: HashMap<(DefId, Symbol), usize>,
+    /// Fields assigned, compound-assigned, or mutably borrowed anywhere in
+    /// the crate: the ones whose value is a state rather than a setting.
+    written: HashSet<(DefId, Symbol)>,
 }
 
 rustc_session::impl_lint_pass!(GuardFlag => [GUARD_FLAG]);
@@ -51,7 +59,36 @@ fn self_bool_field<'tcx>(
     is_bool.then_some((*adt, ident.name))
 }
 
+/// The struct field a written place denotes, for any receiver: `x.flag`,
+/// `(*this).flag`, `self.inner.flag`.
+fn written_field<'tcx>(cx: &LateContext<'tcx>, place: &'tcx Expr<'tcx>) -> Option<(DefId, Symbol)> {
+    let mut place = place;
+    while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) = place.kind {
+        place = inner;
+    }
+    let ExprKind::Field(base, ident) = place.kind else {
+        return None;
+    };
+    let adt = cx
+        .typeck_results()
+        .expr_ty_adjusted(base)
+        .peel_refs()
+        .ty_adt_def()?;
+    (adt.is_struct() && adt.did().is_local()).then(|| (adt.did(), ident.name))
+}
+
 impl<'tcx> LateLintPass<'tcx> for GuardFlag {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let place = match expr.kind {
+            ExprKind::Assign(place, ..) | ExprKind::AssignOp(_, place, _) => place,
+            ExprKind::AddrOf(_, Mutability::Mut, place) => place,
+            _ => return,
+        };
+        if let Some(key) = written_field(cx, place) {
+            self.written.insert(key);
+        }
+    }
+
     fn check_fn(
         &mut self,
         cx: &LateContext<'tcx>,
@@ -87,7 +124,7 @@ impl<'tcx> LateLintPass<'tcx> for GuardFlag {
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
         for ((did, field), count) in &self.guards {
-            if *count < 2 {
+            if *count < 2 || !self.written.contains(&(*did, *field)) {
                 continue;
             }
             let Some(fdef) = struct_field(cx.tcx.adt_def(*did), *field) else {

--- a/src/guard_flag.rs
+++ b/src/guard_flag.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 
+use crate::adt_facts::{field_ty, struct_field};
 use crate::baseline::emit;
+use crate::hir_shapes::{ends_in_return, peel_not, self_field};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{Body, Expr, ExprKind, FnDecl, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::def_id::LocalDefId;
-use rustc_span::symbol::kw;
 use rustc_span::{Span, Symbol};
 
 rustc_session::declare_lint! {
@@ -34,65 +35,20 @@ impl GuardFlag {
     }
 }
 
-/// Strip `!`, parens, and HIR condition wrappers.
-fn peel_cond<'tcx>(mut e: &'tcx Expr<'tcx>) -> &'tcx Expr<'tcx> {
-    loop {
-        match e.kind {
-            ExprKind::Unary(rustc_hir::UnOp::Not, inner) | ExprKind::DropTemps(inner) => e = inner,
-            _ => return e,
-        }
-    }
-}
-
 /// `self.field` where `self` is the literal receiver.
 fn self_bool_field<'tcx>(
     cx: &LateContext<'tcx>,
     e: &'tcx Expr<'tcx>,
 ) -> Option<(ty::AdtDef<'tcx>, Symbol)> {
-    let ExprKind::Field(base, ident) = e.kind else {
-        return None;
-    };
-    let ExprKind::Path(rustc_hir::QPath::Resolved(None, path)) = base.kind else {
-        return None;
-    };
-    if path.segments.len() != 1 || path.segments[0].ident.name != kw::SelfLower {
-        return None;
-    }
+    let (base, ident) = self_field(e)?;
     let ty::Adt(adt, _) = cx.typeck_results().expr_ty(base).peel_refs().kind() else {
         return None;
     };
     if !adt.did().is_local() || !adt.is_struct() {
         return None;
     }
-    let is_bool = adt.non_enum_variant().fields.iter().any(|f| {
-        f.name == ident.name
-            && cx
-                .tcx
-                .type_of(f.did)
-                .instantiate_identity()
-                .skip_normalization()
-                .is_bool()
-    });
+    let is_bool = struct_field(*adt, ident.name).is_some_and(|f| field_ty(cx, f).is_bool());
     is_bool.then_some((*adt, ident.name))
-}
-
-/// The block's final action is a `return`.
-fn ends_in_return(e: &Expr<'_>) -> bool {
-    match e.kind {
-        ExprKind::Ret(_) => true,
-        ExprKind::Block(b, _) => match (b.stmts.last(), b.expr) {
-            (_, Some(tail)) => ends_in_return(tail),
-            (
-                Some(Stmt {
-                    kind: StmtKind::Expr(s) | StmtKind::Semi(s),
-                    ..
-                }),
-                None,
-            ) => ends_in_return(s),
-            _ => false,
-        },
-        _ => false,
-    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for GuardFlag {
@@ -121,7 +77,7 @@ impl<'tcx> LateLintPass<'tcx> for GuardFlag {
         let ExprKind::If(cond, then, _) = first.kind else {
             return;
         };
-        let Some((adt, field)) = self_bool_field(cx, peel_cond(cond)) else {
+        let Some((adt, field)) = self_bool_field(cx, peel_not(cond).0) else {
             return;
         };
         if ends_in_return(then) {
@@ -134,14 +90,7 @@ impl<'tcx> LateLintPass<'tcx> for GuardFlag {
             if *count < 2 {
                 continue;
             }
-            let Some(fdef) = cx
-                .tcx
-                .adt_def(*did)
-                .non_enum_variant()
-                .fields
-                .iter()
-                .find(|f| f.name == *field)
-            else {
+            let Some(fdef) = struct_field(cx.tcx.adt_def(*did), *field) else {
                 continue;
             };
             emit(

--- a/src/hir_shapes.rs
+++ b/src/hir_shapes.rs
@@ -1,0 +1,95 @@
+//! Shapes several lints read off HIR the same way: the literal `self`
+//! receiver, a field of it, a condition with its negations peeled, a branch
+//! that ends in `return`, and the definition a call expression invokes. Each
+//! lint applies its own filters on top; what lives here is only the part they
+//! spelled identically.
+
+use rustc_hir::def_id::DefId;
+use rustc_hir::{Expr, ExprKind, QPath, Stmt, StmtKind, UnOp};
+use rustc_lint::LateContext;
+use rustc_span::Ident;
+use rustc_span::symbol::kw;
+
+/// The bare `self` path.
+pub(crate) fn is_self_path(e: &Expr<'_>) -> bool {
+    matches!(&e.kind, ExprKind::Path(QPath::Resolved(None, p))
+        if p.segments.len() == 1 && p.segments[0].ident.name == kw::SelfLower)
+}
+
+/// `self.field`, as the `self` expression it is read off and the field name.
+pub(crate) fn self_field<'h>(e: &Expr<'h>) -> Option<(&'h Expr<'h>, Ident)> {
+    match e.kind {
+        ExprKind::Field(base, ident) if is_self_path(base) => Some((base, ident)),
+        _ => None,
+    }
+}
+
+/// `e` with every `!` and HIR condition wrapper stripped, in any
+/// interleaving, and whether at least one `!` was among them. `!!x` reports
+/// negated: the callers ask whether the condition is spelled as a bail-out,
+/// not what it evaluates to.
+pub(crate) fn peel_not<'h>(mut e: &'h Expr<'h>) -> (&'h Expr<'h>, bool) {
+    let mut negated = false;
+    loop {
+        match e.kind {
+            ExprKind::Unary(UnOp::Not, inner) => {
+                negated = true;
+                e = inner;
+            }
+            ExprKind::DropTemps(inner) => e = inner,
+            _ => return (e, negated),
+        }
+    }
+}
+
+/// The expression's final action is a `return`.
+pub(crate) fn ends_in_return(e: &Expr<'_>) -> bool {
+    match e.kind {
+        ExprKind::Ret(_) => true,
+        ExprKind::Block(b, _) => match (b.stmts.last(), b.expr) {
+            (_, Some(tail)) => ends_in_return(tail),
+            (
+                Some(Stmt {
+                    kind: StmtKind::Expr(s) | StmtKind::Semi(s),
+                    ..
+                }),
+                None,
+            ) => ends_in_return(s),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// What a call expression invokes.
+pub(crate) enum Callee<'h> {
+    /// `f(..)`, `T::f(..)`, `E::V(..)`: whatever the callee path resolves to.
+    Path { def: DefId, args: &'h [Expr<'h>] },
+    /// `recv.m(..)`: the method type-dependent resolution picked.
+    Method {
+        def: DefId,
+        recv: &'h Expr<'h>,
+        args: &'h [Expr<'h>],
+    },
+}
+
+/// Resolves a call or method call. `def` is unfiltered — constructors and
+/// foreign definitions come back too — because each caller wants a different
+/// subset. A call through anything but a path (a closure value, a field
+/// holding a fn pointer) resolves to nothing.
+pub(crate) fn callee_of<'tcx>(cx: &LateContext<'tcx>, e: &Expr<'tcx>) -> Option<Callee<'tcx>> {
+    match e.kind {
+        ExprKind::Call(callee, args) => {
+            let ExprKind::Path(qpath) = &callee.kind else {
+                return None;
+            };
+            let def = cx.qpath_res(qpath, callee.hir_id).opt_def_id()?;
+            Some(Callee::Path { def, args })
+        }
+        ExprKind::MethodCall(_, recv, args, _) => {
+            let def = cx.typeck_results().type_dependent_def_id(e.hir_id)?;
+            Some(Callee::Method { def, recv, args })
+        }
+        _ => None,
+    }
+}

--- a/src/insert_then_unwrap.rs
+++ b/src/insert_then_unwrap.rs
@@ -1,5 +1,5 @@
 use clippy_utils::visitors::for_each_expr;
-use rustc_hir::{Block, Expr, ExprKind, QPath, StmtKind};
+use rustc_hir::{Block, Expr, ExprKind, Pat, QPath, StmtKind, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::sym;
@@ -13,6 +13,9 @@ rustc_session::declare_lint! {
     /// could touch the map or the key: no calls, no assignments to either.
     /// The unwrap re-fetches a value the code already held, and the panic
     /// path plus the second hash both disappear by keeping it.
+    ///
+    /// Silent once a `let` in between rebinds the name the map or key was
+    /// spelled with, and treats `-k` / `!k` as a different key from `k`.
     pub INSERT_THEN_UNWRAP,
     Warn,
     "unwrap of a lookup proven by an insert just above"
@@ -21,8 +24,9 @@ rustc_session::declare_lint! {
 rustc_session::declare_lint_pass!(InsertThenUnwrap => [INSERT_THEN_UNWRAP]);
 
 /// A stable textual identity for the small expressions worth tracking:
-/// `self.a.b` chains, plain locals, and literals. Anything else is `None`,
-/// and untrackable means unprovable means silent.
+/// `self.a.b` chains, plain locals, and literals, seen through `&` and `*`
+/// (which name the same value); `-k` and `!k` are different values from `k`.
+/// Anything else is `None`, and untrackable means unprovable means silent.
 fn identity(e: &Expr<'_>) -> Option<String> {
     match &e.kind {
         ExprKind::Field(base, ident) => Some(format!("{}.{}", identity(base)?, ident.name)),
@@ -35,9 +39,24 @@ fn identity(e: &Expr<'_>) -> Option<String> {
             }
         }
         ExprKind::Lit(lit) => Some(format!("lit:{:?}", lit.node)),
-        ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(_, inner) => identity(inner),
+        ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) => identity(inner),
         _ => None,
     }
+}
+
+/// The local an identity is rooted at: `k` for `k` and `k.id`, `None` for
+/// `self` chains and literals, which no `let` can rebind.
+fn root_local(id: &str) -> Option<&str> {
+    let root = id.split('.').next()?;
+    (root != "self" && !root.starts_with("lit:")).then_some(root)
+}
+
+/// A `let` between the insert and the lookup that rebinds the map's or the
+/// key's root name makes the later spelling name a different value.
+fn rebinds(pat: &Pat<'_>, roots: &[&str]) -> bool {
+    let mut hit = false;
+    pat.each_binding(|_, _, _, ident| hit |= roots.contains(&ident.as_str()));
+    hit
 }
 
 fn is_map(cx: &LateContext<'_>, recv: &Expr<'_>) -> bool {
@@ -117,17 +136,23 @@ impl<'tcx> LateLintPass<'tcx> for InsertThenUnwrap {
             let Some((map, key)) = insert_of(cx, e) else {
                 continue;
             };
+            let roots: Vec<&str> = [&map, &key]
+                .into_iter()
+                .filter_map(|id| root_local(id))
+                .collect();
             for later in &block.stmts[i + 1..] {
-                let le = match later.kind {
-                    StmtKind::Expr(le) | StmtKind::Semi(le) => Some(le),
-                    StmtKind::Let(l) => l.init,
-                    StmtKind::Item(_) => None,
+                let (le, pat) = match later.kind {
+                    StmtKind::Expr(le) | StmtKind::Semi(le) => (Some(le), None),
+                    // The initializer still sees the names as the insert did;
+                    // the pattern takes effect for the statements after it.
+                    StmtKind::Let(l) => (l.init, Some(l.pat)),
+                    StmtKind::Item(_) => (None, None),
                 };
-                let Some(le) = le else { continue };
                 // The lookup must be the statement's own top-level shape (or
                 // the let initializer); a lookup buried under other calls is
                 // checked as a disturbance instead.
-                if let Some((gmap, gkey, shown, at)) = get_unwrap_of(cx, le)
+                if let Some(le) = le
+                    && let Some((gmap, gkey, shown, at)) = get_unwrap_of(cx, le)
                     && gmap == map
                     && gkey == key
                 {
@@ -143,7 +168,10 @@ impl<'tcx> LateLintPass<'tcx> for InsertThenUnwrap {
                     );
                     return;
                 }
-                if may_disturb(cx, le) {
+                if pat.is_some_and(|p| rebinds(p, &roots)) {
+                    break;
+                }
+                if le.is_some_and(|le| may_disturb(cx, le)) {
                     break;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate rustc_span;
 
 dylint_linting::dylint_library!();
 
+mod adt_facts;
 mod asymmetric_guard;
 mod baseline;
 mod bypassed_validator;
@@ -26,8 +27,10 @@ mod exclusive_options;
 mod flag_cluster;
 mod forbidden_reach;
 mod guard_flag;
+mod hir_shapes;
 mod insert_then_unwrap;
 mod lock_order;
+mod mir_flow;
 mod narrowed_return;
 mod nonidentity_key;
 mod overwide_parameter;
@@ -54,7 +57,7 @@ mod wildcard_local_enum;
 /// gate reads these field names out of the pinned source to decide which keys
 /// it may set — so grouping them into sub-structs would rename user-visible
 /// keys to satisfy a lint about internal invariants.
-#[derive(Clone, serde::Deserialize)]
+#[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
 #[cfg_attr(dylint_lib = "mordant", allow(flag_cluster))]
 pub struct MordantConfig {
@@ -146,9 +149,9 @@ impl Default for MordantConfig {
 pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
     dylint_linting::init_config(sess);
     let config: MordantConfig = dylint_linting::config_or_default(env!("CARGO_PKG_NAME"));
+    let config: &'static MordantConfig = Box::leak(Box::new(config));
     baseline::setup(&config.baseline);
     lint_store.register_lints(&[
-        baseline::MORDANT_BASELINE,
         stringly_error::STRINGLY_ERROR,
         nonidentity_key::NONIDENTITY_KEY,
         stringified_error::STRINGIFIED_ERROR,
@@ -173,40 +176,32 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
         discarded_error::DISCARDED_ERROR,
         stored_projection::STORED_PROJECTION,
     ]);
-    let c1 = config.clone();
-    let c2 = config.clone();
-    let c3 = config.clone();
-    lint_store.register_late_pass(move |_| Box::new(stringly_error::StringlyError::new(&c1)));
-    lint_store.register_late_pass(move |_| Box::new(nonidentity_key::NonidentityKey::new(&c2)));
+    lint_store.register_late_pass(move |_| Box::new(stringly_error::StringlyError::new(config)));
+    lint_store.register_late_pass(move |_| Box::new(nonidentity_key::NonidentityKey::new(config)));
     lint_store.register_late_pass(|_| Box::new(stringified_error::StringifiedError));
-    lint_store.register_late_pass(move |_| Box::new(exclusive_options::ExclusiveOptions::new(&c3)));
-    lint_store.register_late_pass(|_| Box::new(parallel_bools::ParallelBools::new()));
-    let c6 = config.clone();
-    // Cloned here rather than beside its registration below: `config` itself is
-    // moved into the `wildcard_local_enum` closure before that point.
-    let c7 = config.clone();
-    lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster::new(&c6)));
-    let c5 = config.clone();
     lint_store
-        .register_late_pass(move |_| Box::new(bypassed_validator::BypassedValidator::new(&c5)));
+        .register_late_pass(move |_| Box::new(exclusive_options::ExclusiveOptions::new(config)));
+    lint_store.register_late_pass(|_| Box::new(parallel_bools::ParallelBools::new()));
+    lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster::new(config)));
+    lint_store
+        .register_late_pass(move |_| Box::new(bypassed_validator::BypassedValidator::new(config)));
     lint_store.register_late_pass(|_| Box::new(unread_error_variant::UnreadErrorVariant::new()));
     lint_store.register_late_pass(|_| Box::new(asymmetric_guard::AsymmetricGuard::new()));
     lint_store.register_late_pass(|_| Box::new(stale_safety_comment::StaleSafetyComment::new()));
     lint_store.register_late_pass(|_| Box::new(unit_mismatch::UnitMismatch));
     lint_store.register_late_pass(|_| Box::new(stale_panic_message::StalePanicMessage::new()));
     lint_store.register_late_pass(|_| Box::new(lock_order::LockOrder::new()));
-    let c4 = config.clone();
-    lint_store.register_late_pass(move |_| Box::new(forbidden_reach::ForbiddenReach::new(&c4)));
+    lint_store.register_late_pass(move |_| Box::new(forbidden_reach::ForbiddenReach::new(config)));
     lint_store.register_late_pass(|_| Box::new(guard_flag::GuardFlag::new()));
     lint_store.register_late_pass(|_| Box::new(unread_none::UnreadNone::new()));
     lint_store.register_late_pass(|_| Box::new(insert_then_unwrap::InsertThenUnwrap));
     lint_store.register_late_pass(|_| Box::new(overwide_parameter::OverwideParameter::new()));
     lint_store.register_late_pass(|_| Box::new(narrowed_return::NarrowedReturn::new()));
-    lint_store.register_late_pass(move |_| {
-        Box::new(wildcard_local_enum::WildcardLocalEnum::new(&config))
-    });
+    lint_store
+        .register_late_pass(move |_| Box::new(wildcard_local_enum::WildcardLocalEnum::new(config)));
     lint_store.register_late_pass(|_| Box::new(discarded_error::DiscardedError));
-    lint_store.register_late_pass(move |_| Box::new(stored_projection::StoredProjection::new(&c7)));
+    lint_store
+        .register_late_pass(move |_| Box::new(stored_projection::StoredProjection::new(config)));
     // Last, so its check_crate_post flushes after every lint has recorded.
     lint_store.register_late_pass(|_| Box::new(baseline::BaselineWriter));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod baseline;
 mod bypassed_validator;
 mod claims;
 mod ctor_flow;
+mod defaulted_failure;
 mod discarded_error;
 mod enum_facts;
 mod exclusive_options;
@@ -35,11 +36,13 @@ mod narrowed_return;
 mod nonidentity_key;
 mod overwide_parameter;
 mod parallel_bools;
+mod stale_across_reentry;
 mod stale_panic_message;
 mod stale_safety_comment;
 mod stored_projection;
 mod stringified_error;
 mod stringly_error;
+mod unchecked_input_len;
 mod unit_mismatch;
 mod unread_error_variant;
 mod unread_none;
@@ -50,7 +53,7 @@ mod wildcard_local_enum;
 ///
 /// `flag_cluster` is allowed on this one struct, and it is the lawful-lattice
 /// case the lint's own help describes rather than an exemption from it. The
-/// bools are opt-ins belonging to *different* lints: all four combinations are
+/// bools are opt-ins belonging to *different* lints: every combination is
 /// reachable from a `dylint.toml` and each means what it says, so there is no
 /// invariant between them for a type to carry. The field set is also this
 /// pack's public interface — every field is a TOML key, and Scarlet's `xtask`
@@ -102,6 +105,40 @@ pub struct MordantConfig {
     /// Reachability bans: from each matching root, no call path may reach a
     /// banned definition. Findings carry the witness path.
     pub forbidden_reach: Vec<forbidden_reach::ReachRule>,
+    /// This project's own re-entry points, for `stale_across_reentry`, on top
+    /// of the built-in closure / fn-pointer / `dyn` / `.await` set: paths
+    /// matched by `::`-segment suffix (`Vm::run_callback`, `run_callback`;
+    /// a method of a trait impl matches under its type or its trait,
+    /// `Worker::run_job` or `Runner::run_job`), with a trailing `*` on the
+    /// last segment matching by prefix (`dispatch*`).
+    pub stale_across_reentry_callees: Vec<String>,
+    /// Callees `defaulted_failure` takes as rejecting their argument without
+    /// reading their body: parsers in other crates, or local ones whose
+    /// failure is built by combinators. Spelled like
+    /// `validator-resource-errors` (a full path, `crate::name`, or a bare
+    /// name). Empty by default; the lint then reports only callees whose
+    /// body it can see the check in.
+    pub defaulted_failure_callees: Vec<String>,
+    /// Opt-in: run `flag_cluster`. Off by default because most structs it
+    /// names are option bags; the state machines among them are found by
+    /// running it once, not by gating on it.
+    pub flag_cluster_enabled: bool,
+    /// Opt-in: run `stale_safety_comment`. Off by default because a name a
+    /// crate cannot see is usually defined in C++, a script, or a downstream
+    /// crate; the stale ones are found by running it once.
+    pub stale_safety_comment_enabled: bool,
+    /// Error types whose failure `defaulted_failure` does not count, on top
+    /// of `validator-resource-errors`: errors that are already recorded
+    /// somewhere else by the time they are returned (a "JS exception is
+    /// pending" marker, a diagnostic already pushed to a log), so defaulting
+    /// them hides nothing. Same spellings as `validator-resource-errors`.
+    pub defaulted_failure_ignored_errors: Vec<String>,
+    /// Opt-in: run `unchecked_input_len`. Off by default because most of
+    /// what it names on a codebase whose callers vouch for their lengths is a
+    /// value the function also uses as some other value's limit (TRIAGE.md),
+    /// which nothing inside the function tells from a missed check; run it
+    /// once over parsing code and read the list.
+    pub unchecked_input_len_enabled: bool,
 }
 
 fn default_min_fields() -> usize {
@@ -140,6 +177,12 @@ impl Default for MordantConfig {
             stored_projection_min_sites: default_min_sites(),
             baseline: None,
             forbidden_reach: Vec::new(),
+            stale_across_reentry_callees: Vec::new(),
+            defaulted_failure_callees: Vec::new(),
+            flag_cluster_enabled: false,
+            stale_safety_comment_enabled: false,
+            defaulted_failure_ignored_errors: Vec::new(),
+            unchecked_input_len_enabled: false,
         }
     }
 }
@@ -159,7 +202,6 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
         parallel_bools::PARALLEL_BOOLS,
         flag_cluster::FLAG_CLUSTER,
         bypassed_validator::BYPASSED_VALIDATOR,
-        bypassed_validator::PUB_INVARIANT_FIELDS,
         unread_error_variant::UNREAD_ERROR_VARIANT,
         asymmetric_guard::ASYMMETRIC_GUARD,
         stale_safety_comment::STALE_SAFETY_COMMENT,
@@ -175,6 +217,9 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
         wildcard_local_enum::WILDCARD_LOCAL_ENUM,
         discarded_error::DISCARDED_ERROR,
         stored_projection::STORED_PROJECTION,
+        stale_across_reentry::STALE_ACROSS_REENTRY,
+        defaulted_failure::DEFAULTED_FAILURE,
+        unchecked_input_len::UNCHECKED_INPUT_LEN,
     ]);
     lint_store.register_late_pass(move |_| Box::new(stringly_error::StringlyError::new(config)));
     lint_store.register_late_pass(move |_| Box::new(nonidentity_key::NonidentityKey::new(config)));
@@ -182,12 +227,19 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     lint_store
         .register_late_pass(move |_| Box::new(exclusive_options::ExclusiveOptions::new(config)));
     lint_store.register_late_pass(|_| Box::new(parallel_bools::ParallelBools::new()));
-    lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster::new(config)));
+    // The opt-in lints stay registered above so `allow(..)` / `-A` of them
+    // still resolve; only their passes are skipped.
+    if config.flag_cluster_enabled {
+        lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster::new(config)));
+    }
     lint_store
         .register_late_pass(move |_| Box::new(bypassed_validator::BypassedValidator::new(config)));
     lint_store.register_late_pass(|_| Box::new(unread_error_variant::UnreadErrorVariant::new()));
     lint_store.register_late_pass(|_| Box::new(asymmetric_guard::AsymmetricGuard::new()));
-    lint_store.register_late_pass(|_| Box::new(stale_safety_comment::StaleSafetyComment::new()));
+    if config.stale_safety_comment_enabled {
+        lint_store
+            .register_late_pass(|_| Box::new(stale_safety_comment::StaleSafetyComment::new()));
+    }
     lint_store.register_late_pass(|_| Box::new(unit_mismatch::UnitMismatch));
     lint_store.register_late_pass(|_| Box::new(stale_panic_message::StalePanicMessage::new()));
     lint_store.register_late_pass(|_| Box::new(lock_order::LockOrder::new()));
@@ -202,6 +254,14 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     lint_store.register_late_pass(|_| Box::new(discarded_error::DiscardedError));
     lint_store
         .register_late_pass(move |_| Box::new(stored_projection::StoredProjection::new(config)));
+    lint_store.register_late_pass(move |_| {
+        Box::new(stale_across_reentry::StaleAcrossReentry::new(config))
+    });
+    lint_store
+        .register_late_pass(move |_| Box::new(defaulted_failure::DefaultedFailure::new(config)));
+    if config.unchecked_input_len_enabled {
+        lint_store.register_late_pass(|_| Box::new(unchecked_input_len::UncheckedInputLen));
+    }
     // Last, so its check_crate_post flushes after every lint has recorded.
     lint_store.register_late_pass(|_| Box::new(baseline::BaselineWriter));
 }
@@ -217,6 +277,12 @@ fn ui() {
             nonidentity-key-methods = ["Value::to_raw"]
             nonidentity-key-composite = true
             nonidentity-key-fixes = ["FileId"]
+            stale-across-reentry-callees = ["Vm::run_callback", "dispatch*", "Worker::run_job", "Runner::schedule"]
+            defaulted-failure-callees = ["from_str_radix", "listed_by_config"]
+            defaulted-failure-ignored-errors = ["Pending"]
+            flag-cluster-enabled = true
+            stale-safety-comment-enabled = true
+            unchecked-input-len-enabled = true
 
             [[mordant.forbidden-reach]]
             from = "hot_path"
@@ -234,6 +300,15 @@ fn ui() {
         .run();
 }
 
+/// The `ui` fixtures for the opt-in lints run with their keys on; these
+/// re-run the same shapes with the keys absent and expect nothing.
+#[test]
+fn ui_opt_in_lints_are_off_without_their_key() {
+    dylint_testing::ui::Test::src_base(env!("CARGO_PKG_NAME"), "ui_off")
+        .dylint_toml("[mordant]\n")
+        .run();
+}
+
 /// `config_or_default` returns `Default` when the linted workspace has no
 /// `dylint.toml`. A derived `Default` yields 0 for every `usize`, which
 /// turns `wildcard_local_enum` off (`n > 0` for every enum) and makes
@@ -245,6 +320,9 @@ fn config_default_thresholds_match_docs() {
     assert_eq!(c.wildcard_local_enum_max_variants, 12);
     assert_eq!(c.flag_cluster_min_bools, 3);
     assert_eq!(c.stored_projection_min_sites, 2);
+    assert!(!c.flag_cluster_enabled);
+    assert!(!c.stale_safety_comment_enabled);
+    assert!(!c.unchecked_input_len_enabled);
 }
 
 /// An empty table (file present, keys omitted) must not drift from
@@ -266,6 +344,15 @@ fn config_omitted_toml_keys_use_the_same_thresholds() {
     assert_eq!(
         parsed.stored_projection_min_sites,
         d.stored_projection_min_sites
+    );
+    assert_eq!(parsed.flag_cluster_enabled, d.flag_cluster_enabled);
+    assert_eq!(
+        parsed.stale_safety_comment_enabled,
+        d.stale_safety_comment_enabled
+    );
+    assert_eq!(
+        parsed.unchecked_input_len_enabled,
+        d.unchecked_input_len_enabled
     );
 }
 

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use clippy_utils::visitors::for_each_expr;
+use clippy_utils::visitors::{Descend, for_each_expr};
+use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{Body, Expr, ExprKind, FnDecl, PatKind, QPath, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -21,16 +22,28 @@ rustc_session::declare_lint! {
     /// Conservative on purpose: only `.lock()`, `.read()` and `.write()` on
     /// receivers whose type is a `Mutex` or `RwLock`, only guards bound by
     /// `let` in the same block, and only second acquisitions in later
-    /// statements of that block with no `drop(guard)` in between.
+    /// statements of that block with no `drop(guard)` in between. A lock is
+    /// a field path off `self` together with `self`'s type, so `self.state`
+    /// of two different types are two different locks. An acquisition inside
+    /// a closure built while the guard is held does not count as a second
+    /// lock: when the closure runs is the holder's business, and the closure
+    /// body is judged on its own when it takes two locks itself.
     pub LOCK_ORDER,
     Warn,
     "two locks acquired in conflicting orders"
 }
 
+/// One lock: the field path off `self`, owned by `self`'s type.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct Lock {
+    owner: DefId,
+    path: String,
+}
+
 #[derive(Default)]
 pub struct LockOrder {
     /// (first lock, second lock) -> where the pair was seen.
-    pairs: HashMap<(String, String), Span>,
+    pairs: HashMap<(Lock, Lock), Span>,
 }
 
 rustc_session::impl_lint_pass!(LockOrder => [LOCK_ORDER]);
@@ -42,8 +55,8 @@ impl LockOrder {
 }
 
 /// `self.a.b.lock()` (or `.read()` / `.write()`) on a `Mutex`/`RwLock`
-/// receiver: the lock's identity is the field path.
-fn lock_acquisition(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<String> {
+/// receiver: the lock's identity is the field path and the type of `self`.
+fn lock_acquisition(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<Lock> {
     let ExprKind::MethodCall(seg, recv, [], _) = &e.kind else {
         return None;
     };
@@ -58,22 +71,32 @@ fn lock_acquisition(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<String> {
     if !(ty_path.ends_with("Mutex") || ty_path.ends_with("RwLock")) {
         return None;
     }
-    field_path(recv)
+    let (root, path) = field_path(recv)?;
+    // Adjusted: `self` is the base of the first field access, so this is the
+    // type the path is projected from, through `&self` or `self: Arc<Self>`.
+    let owner = cx
+        .typeck_results()
+        .expr_ty_adjusted(root)
+        .peel_refs()
+        .ty_adt_def()?
+        .did();
+    Some(Lock { owner, path })
 }
 
-/// `self.a.b` rendered as "a.b"; `None` for anything that is not a plain
-/// field chain off `self`, since only those have a stable identity.
-fn field_path(e: &Expr<'_>) -> Option<String> {
+/// `self.a.b` rendered as "a.b", with the `self` it hangs off; `None` for
+/// anything that is not a plain field chain off `self`, since only those
+/// have a stable identity.
+fn field_path<'h>(e: &'h Expr<'h>) -> Option<(&'h Expr<'h>, String)> {
     match &e.kind {
         ExprKind::Field(base, ident) => {
-            let prefix = field_path(base)?;
+            let (root, prefix) = field_path(base)?;
             if prefix.is_empty() {
-                Some(ident.name.to_string())
+                Some((root, ident.name.to_string()))
             } else {
-                Some(format!("{prefix}.{}", ident.name))
+                Some((root, format!("{prefix}.{}", ident.name)))
             }
         }
-        ExprKind::Path(_) if is_self_path(e) => Some(String::new()),
+        ExprKind::Path(_) if is_self_path(e) => Some((e, String::new())),
         ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(_, inner) => field_path(inner),
         _ => None,
     }
@@ -81,10 +104,7 @@ fn field_path(e: &Expr<'_>) -> Option<String> {
 
 /// The lock acquired by this statement's `let` initializer, with the bound
 /// name, when the whole initializer is (or trivially wraps) the acquisition.
-fn stmt_lock_binding(
-    cx: &LateContext<'_>,
-    stmt: &Stmt<'_>,
-) -> Option<(String, rustc_span::Symbol)> {
+fn stmt_lock_binding(cx: &LateContext<'_>, stmt: &Stmt<'_>) -> Option<(Lock, rustc_span::Symbol)> {
     let StmtKind::Let(l) = stmt.kind else {
         return None;
     };
@@ -149,14 +169,22 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
                             if is_drop_of(le, guard_name) {
                                 break 'later;
                             }
-                            let mut second: Option<(String, Span)> = None;
+                            let mut second: Option<(Lock, Span)> = None;
                             for_each_expr(cx, le, |inner: &Expr<'_>| {
+                                // A closure built here runs whenever its
+                                // holder decides, possibly after the guard is
+                                // gone; what it locks is not locked now.
+                                if matches!(inner.kind, ExprKind::Closure(..)) {
+                                    return std::ops::ControlFlow::<(), Descend>::Continue(
+                                        Descend::No,
+                                    );
+                                }
                                 if let Some(l) = lock_acquisition(cx, inner)
                                     && l != first
                                 {
                                     second = Some((l, inner.span));
                                 }
-                                std::ops::ControlFlow::<()>::Continue(())
+                                std::ops::ControlFlow::<(), Descend>::Continue(Descend::Yes)
                             });
                             if let Some((second, at)) = second {
                                 self.pairs.entry((first.clone(), second)).or_insert(at);
@@ -174,10 +202,11 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
         for ((a, b), span) in &self.pairs {
             // Report each conflicting pair once, from the lexically smaller
             // side, so the two orders produce one finding, not two.
-            if a >= b {
+            if a.path >= b.path {
                 continue;
             }
             if let Some(rev_span) = self.pairs.get(&(b.clone(), a.clone())) {
+                let (a, b) = (&a.path, &b.path);
                 emit(
                     cx,
                     LOCK_ORDER,

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -7,9 +7,9 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
-use rustc_span::symbol::kw;
 
 use crate::baseline::emit;
+use crate::hir_shapes::is_self_path;
 
 rustc_session::declare_lint! {
     /// Flags two lock acquisitions the crate performs in both orders: one
@@ -73,11 +73,7 @@ fn field_path(e: &Expr<'_>) -> Option<String> {
                 Some(format!("{prefix}.{}", ident.name))
             }
         }
-        ExprKind::Path(QPath::Resolved(None, p))
-            if p.segments.len() == 1 && p.segments[0].ident.name == kw::SelfLower =>
-        {
-            Some(String::new())
-        }
+        ExprKind::Path(_) if is_self_path(e) => Some(String::new()),
         ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(_, inner) => field_path(inner),
         _ => None,
     }

--- a/src/mir_flow.rs
+++ b/src/mir_flow.rs
@@ -1,7 +1,7 @@
 //! MIR machinery shared by the body-level analyses, with no opinion about
 //! what any of it means for a lint.
 //!
-//! It answers four questions about a body:
+//! It answers five questions about a body:
 //!
 //! * which MIR to read at all (`mir_for`: the pre-optimization body, so `?`
 //!   is still a `Try::branch` call and every aggregate is intact);
@@ -11,11 +11,15 @@
 //!   `post_dominators`, `control_deps`), over a CFG in which blocks that
 //!   cannot reach a `return` do not exist, so nothing is "decided" by an
 //!   `assert!`;
+//! * whether every path to a block passes through another (`dominates`).
+//!   This is a different relation from control dependence: a clamp's branch
+//!   dominates the use after it without deciding whether the use runs;
 //! * what a branch switches on (`switch_operand_atoms`).
 //!
 //! What the answers mean is the caller's business: `ctor_flow` combines them
-//! into "does a failure exit depend on a stored field", `variant_flow` uses
-//! only `mir_for` and traces returned variants its own way.
+//! into "does a failure exit depend on a stored field", `unchecked_input_len`
+//! asks whether a comparison dominates a use, `variant_flow` uses only
+//! `mir_for` and traces returned variants its own way.
 
 use std::collections::{HashSet, VecDeque};
 
@@ -316,25 +320,36 @@ pub(crate) fn post_dominators(cfg: &Cfg) -> Vec<Bits> {
     pdom
 }
 
+/// Branches (`t` not post-dominating them, but post-dominating one of their
+/// successors) whose outcome decides whether `t` runs, in block order.
+fn direct_deps(cfg: &Cfg, pdom: &[Bits], t: usize) -> Vec<usize> {
+    (0..cfg.exit)
+        .filter(|a| {
+            let strictly = pdom[*a].has(t) && *a != t;
+            cfg.succs[*a].len() >= 2 && !strictly && cfg.succs[*a].iter().any(|s| pdom[*s].has(t))
+        })
+        .collect()
+}
+
+/// Branch blocks that `target` is directly control-dependent on: the ones
+/// whose outcome sends control to `target` or away from it. A branch that
+/// only decides whether one of those is reached (an early `return Ok` guard
+/// in front of it) is not among them; `control_deps` has those too.
+pub(crate) fn direct_control_deps(cfg: &Cfg, pdom: &[Bits], target: BasicBlock) -> Vec<BasicBlock> {
+    direct_deps(cfg, pdom, target.as_usize())
+        .into_iter()
+        .map(BasicBlock::from_usize)
+        .collect()
+}
+
 /// Branch blocks that `target` is transitively control-dependent on,
 /// innermost first.
 pub(crate) fn control_deps(cfg: &Cfg, pdom: &[Bits], target: BasicBlock) -> Vec<BasicBlock> {
-    let branches: Vec<usize> = (0..cfg.exit).filter(|a| cfg.succs[*a].len() >= 2).collect();
-    let direct = |t: usize| -> Vec<usize> {
-        branches
-            .iter()
-            .copied()
-            .filter(|a| {
-                let strictly = pdom[*a].has(t) && *a != t;
-                !strictly && cfg.succs[*a].iter().any(|s| pdom[*s].has(t))
-            })
-            .collect()
-    };
     let mut seen = HashSet::new();
     let mut q = VecDeque::from([target.as_usize()]);
     let mut deps = Vec::new();
     while let Some(t) = q.pop_front() {
-        for a in direct(t) {
+        for a in direct_deps(cfg, pdom, t) {
             if seen.insert(a) {
                 deps.push(BasicBlock::from_usize(a));
                 q.push_back(a);
@@ -356,4 +371,13 @@ pub(crate) fn switch_operand_atoms(body: &Body<'_>, bb: BasicBlock) -> Vec<Atom>
             .unwrap_or_default(),
         _ => Vec::new(),
     }
+}
+
+// ── dominance ────────────────────────────────────────────────────────────────
+
+/// Every path from the entry to `at` passes through `check` (rustc's forward
+/// dominators over the full CFG). Reflexive; false when `at` is unreachable.
+pub(crate) fn dominates(body: &Body<'_>, check: BasicBlock, at: BasicBlock) -> bool {
+    let d = body.basic_blocks.dominators();
+    d.is_reachable(at) && d.dominates(check, at)
 }

--- a/src/mir_flow.rs
+++ b/src/mir_flow.rs
@@ -1,0 +1,359 @@
+//! MIR machinery shared by the body-level analyses, with no opinion about
+//! what any of it means for a lint.
+//!
+//! It answers four questions about a body:
+//!
+//! * which MIR to read at all (`mir_for`: the pre-optimization body, so `?`
+//!   is still a `Try::branch` call and every aggregate is intact);
+//! * what a place names, as an [`Atom`] -- a local plus its leading field
+//!   path -- and how faithfully (`place_info`, [`Exactness`]);
+//! * which branches a block is control-dependent on (`build_cfg`,
+//!   `post_dominators`, `control_deps`), over a CFG in which blocks that
+//!   cannot reach a `return` do not exist, so nothing is "decided" by an
+//!   `assert!`;
+//! * what a branch switches on (`switch_operand_atoms`).
+//!
+//! What the answers mean is the caller's business: `ctor_flow` combines them
+//! into "does a failure exit depend on a stored field", `variant_flow` uses
+//! only `mir_for` and traces returned variants its own way.
+
+use std::collections::{HashSet, VecDeque};
+
+use rustc_hir::def_id::LocalDefId;
+use rustc_middle::mir::{BasicBlock, Body, Local, Operand, Place, ProjectionElem, TerminatorKind};
+use rustc_middle::ty::TyCtxt;
+
+// ── MIR access ───────────────────────────────────────────────────────────────
+
+pub(crate) fn mir_for<'tcx>(tcx: TyCtxt<'tcx>, def: LocalDefId) -> Option<MirRef<'tcx>> {
+    if !tcx.def_kind(def).is_fn_like() || !tcx.is_mir_available(def.to_def_id()) {
+        return None;
+    }
+    // The pre-optimization body keeps `?` as `Try::branch` calls and every
+    // aggregate intact regardless of the build's opt level. It is stolen once
+    // `optimized_mir` runs, which nothing before codegen asks for; fall back
+    // if some other driver did.
+    let steal = tcx.mir_drops_elaborated_and_const_checked(def);
+    if steal.is_stolen() {
+        Some(MirRef::Opt(tcx.optimized_mir(def.to_def_id())))
+    } else {
+        Some(MirRef::Steal(steal.borrow()))
+    }
+}
+
+pub(crate) enum MirRef<'tcx> {
+    Steal(rustc_data_structures::sync::MappedReadGuard<'tcx, Body<'tcx>>),
+    Opt(&'tcx Body<'tcx>),
+}
+
+impl<'tcx> std::ops::Deref for MirRef<'tcx> {
+    type Target = Body<'tcx>;
+    fn deref(&self) -> &Body<'tcx> {
+        match self {
+            MirRef::Steal(g) => g,
+            MirRef::Opt(b) => b,
+        }
+    }
+}
+
+// ── places as atoms ──────────────────────────────────────────────────────────
+
+/// A local plus the leading run of field projections: `_3.1.0`. Anything past
+/// the first deref/index/downcast is folded into the prefix before it.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct Atom {
+    pub(crate) local: Local,
+    pub(crate) path: Vec<u32>,
+}
+
+/// Path component for "some element of": indexing conflates positions but
+/// keeps the container distinct from its elements, so a length check on a
+/// slice is not a check on the element later stored out of it.
+pub(crate) const ANY_ELEM: u32 = u32::MAX;
+
+impl Atom {
+    pub(crate) fn whole(local: Local) -> Self {
+        Atom {
+            local,
+            path: Vec::new(),
+        }
+    }
+    pub(crate) fn extended(&self, tail: &[u32]) -> Self {
+        // `node = node.next` in a loop composes without bound; past a few
+        // levels the distinction stops mattering, so the path saturates.
+        const MAX_PATH: usize = 6;
+        let mut path = self.path.clone();
+        let room = MAX_PATH.saturating_sub(path.len());
+        path.extend_from_slice(&tail[..tail.len().min(room)]);
+        Atom {
+            local: self.local,
+            path,
+        }
+    }
+    pub(crate) fn overlaps(&self, other: &Atom) -> bool {
+        self.local == other.local && self.path.iter().zip(&other.path).all(|(a, b)| a == b)
+    }
+    /// `self` (a decision atom) reads `stored` or a part of it. The reverse,
+    /// a decision on the whole of something only part of which is stored
+    /// (`lexer.next()?` then `log: lexer.log`), is not evidence about the part.
+    pub(crate) fn inspects(&self, stored: &Atom) -> bool {
+        self.local == stored.local && is_prefix(&stored.path, &self.path)
+    }
+}
+
+/// How well `PlaceInfo::atom` names what the projection actually read.
+///
+/// A `Downcast` is absorbing: it ends the exact field path and no later
+/// projection puts it back, so "payload" and "exact" cannot hold at once and
+/// every caller below branches payload-first. Three states, not four.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Exactness {
+    /// Pure field access: the atom is exact.
+    Exact,
+    /// A `Downcast` appeared: this reads a variant payload of the atom.
+    VariantPayload,
+    /// Some other projection: the atom names more than was read.
+    Inexact,
+}
+
+impl Exactness {
+    /// A projection this does not model. It can only lose precision, and it
+    /// cannot un-see a `Downcast`.
+    fn blur(self) -> Self {
+        match self {
+            Exactness::Exact | Exactness::Inexact => Exactness::Inexact,
+            Exactness::VariantPayload => Exactness::VariantPayload,
+        }
+    }
+}
+
+pub(crate) struct PlaceInfo {
+    pub(crate) atom: Atom,
+    pub(crate) exactness: Exactness,
+    pub(crate) index_locals: Vec<Local>,
+}
+
+pub(crate) fn place_info(place: Place<'_>) -> PlaceInfo {
+    let mut path = Vec::new();
+    let mut exactness = Exactness::Exact;
+    let mut index_locals = Vec::new();
+    for elem in place.projection.iter() {
+        match elem {
+            ProjectionElem::Field(f, _) if exactness == Exactness::Exact => path.push(f.as_u32()),
+            ProjectionElem::Field(..) => {}
+            // `(*r).f`: the reference is the value for slicing purposes, so
+            // a deref neither ends the field path nor makes it inexact.
+            ProjectionElem::Deref => {}
+            ProjectionElem::Downcast(..) => exactness = Exactness::VariantPayload,
+            ProjectionElem::Index(v) => {
+                index_locals.push(v);
+                if exactness == Exactness::Exact {
+                    path.push(ANY_ELEM);
+                }
+            }
+            ProjectionElem::ConstantIndex { .. } | ProjectionElem::Subslice { .. }
+                if exactness == Exactness::Exact =>
+            {
+                path.push(ANY_ELEM);
+            }
+            _ => exactness = exactness.blur(),
+        }
+    }
+    PlaceInfo {
+        atom: Atom {
+            local: place.local,
+            path,
+        },
+        exactness,
+        index_locals,
+    }
+}
+
+pub(crate) fn operand_place<'tcx>(op: &Operand<'tcx>) -> Option<Place<'tcx>> {
+    match op {
+        Operand::Copy(p) | Operand::Move(p) => Some(*p),
+        Operand::Constant(_) | Operand::RuntimeChecks(_) => None,
+    }
+}
+
+pub(crate) fn is_prefix(a: &[u32], b: &[u32]) -> bool {
+    a.len() <= b.len() && a.iter().zip(b).all(|(x, y)| x == y)
+}
+
+// ── control dependence ───────────────────────────────────────────────────────
+
+/// The body's CFG over normal (non-unwind) edges, with every block that
+/// cannot reach a `return` pruned: a panic, abort or `unreachable!()` is
+/// "does not happen" here, otherwise everything after `assert!(x)` would be
+/// control-dependent on `x`.
+pub(crate) struct Cfg {
+    succs: Vec<Vec<usize>>,
+    /// Index of the virtual exit node.
+    exit: usize,
+}
+
+fn raw_successors(body: &Body<'_>, bb: BasicBlock) -> Vec<BasicBlock> {
+    let Some(term) = &body.basic_blocks[bb].terminator else {
+        return Vec::new();
+    };
+    let mut v = match &term.kind {
+        TerminatorKind::Goto { target } => vec![*target],
+        TerminatorKind::SwitchInt { targets, .. } => targets.all_targets().to_vec(),
+        TerminatorKind::Drop { target, .. } | TerminatorKind::Assert { target, .. } => {
+            vec![*target]
+        }
+        TerminatorKind::Call { target, .. } => target.iter().copied().collect(),
+        TerminatorKind::Yield { resume, .. } => vec![*resume],
+        TerminatorKind::FalseEdge { real_target, .. }
+        | TerminatorKind::FalseUnwind { real_target, .. } => {
+            vec![*real_target]
+        }
+        TerminatorKind::InlineAsm { targets, .. } => targets.to_vec(),
+        TerminatorKind::Return
+        | TerminatorKind::Unreachable
+        | TerminatorKind::UnwindResume
+        | TerminatorKind::UnwindTerminate(_)
+        | TerminatorKind::CoroutineDrop
+        | TerminatorKind::TailCall { .. } => Vec::new(),
+    };
+    v.retain(|b| !body.basic_blocks[*b].is_cleanup);
+    v.sort();
+    v.dedup();
+    v
+}
+
+pub(crate) fn build_cfg(body: &Body<'_>) -> Cfg {
+    let n = body.basic_blocks.len();
+    let raw: Vec<Vec<usize>> = (0..n)
+        .map(|i| {
+            let bb = BasicBlock::from_usize(i);
+            if body.basic_blocks[bb].is_cleanup {
+                Vec::new()
+            } else {
+                raw_successors(body, bb)
+                    .into_iter()
+                    .map(|b| b.as_usize())
+                    .collect()
+            }
+        })
+        .collect();
+    let mut can_return: Vec<bool> = (0..n)
+        .map(|i| {
+            matches!(
+                body.basic_blocks[BasicBlock::from_usize(i)]
+                    .terminator
+                    .as_ref()
+                    .map(|t| &t.kind),
+                Some(TerminatorKind::Return | TerminatorKind::TailCall { .. })
+            )
+        })
+        .collect();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for b in 0..n {
+            if !can_return[b] && raw[b].iter().any(|s| can_return[*s]) {
+                can_return[b] = true;
+                changed = true;
+            }
+        }
+    }
+    let succs = (0..n)
+        .map(|b| {
+            let live: Vec<usize> = raw[b].iter().copied().filter(|s| can_return[*s]).collect();
+            if live.is_empty() { vec![n] } else { live }
+        })
+        .collect();
+    Cfg { succs, exit: n }
+}
+
+pub(crate) struct Bits(Vec<u64>);
+impl Bits {
+    fn full(n: usize) -> Self {
+        let mut v = vec![!0u64; n.div_ceil(64)];
+        if !n.is_multiple_of(64) {
+            *v.last_mut().unwrap() = (1u64 << (n % 64)) - 1;
+        }
+        Bits(v)
+    }
+    fn empty(n: usize) -> Self {
+        Bits(vec![0; n.div_ceil(64)])
+    }
+    fn set(&mut self, i: usize) {
+        self.0[i / 64] |= 1 << (i % 64);
+    }
+    fn has(&self, i: usize) -> bool {
+        self.0[i / 64] & (1 << (i % 64)) != 0
+    }
+    fn and_assign(&mut self, o: &Bits) {
+        for (a, b) in self.0.iter_mut().zip(&o.0) {
+            *a &= *b;
+        }
+    }
+}
+
+/// Post-dominator sets over blocks plus the virtual exit.
+pub(crate) fn post_dominators(cfg: &Cfg) -> Vec<Bits> {
+    let n = cfg.exit;
+    let mut pdom: Vec<Bits> = (0..=n).map(|_| Bits::full(n + 1)).collect();
+    pdom[n] = Bits::empty(n + 1);
+    pdom[n].set(n);
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for b in 0..n {
+            let mut acc = Bits::full(n + 1);
+            for &s in &cfg.succs[b] {
+                acc.and_assign(&pdom[s]);
+            }
+            acc.set(b);
+            if acc.0 != pdom[b].0 {
+                pdom[b] = acc;
+                changed = true;
+            }
+        }
+    }
+    pdom
+}
+
+/// Branch blocks that `target` is transitively control-dependent on,
+/// innermost first.
+pub(crate) fn control_deps(cfg: &Cfg, pdom: &[Bits], target: BasicBlock) -> Vec<BasicBlock> {
+    let branches: Vec<usize> = (0..cfg.exit).filter(|a| cfg.succs[*a].len() >= 2).collect();
+    let direct = |t: usize| -> Vec<usize> {
+        branches
+            .iter()
+            .copied()
+            .filter(|a| {
+                let strictly = pdom[*a].has(t) && *a != t;
+                !strictly && cfg.succs[*a].iter().any(|s| pdom[*s].has(t))
+            })
+            .collect()
+    };
+    let mut seen = HashSet::new();
+    let mut q = VecDeque::from([target.as_usize()]);
+    let mut deps = Vec::new();
+    while let Some(t) = q.pop_front() {
+        for a in direct(t) {
+            if seen.insert(a) {
+                deps.push(BasicBlock::from_usize(a));
+                q.push_back(a);
+            }
+        }
+    }
+    deps
+}
+
+pub(crate) fn switch_operand_atoms(body: &Body<'_>, bb: BasicBlock) -> Vec<Atom> {
+    match &body.basic_blocks[bb].terminator().kind {
+        TerminatorKind::SwitchInt { discr, .. } => operand_place(discr)
+            .map(|p| {
+                let info = place_info(p);
+                let mut v: Vec<Atom> = info.index_locals.into_iter().map(Atom::whole).collect();
+                v.push(info.atom);
+                v
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}

--- a/src/narrowed_return.rs
+++ b/src/narrowed_return.rs
@@ -11,6 +11,7 @@ use rustc_span::def_id::LocalDefId;
 
 use crate::baseline::emit;
 use crate::enum_facts::{arm_variant, is_panic_arm};
+use crate::hir_shapes::{Callee, callee_of};
 use crate::variant_flow::returned_variants;
 
 rustc_session::declare_lint! {
@@ -78,13 +79,7 @@ impl<'tcx> LateLintPass<'tcx> for NarrowedReturn {
         let ExprKind::Match(scrut, arms, _) = expr.kind else {
             return;
         };
-        let ExprKind::Call(callee, _) = &scrut.kind else {
-            return;
-        };
-        let ExprKind::Path(qpath) = &callee.kind else {
-            return;
-        };
-        let Some(def) = cx.qpath_res(qpath, callee.hir_id).opt_def_id() else {
+        let Some(Callee::Path { def, .. }) = callee_of(cx, scrut) else {
             return;
         };
         if !def.is_local() || !matches!(cx.tcx.def_kind(def), DefKind::Fn | DefKind::AssocFn) {

--- a/src/overwide_parameter.rs
+++ b/src/overwide_parameter.rs
@@ -18,7 +18,9 @@ rustc_session::declare_lint! {
     /// site can send: the function takes the full enum, panics on `E::C`, and
     /// every call site in the crate provably passes a different variant
     /// (constructor literals only — anything else makes the set unknowable
-    /// and the lint silent). The parameter type is wider than the function's
+    /// and the lint silent; a method's receiver is the value sent to `self`,
+    /// so `m.run()` makes `run`'s domain unknowable while `Mode::Off.run()`
+    /// passes `Off`). The parameter type is wider than the function's
     /// real domain; narrowing it turns the panic into a compile error for
     /// future callers.
     pub OVERWIDE_PARAMETER,
@@ -53,6 +55,25 @@ rustc_session::impl_lint_pass!(OverwideParameter => [OVERWIDE_PARAMETER]);
 impl OverwideParameter {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// One call of `def`, with the value sent to each body param index.
+    fn record_call<'tcx>(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        def: DefId,
+        values: impl Iterator<Item = (usize, &'tcx Expr<'tcx>)>,
+    ) {
+        for (i, value) in values {
+            let facts = self.calls.entry((def, i)).or_default();
+            facts.sites += 1;
+            match crate::enum_facts::ctor_literal_variant(cx, value) {
+                Some(v) => {
+                    facts.passed.insert(v);
+                }
+                None => facts.unknown = true,
+            }
+        }
     }
 }
 
@@ -137,34 +158,21 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
                 {
                     return;
                 }
-                for (i, arg) in args.iter().enumerate() {
-                    let facts = self.calls.entry((def, i)).or_default();
-                    facts.sites += 1;
-                    match crate::enum_facts::ctor_literal_variant(cx, arg) {
-                        Some(v) => {
-                            facts.passed.insert(v);
-                        }
-                        None => facts.unknown = true,
-                    }
-                }
+                self.record_call(cx, def, args.iter().enumerate());
             }
-            Some(Callee::Method { def, args, .. }) => {
+            Some(Callee::Method { def, recv, args }) => {
                 if !def.is_local() {
                     return;
                 }
-                // Method args start after the receiver, which is param 0 in
-                // the body's param list only for free fns; for methods the
-                // receiver occupies body param 0, so args map to 1..
-                for (i, arg) in args.iter().enumerate() {
-                    let facts = self.calls.entry((def, i + 1)).or_default();
-                    facts.sites += 1;
-                    match crate::enum_facts::ctor_literal_variant(cx, arg) {
-                        Some(v) => {
-                            facts.passed.insert(v);
-                        }
-                        None => facts.unknown = true,
-                    }
-                }
+                // The receiver is the body's param 0 (`self`), so it is a
+                // call-site value for that param like any other: `m.run()`
+                // sends whatever `m` holds, `Mode::Off.run()` sends `Off`.
+                self.record_call(
+                    cx,
+                    def,
+                    std::iter::once((0, recv))
+                        .chain(args.iter().enumerate().map(|(i, a)| (i + 1, a))),
+                );
             }
             // A bare reference to a local fn (fn pointer, higher-order use):
             // its future call sites are invisible. The callee position of a
@@ -200,6 +208,7 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
+        let mut findings: Vec<(Span, String)> = Vec::new();
         for (fn_def, params) in &self.fns {
             if self.poisoned.contains(fn_def) {
                 continue;
@@ -223,9 +232,7 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
                         .map(|v| format!("`{}`", cx.tcx.item_name(*v)))
                         .collect();
                     passed.sort();
-                    emit(
-                        cx,
-                        OVERWIDE_PARAMETER,
+                    findings.push((
                         *span,
                         format!(
                             "all {} call sites of `{}` pass {}; this arm panics on `{}`, which no existing caller sends",
@@ -234,10 +241,20 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
                             passed.join(", "),
                             cx.tcx.item_name(*variant),
                         ),
-                        "the parameter is wider than the function's domain; narrow the type and the panic becomes a compile error for future callers",
-                    );
+                    ));
                 }
             }
+        }
+        // `fns` is a HashMap; report in source order.
+        findings.sort_by_key(|(span, _)| span.lo());
+        for (span, msg) in findings {
+            emit(
+                cx,
+                OVERWIDE_PARAMETER,
+                span,
+                msg,
+                "the parameter is wider than the function's domain; narrow the type and the panic becomes a compile error for future callers",
+            );
         }
     }
 }

--- a/src/overwide_parameter.rs
+++ b/src/overwide_parameter.rs
@@ -11,6 +11,7 @@ use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
 use crate::baseline::emit;
+use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
     /// Flags a panicking match arm for an enum variant that no existing call
@@ -129,14 +130,8 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        match &expr.kind {
-            ExprKind::Call(callee, args) => {
-                let ExprKind::Path(qpath) = &callee.kind else {
-                    return;
-                };
-                let Some(def) = cx.qpath_res(qpath, callee.hir_id).opt_def_id() else {
-                    return;
-                };
+        match callee_of(cx, expr) {
+            Some(Callee::Path { def, args }) => {
                 if !def.is_local()
                     || !matches!(cx.tcx.def_kind(def), DefKind::Fn | DefKind::AssocFn)
                 {
@@ -153,10 +148,7 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
                     }
                 }
             }
-            ExprKind::MethodCall(_, _, args, _) => {
-                let Some(def) = cx.typeck_results().type_dependent_def_id(expr.hir_id) else {
-                    return;
-                };
+            Some(Callee::Method { def, args, .. }) => {
                 if !def.is_local() {
                     return;
                 }
@@ -177,7 +169,10 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
             // A bare reference to a local fn (fn pointer, higher-order use):
             // its future call sites are invisible. The callee position of a
             // direct call is not a bare reference; that call is counted above.
-            ExprKind::Path(qpath) => {
+            None => {
+                let ExprKind::Path(qpath) = &expr.kind else {
+                    return;
+                };
                 let is_direct_callee =
                     cx.tcx
                         .hir_parent_iter(expr.hir_id)
@@ -201,7 +196,6 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
                     self.poisoned.insert(def);
                 }
             }
-            _ => {}
         }
     }
 

--- a/src/parallel_bools.rs
+++ b/src/parallel_bools.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::adt_facts::{field_ty, private_local_struct, struct_field};
 use crate::baseline::emit;
 use clippy_utils::get_enclosing_block;
 use rustc_hir::def_id::DefId;
@@ -37,31 +38,14 @@ impl ParallelBools {
 
 /// The crate-private local struct behind `ty`, if it has 2+ bool fields.
 fn relevant_struct<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>) -> Option<ty::AdtDef<'tcx>> {
-    let ty::Adt(adt, _) = ty.peel_refs().kind() else {
-        return None;
-    };
-    if !adt.is_struct() || !adt.did().is_local() {
-        return None;
-    }
-    if cx
-        .effective_visibilities
-        .is_exported(adt.did().expect_local())
-    {
-        return None;
-    }
+    let adt = private_local_struct(cx, ty)?;
     let bools = adt
         .non_enum_variant()
         .fields
         .iter()
-        .filter(|f| {
-            cx.tcx
-                .type_of(f.did)
-                .instantiate_identity()
-                .skip_normalization()
-                .is_bool()
-        })
+        .filter(|f| field_ty(cx, f).is_bool())
         .count();
-    (bools >= 2).then_some(*adt)
+    (bools >= 2).then_some(adt)
 }
 
 impl<'tcx> LateLintPass<'tcx> for ParallelBools {
@@ -75,15 +59,8 @@ impl<'tcx> LateLintPass<'tcx> for ParallelBools {
         let Some(adt) = relevant_struct(cx, cx.typeck_results().expr_ty(base)) else {
             return;
         };
-        let field_is_bool = adt.non_enum_variant().fields.iter().any(|f| {
-            f.name == ident.name
-                && cx
-                    .tcx
-                    .type_of(f.did)
-                    .instantiate_identity()
-                    .skip_normalization()
-                    .is_bool()
-        });
+        let field_is_bool =
+            struct_field(adt, ident.name).is_some_and(|f| field_ty(cx, f).is_bool());
         if !field_is_bool {
             return;
         }

--- a/src/parallel_bools.rs
+++ b/src/parallel_bools.rs
@@ -4,7 +4,7 @@ use crate::adt_facts::{field_ty, private_local_struct, struct_field};
 use crate::baseline::emit;
 use clippy_utils::get_enclosing_block;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind, HirId};
+use rustc_hir::{Expr, ExprKind, HirId, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Symbol;
@@ -16,7 +16,9 @@ rustc_session::declare_lint! {
     /// makes the unpaired combinations unrepresentable.
     ///
     /// Only fires on structs private to the crate. One lone write to either
-    /// field anywhere disproves the pairing and silences the lint.
+    /// field anywhere — `s.f = ..`, `s.f |= ..`, or either through a `Box`,
+    /// guard or other `Deref` container — disproves the pairing and silences
+    /// the lint.
     pub PARALLEL_BOOLS,
     Warn,
     "bool fields only ever assigned together"
@@ -50,13 +52,20 @@ fn relevant_struct<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>) -> Option<ty:
 
 impl<'tcx> LateLintPass<'tcx> for ParallelBools {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        let ExprKind::Assign(lhs, _, _) = expr.kind else {
+        let (ExprKind::Assign(mut place, _, _) | ExprKind::AssignOp(_, mut place, _)) = expr.kind
+        else {
             return;
         };
-        let ExprKind::Field(base, ident) = lhs.kind else {
+        while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) = place.kind {
+            place = inner;
+        }
+        let ExprKind::Field(base, ident) = place.kind else {
             return;
         };
-        let Some(adt) = relevant_struct(cx, cx.typeck_results().expr_ty(base)) else {
+        // The adjusted type: a write through a `Box`, a guard or any other
+        // `Deref` container is a write to the struct behind it, and one such
+        // lone write disproves the pairing like any other.
+        let Some(adt) = relevant_struct(cx, cx.typeck_results().expr_ty_adjusted(base)) else {
             return;
         };
         let field_is_bool =

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -1,0 +1,855 @@
+use clippy_utils::visitors::{for_each_expr, for_each_expr_without_closures};
+use rustc_hir::def::Res;
+use rustc_hir::def_id::DefId;
+use rustc_hir::intravisit::{Visitor, walk_expr};
+use rustc_hir::{
+    BinOpKind, Block, Expr, ExprKind, HirId, ImplicitSelfKind, MatchSource, Mutability, PatKind,
+    QPath, Stmt, StmtKind, UnOp,
+};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
+use rustc_span::Span;
+use rustc_span::symbol::{Symbol, kw, sym};
+
+use crate::MordantConfig;
+use crate::adt_facts::impl_self_adt;
+use crate::baseline::emit_with_note;
+
+rustc_session::declare_lint! {
+    /// A fact read off a field of `self` (`let n = self.items.len()`, `let p =
+    /// self.buf.as_ptr()`, `let had = self.cb.is_some()`), then a statement
+    /// that hands control to code this function cannot see, then a later
+    /// statement that acts on the same field as if the fact still held:
+    /// indexing or removing at `n`, unwrapping under `had`, or touching `p`
+    /// at all. Whatever ran in between had `self` available and may have
+    /// pushed, popped, taken, or reallocated; the panic or dangling access
+    /// only shows up on the re-entrant path, which is the one tests skip.
+    ///
+    /// The re-entrant statements are calls through a closure or fn-pointer
+    /// parameter or field, calls on a `dyn Trait` receiver, `.await`, and
+    /// anything named in `stale-across-reentry-callees` (a project's own
+    /// dispatch points, such as the methods that run script callbacks). A
+    /// plain call to a named function is not one: whether it re-enters is not
+    /// decidable from here, so it is only counted when the config says so.
+    /// A configured callee counts wherever it appears; the language-level
+    /// ones count only where the language lets them reach the field: in a
+    /// `&mut self` method the call must actually receive `self` or the field
+    /// by `&mut` (an argument coerced to `&Host` or `&Vec<_>` does not
+    /// count), and in a `&self` method, or through a shared reference, the
+    /// field's type must be changeable behind `&`: a type of this crate that
+    /// is not `Freeze` or reaches non-`Freeze` state through a pointer. A
+    /// std collection, or a `Freeze` newtype over one, changes only through
+    /// `&mut`. A call counts only on a path that goes on to the later
+    /// statement: one inside a branch that returns, breaks out of the block,
+    /// or panics does not, and one inside a closure that is merely built
+    /// here has not run.
+    ///
+    /// Silent when the fact is about a local rather than a field of `self`,
+    /// when the field is a reference or a pointer wrapper rather than an
+    /// owned collection (`NonNull::as_ptr` copies an address out, it does
+    /// not point into the field), when the field is re-queried after the
+    /// re-entry (a fresh `len()`, `is_some()`, or a whole-field assignment)
+    /// before the fact is reused, when the reuse cannot panic (`get(n)`,
+    /// `truncate(n)`), and when the fact and its reuse are not in the same
+    /// block.
+    pub STALE_ACROSS_REENTRY,
+    Warn,
+    "a fact about a field of self reused after a call that can re-enter and change it"
+}
+
+pub struct StaleAcrossReentry {
+    callees: Vec<String>,
+}
+
+rustc_session::impl_lint_pass!(StaleAcrossReentry => [STALE_ACROSS_REENTRY]);
+
+impl StaleAcrossReentry {
+    pub fn new(config: &MordantConfig) -> Self {
+        Self {
+            callees: config.stale_across_reentry_callees.clone(),
+        }
+    }
+
+    /// Whether the call to `def` with `args` is one the config names, under
+    /// any spelling of either the item typeck resolved or the impl item the
+    /// receiver type sends it to.
+    fn configured<'tcx>(
+        &self,
+        cx: &LateContext<'tcx>,
+        def: DefId,
+        args: ty::GenericArgsRef<'tcx>,
+    ) -> bool {
+        if self.callees.is_empty() {
+            return false;
+        }
+        std::iter::once(def)
+            .chain(impl_item_of(cx, def, args))
+            .flat_map(|def| callee_names(cx, def))
+            .any(|(name, with_crate)| {
+                self.callees
+                    .iter()
+                    .any(|p| matches_pattern(&name, p) || matches_pattern(&with_crate, p))
+            })
+    }
+}
+
+/// A call to a trait method is recorded against the trait's item, whose path
+/// is `Runner::run_job` whatever the receiver; when the receiver type picks
+/// the impl here, this is the impl's item, so that `Worker::run_job` can be
+/// named too. Dispatch through `dyn` or a type parameter has no impl to name.
+fn impl_item_of<'tcx>(
+    cx: &LateContext<'tcx>,
+    def: DefId,
+    args: ty::GenericArgsRef<'tcx>,
+) -> Option<DefId> {
+    cx.tcx.trait_of_assoc(def)?;
+    let args = cx
+        .tcx
+        .try_normalize_erasing_regions(cx.typing_env(), ty::Unnormalized::new_wip(args))
+        .ok()?;
+    let instance = ty::Instance::try_resolve(cx.tcx, cx.typing_env(), def, args).ok()??;
+    match instance.def {
+        ty::InstanceKind::Item(item) if item != def => Some(item),
+        _ => None,
+    }
+}
+
+/// The spellings a pattern may match a callee under, each also prefixed
+/// with its crate name. The def path covers free functions, inherent methods
+/// (`Vm::run_callback`) and trait items (`Runner::run_job`); an impl's item
+/// renders as `<Worker as Runner>::run_job`, which no `Type::method` pattern
+/// matches, so it is spelled `Worker::run_job` and `Runner::run_job` instead.
+fn callee_names(cx: &LateContext<'_>, def: DefId) -> Vec<(String, String)> {
+    let path_of = |did: DefId| strip_generic_segments(&cx.tcx.def_path_str(did));
+    let mut names = vec![path_of(def)];
+    if let Some(impl_did) = cx.tcx.impl_of_assoc(def)
+        && let Some(trait_ref) = cx.tcx.impl_opt_trait_ref(impl_did)
+    {
+        let item = cx.tcx.item_name(def);
+        if let Some(adt) = impl_self_adt(cx, impl_did) {
+            names.push(format!("{}::{item}", path_of(adt.did())));
+        }
+        names.push(format!(
+            "{}::{item}",
+            path_of(trait_ref.skip_binder().def_id)
+        ));
+    }
+    let krate = cx.tcx.crate_name(def.krate);
+    names
+        .into_iter()
+        .map(|name| {
+            let with_crate = format!("{krate}::{name}");
+            (name, with_crate)
+        })
+        .collect()
+}
+
+/// Segment-wise suffix match: `run_callback` and `Vm::run_callback` both
+/// match `bun::vm::Vm::run_callback`; a final `dispatch*` matches any last
+/// segment starting with `dispatch`. Substrings never match by accident.
+fn matches_pattern(name: &str, pattern: &str) -> bool {
+    let mut want = pattern.rsplit("::");
+    let mut have = name.rsplit("::");
+    let (Some(want_last), Some(have_last)) = (want.next(), have.next()) else {
+        return false;
+    };
+    let last_matches = match want_last.strip_suffix('*') {
+        Some(prefix) => have_last.starts_with(prefix),
+        None => have_last == want_last,
+    };
+    last_matches && want.all(|w| have.next() == Some(w))
+}
+
+/// `Vec::<T>::push` -> `Vec::push`, so patterns are written the way the
+/// source spells the call.
+fn strip_generic_segments(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    let mut depth = 0usize;
+    let mut chars = path.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            _ if depth > 0 => {}
+            ':' if chars.peek() == Some(&':') && out.ends_with("::") => {
+                chars.next();
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// What kind of fact a binding holds about its place, which decides what
+/// counts as reusing it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Fact {
+    /// `len()` / `capacity()`: reused by indexing or a position-taking
+    /// method on the place, or by gating one of those on the number.
+    Count,
+    /// `is_empty()` / `is_some()` / `is_none()`: reused by gating an access
+    /// to the place on the flag.
+    Flag,
+    /// `as_ptr()` / `as_mut_ptr()`: reused by any mention at all, since the
+    /// allocation it points into is what a re-entrant callee can move.
+    Pointer,
+}
+
+impl Fact {
+    fn of(method: &str) -> Option<Self> {
+        match method {
+            "len" | "capacity" => Some(Fact::Count),
+            "is_empty" | "is_some" | "is_none" => Some(Fact::Flag),
+            "as_ptr" | "as_mut_ptr" => Some(Fact::Pointer),
+            _ => None,
+        }
+    }
+
+    /// The binding's type must be what the method name promises; a project
+    /// method that happens to share the name but returns something richer is
+    /// not one of these facts.
+    fn matches_ty(self, ty: ty::Ty<'_>) -> bool {
+        match self {
+            Fact::Count => ty.is_integral(),
+            Fact::Flag => ty.is_bool(),
+            Fact::Pointer => ty.is_raw_ptr(),
+        }
+    }
+
+    fn help(self) -> &'static str {
+        match self {
+            Fact::Count | Fact::Flag => {
+                "re-read the field after the call, or hold the item itself rather than its position"
+            }
+            Fact::Pointer => {
+                "take the pointer after the call, or keep what it points at alive across it by value"
+            }
+        }
+    }
+}
+
+/// Methods that take a position or otherwise panic / are unsafe when the
+/// container has shrunk since the position was computed. Non-panicking
+/// lookups (`get`, `truncate`) are deliberately absent.
+const POSITIONAL: &[&str] = &[
+    "remove",
+    "swap_remove",
+    "insert",
+    "split_off",
+    "drain",
+    "split_at",
+    "split_at_mut",
+    "swap",
+    "copy_within",
+    "set_len",
+    "get_unchecked",
+    "get_unchecked_mut",
+];
+
+const UNWRAPS: &[&str] = &["unwrap", "expect", "unwrap_unchecked"];
+
+/// Adapters between an `Option`/`Vec` field and the `unwrap` that bets on
+/// it: `self.cb.as_ref().unwrap()`, `self.items.get(n).unwrap()`.
+const ADAPTERS: &[&str] = &[
+    "as_ref",
+    "as_mut",
+    "as_deref",
+    "as_deref_mut",
+    "take",
+    "get",
+    "get_mut",
+    "first",
+    "last",
+    "first_mut",
+    "last_mut",
+];
+
+/// `self.a.b` as `[a, b]`; anything not rooted at `self` through fields
+/// alone has no identity a re-entrant callee shares with this function.
+fn self_place(e: &Expr<'_>) -> Option<Vec<Symbol>> {
+    fn go(e: &Expr<'_>, out: &mut Vec<Symbol>) -> bool {
+        match &e.kind {
+            ExprKind::Field(base, ident) => {
+                if !go(base, out) {
+                    return false;
+                }
+                out.push(ident.name);
+                true
+            }
+            ExprKind::Path(QPath::Resolved(None, p)) => {
+                p.segments.len() == 1 && p.segments[0].ident.name == kw::SelfLower
+            }
+            ExprKind::AddrOf(_, _, inner)
+            | ExprKind::Unary(UnOp::Deref, inner)
+            | ExprKind::DropTemps(inner) => go(inner, out),
+            _ => false,
+        }
+    }
+    let mut out = Vec::new();
+    (go(e, &mut out) && !out.is_empty()).then_some(out)
+}
+
+fn render(place: &[Symbol]) -> String {
+    let mut s = String::from("self");
+    for f in place {
+        s.push('.');
+        s.push_str(f.as_str());
+    }
+    s
+}
+
+/// What the fact's field is, which decides who could change it underneath
+/// the fact.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Container {
+    /// A std collection or `Option`, or a type of this crate with nothing
+    /// mutable behind `&`. Changes only through `&mut`, so a callee has to be
+    /// handed one.
+    Frozen,
+    /// A type of this crate that can change behind `&`, so anyone holding a
+    /// shared reference to the owner can change it.
+    Interior,
+}
+
+/// The field type a fact can be about. A reference-typed field (`&[u8]`)
+/// cannot change under a borrow at all; a pointer wrapper's `as_ptr()`
+/// (`NonNull`, `RefPtr`) copies a stored address out rather than pointing
+/// into storage the field owns, so a pointer fact needs a `Vec` or `String`.
+fn container_of<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>, fact: Fact) -> Option<Container> {
+    let ty::Adt(adt, _) = ty.kind() else {
+        return None;
+    };
+    if adt.did().is_local() {
+        if fact == Fact::Pointer {
+            return None;
+        }
+        return Some(if changes_behind_shared(cx, ty, 4) {
+            Container::Interior
+        } else {
+            Container::Frozen
+        });
+    }
+    let name = cx.tcx.get_diagnostic_name(adt.did())?;
+    let owning = match fact {
+        Fact::Pointer => matches!(name.as_str(), "Vec" | "String"),
+        Fact::Count | Fact::Flag => matches!(
+            name.as_str(),
+            "Vec"
+                | "String"
+                | "VecDeque"
+                | "HashMap"
+                | "HashSet"
+                | "BTreeMap"
+                | "BTreeSet"
+                | "Option"
+        ),
+    };
+    owning.then_some(Container::Frozen)
+}
+
+/// Whether a `&` to the type reaches something that can change: the type
+/// itself is not `Freeze`, or one of its fields gets to non-`Freeze` state
+/// through a reference, a raw pointer, or a pointer type's argument
+/// (`Box<RefCell<_>>`, `Rc<Cell<_>>`), which `Freeze` does not look
+/// through. A bare type parameter met behind a pointer is unknown rather
+/// than mutable; `depth` bounds the walk through self-referential types.
+fn changes_behind_shared<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>, depth: usize) -> bool {
+    if depth == 0 {
+        return false;
+    }
+    let inner = |t| changes_behind_shared(cx, t, depth - 1);
+    match ty.kind() {
+        ty::Param(_) => false,
+        _ if !ty.is_freeze(cx.tcx, cx.typing_env()) => true,
+        ty::RawPtr(..) => true,
+        ty::Ref(_, pointee, _) | ty::Array(pointee, _) | ty::Slice(pointee) => inner(*pointee),
+        ty::Tuple(elems) => elems.iter().any(inner),
+        ty::Adt(adt, args) if adt.did().is_local() => adt
+            .all_fields()
+            .any(|f| inner(f.ty(cx.tcx, args).skip_normalization())),
+        ty::Adt(adt, _) if adt.is_phantom_data() => false,
+        ty::Adt(adt, args) => {
+            cx.tcx.is_diagnostic_item(sym::NonNull, adt.did()) || args.types().any(inner)
+        }
+        _ => false,
+    }
+}
+
+struct Tracked {
+    binding: HirId,
+    name: Symbol,
+    place: Vec<Symbol>,
+    fact: Fact,
+    container: Container,
+}
+
+/// The fact query inside a `let` initializer, looking through the wrappers
+/// facts are habitually stored under: `as u32`, `!`, `- 1`.
+fn fact_query<'tcx>(
+    cx: &LateContext<'tcx>,
+    e: &'tcx Expr<'tcx>,
+) -> Option<(Vec<Symbol>, Fact, Container)> {
+    match &e.kind {
+        ExprKind::MethodCall(seg, recv, [], _) => {
+            let fact = Fact::of(seg.ident.as_str())?;
+            if !fact.matches_ty(cx.typeck_results().expr_ty(e)) {
+                return None;
+            }
+            let container = container_of(cx, cx.typeck_results().expr_ty(recv), fact)?;
+            Some((self_place(recv)?, fact, container))
+        }
+        ExprKind::Cast(inner, _) | ExprKind::Unary(UnOp::Not, inner) => fact_query(cx, inner),
+        ExprKind::Binary(op, l, r)
+            if matches!(
+                op.node,
+                BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul | BinOpKind::Div
+            ) =>
+        {
+            fact_query(cx, l).or_else(|| fact_query(cx, r))
+        }
+        ExprKind::DropTemps(inner) => fact_query(cx, inner),
+        _ => None,
+    }
+}
+
+fn tracked_of<'tcx>(cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'tcx>) -> Option<Tracked> {
+    let StmtKind::Let(l) = stmt.kind else {
+        return None;
+    };
+    let PatKind::Binding(_, binding, ident, None) = l.pat.kind else {
+        return None;
+    };
+    let (place, fact, container) = fact_query(cx, l.init?)?;
+    // A derived value must still be the fact's own kind: `len() > 0` is a
+    // Flag spelled through Count, and gating on it is handled by tracking
+    // nothing rather than by guessing.
+    if !fact.matches_ty(cx.typeck_results().pat_ty(l.pat)) {
+        return None;
+    }
+    Some(Tracked {
+        binding,
+        name: ident.name,
+        place,
+        fact,
+        container,
+    })
+}
+
+/// How the enclosing method holds `self`, which is what bounds who else can
+/// get at its fields while the method runs.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SelfAccess {
+    /// `&mut self` or `self`: nothing else can reach the fields unless this
+    /// method hands them out.
+    Exclusive,
+    /// `&self`: every other holder of a reference can reach them too, and
+    /// changes them if the field's type allows it.
+    Shared,
+}
+
+fn self_access(cx: &LateContext<'_>, block: &Block<'_>) -> Option<SelfAccess> {
+    let owner = cx.tcx.hir_get_parent_item(block.hir_id);
+    match cx.tcx.hir_owner_node(owner).fn_decl()?.implicit_self() {
+        ImplicitSelfKind::Imm | ImplicitSelfKind::Mut | ImplicitSelfKind::RefMut => {
+            Some(SelfAccess::Exclusive)
+        }
+        ImplicitSelfKind::RefImm => Some(SelfAccess::Shared),
+        ImplicitSelfKind::None => None,
+    }
+}
+
+/// `self`, `&mut self.a`, `&mut self.a.b` handed to a call, where the
+/// tracked place is `self.a.b`: the callee can now change it. What the
+/// callee receives is read off the argument's adjusted type, so `self`
+/// passed to an `fn(&Host)`, or `&mut self.a` to an `fn(&A)`, arrives shared
+/// and counts only when the field's type can be changed through a shared
+/// reference.
+fn hands_out<'tcx>(cx: &LateContext<'tcx>, arg: &'tcx Expr<'tcx>, t: &Tracked) -> bool {
+    let mut e = arg;
+    let mut shared = matches!(
+        cx.typeck_results().expr_ty_adjusted(arg).kind(),
+        ty::Ref(_, _, Mutability::Not)
+    );
+    let counts = |shared: bool| !shared || t.container == Container::Interior;
+    loop {
+        match &e.kind {
+            ExprKind::AddrOf(_, Mutability::Mut, inner) => {
+                if self_place(inner).is_some_and(|p| t.place.starts_with(&p)) {
+                    return counts(shared);
+                }
+                e = inner;
+            }
+            ExprKind::AddrOf(_, Mutability::Not, inner) => {
+                shared = true;
+                e = inner;
+            }
+            ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) => e = inner,
+            ExprKind::Path(QPath::Resolved(None, p)) => {
+                return p.segments.len() == 1
+                    && p.segments[0].ident.name == kw::SelfLower
+                    && counts(shared);
+            }
+            _ => return false,
+        }
+    }
+}
+
+fn is_binding(e: &Expr<'_>, binding: HirId) -> bool {
+    matches!(&e.kind, ExprKind::Path(QPath::Resolved(None, p)) if p.res == Res::Local(binding))
+}
+
+fn mentions<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>, binding: HirId) -> bool {
+    for_each_expr(cx, e, |inner: &Expr<'tcx>| {
+        if is_binding(inner, binding) {
+            std::ops::ControlFlow::Break(())
+        } else {
+            std::ops::ControlFlow::Continue(())
+        }
+    })
+    .is_some()
+}
+
+/// The statement's expression, for `let` its initializer.
+fn stmt_expr<'tcx>(stmt: &'tcx Stmt<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    match stmt.kind {
+        StmtKind::Expr(e) | StmtKind::Semi(e) => Some(e),
+        StmtKind::Let(l) => l.init,
+        StmtKind::Item(_) => None,
+    }
+}
+
+/// How an expression gives control away.
+enum Exit<'tcx> {
+    /// A configured callee: the project says it re-enters, and re-entry
+    /// reaches whatever the project's other handles reach, so no argument
+    /// analysis applies.
+    Configured,
+    /// Code this crate cannot see (a closure or fn pointer, a `dyn` method,
+    /// the executor behind `.await`), which can only touch what the language
+    /// lets it: what it is handed, plus whatever a shared reference reaches.
+    Opaque { args: &'tcx [Expr<'tcx>] },
+}
+
+impl StaleAcrossReentry {
+    fn exit_of<'tcx>(&self, cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>) -> Option<Exit<'tcx>> {
+        match &e.kind {
+            ExprKind::Call(callee, args) => {
+                let ty = cx.typeck_results().expr_ty_adjusted(callee).peel_refs();
+                let ty = ty.boxed_ty().unwrap_or(ty).peel_refs();
+                match ty.kind() {
+                    ty::FnPtr(..) | ty::Dynamic(..) | ty::Param(_) => Some(Exit::Opaque { args }),
+                    ty::FnDef(def, fn_args) if self.configured(cx, *def, fn_args) => {
+                        Some(Exit::Configured)
+                    }
+                    _ => None,
+                }
+            }
+            ExprKind::MethodCall(_, recv, args, _) => {
+                if cx
+                    .typeck_results()
+                    .type_dependent_def_id(e.hir_id)
+                    .is_some_and(|def| {
+                        self.configured(cx, def, cx.typeck_results().node_args(e.hir_id))
+                    })
+                {
+                    Some(Exit::Configured)
+                } else if cx
+                    .typeck_results()
+                    .expr_ty_adjusted(recv)
+                    .peel_refs()
+                    .is_trait()
+                {
+                    Some(Exit::Opaque { args })
+                } else {
+                    None
+                }
+            }
+            ExprKind::Match(_, _, MatchSource::AwaitDesugar) => Some(Exit::Opaque { args: &[] }),
+            _ => None,
+        }
+    }
+
+    fn reaches<'tcx>(
+        &self,
+        cx: &LateContext<'tcx>,
+        e: &'tcx Expr<'tcx>,
+        t: &Tracked,
+        access: SelfAccess,
+    ) -> bool {
+        match self.exit_of(cx, e) {
+            None => false,
+            Some(Exit::Configured) => true,
+            Some(Exit::Opaque { args }) => match access {
+                SelfAccess::Exclusive => args.iter().any(|a| hands_out(cx, a, t)),
+                SelfAccess::Shared => t.container == Container::Interior,
+            },
+        }
+    }
+
+    /// The first expression in the statement `e` that gives control to code
+    /// which can change the tracked field, on a path that then goes on to
+    /// the statements after `e`.
+    fn reentry<'tcx>(
+        &self,
+        cx: &LateContext<'tcx>,
+        e: &'tcx Expr<'tcx>,
+        t: &Tracked,
+        access: SelfAccess,
+    ) -> Option<Span> {
+        let mut v = Reentry {
+            lint: self,
+            cx,
+            t,
+            access,
+            targets: Vec::new(),
+            found: None,
+        };
+        v.visit_expr(e);
+        v.found
+    }
+}
+
+/// Walks one statement for a re-entry that falls through to the next. As a
+/// HIR visitor it stays out of closure bodies, whose calls have not run. A
+/// subtree of type `!` never completes; the statements after it are reached
+/// from inside it only by a `break` or `continue` to a loop or labelled
+/// block that is itself inside the statement (`targets`), so a diverging
+/// subtree without one, a returning branch or a `?` failure arm, is skipped
+/// along with any call inside it.
+struct Reentry<'a, 'tcx> {
+    lint: &'a StaleAcrossReentry,
+    cx: &'a LateContext<'tcx>,
+    t: &'a Tracked,
+    access: SelfAccess,
+    targets: Vec<HirId>,
+    found: Option<Span>,
+}
+
+impl<'tcx> Reentry<'_, 'tcx> {
+    fn diverges(&self, e: &'tcx Expr<'tcx>) -> bool {
+        self.cx
+            .typeck_results()
+            .expr_ty_opt(e)
+            .is_some_and(ty::Ty::is_never)
+    }
+
+    fn escapes_into_statement(&self, e: &'tcx Expr<'tcx>) -> bool {
+        for_each_expr_without_closures(e, |inner: &Expr<'tcx>| {
+            let target = match &inner.kind {
+                ExprKind::Break(dest, _) | ExprKind::Continue(dest) => dest.target_id.ok(),
+                _ => None,
+            };
+            if target.is_some_and(|id| self.targets.contains(&id)) {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        })
+        .is_some()
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for Reentry<'_, 'tcx> {
+    fn visit_expr(&mut self, e: &'tcx Expr<'tcx>) {
+        if self.found.is_some() || (self.diverges(e) && !self.escapes_into_statement(e)) {
+            return;
+        }
+        if self.lint.reaches(self.cx, e, self.t, self.access) {
+            self.found = Some(e.span);
+            return;
+        }
+        match &e.kind {
+            ExprKind::Loop(..) | ExprKind::Block(_, Some(_)) => {
+                self.targets.push(e.hir_id);
+                walk_expr(self, e);
+                self.targets.pop();
+            }
+            _ => walk_expr(self, e),
+        }
+    }
+}
+
+/// The statement invalidates the tracked fact on its own account, before any
+/// re-entry is involved: it assigns the binding, the place, or a prefix of
+/// the place. After a re-entry a fresh query of the place (`after_reentry`)
+/// counts too — the code re-derived the fact, and what follows is its own.
+fn refreshes<'tcx>(
+    cx: &LateContext<'tcx>,
+    e: &'tcx Expr<'tcx>,
+    t: &Tracked,
+    after_reentry: bool,
+) -> bool {
+    for_each_expr(cx, e, |inner: &Expr<'tcx>| {
+        let yes = match &inner.kind {
+            ExprKind::MethodCall(seg, recv, [], _)
+                if after_reentry && Fact::of(seg.ident.as_str()).is_some() =>
+            {
+                self_place(recv).is_some_and(|p| p == t.place)
+            }
+            ExprKind::Assign(lhs, _, _) | ExprKind::AssignOp(_, lhs, _) => {
+                is_binding(lhs, t.binding)
+                    || self_place(lhs).is_some_and(|p| t.place.starts_with(&p))
+            }
+            _ => false,
+        };
+        if yes {
+            std::ops::ControlFlow::Break(())
+        } else {
+            std::ops::ControlFlow::Continue(())
+        }
+    })
+    .is_some()
+}
+
+struct Reuse<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    t: &'a Tracked,
+    /// Depth of enclosing branches whose condition read the binding.
+    gated: usize,
+    found: Option<Span>,
+}
+
+impl<'a, 'tcx> Reuse<'a, 'tcx> {
+    fn depends(&self, args: &'tcx [Expr<'tcx>]) -> bool {
+        self.gated > 0 || args.iter().any(|a| mentions(self.cx, a, self.t.binding))
+    }
+
+    fn access(&self, e: &'tcx Expr<'tcx>) -> bool {
+        match &e.kind {
+            ExprKind::Index(base, idx, _) => {
+                self_place(base).is_some_and(|p| p == self.t.place)
+                    && self.depends(std::slice::from_ref(*idx))
+            }
+            ExprKind::MethodCall(seg, recv, args, _) => {
+                let name = seg.ident.as_str();
+                if POSITIONAL.contains(&name) {
+                    return self_place(recv).is_some_and(|p| p == self.t.place)
+                        && self.depends(args);
+                }
+                if !UNWRAPS.contains(&name) {
+                    return false;
+                }
+                let mut depends = self.gated > 0;
+                let mut inner: &Expr<'tcx> = recv;
+                while let ExprKind::MethodCall(s, r, a, _) = &inner.kind
+                    && ADAPTERS.contains(&s.ident.as_str())
+                {
+                    depends |= self.depends(a);
+                    inner = r;
+                }
+                depends && self_place(inner).is_some_and(|p| p == self.t.place)
+            }
+            _ => false,
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for Reuse<'_, 'tcx> {
+    fn visit_expr(&mut self, e: &'tcx Expr<'tcx>) {
+        if self.found.is_some() {
+            return;
+        }
+        if self.t.fact == Fact::Pointer {
+            if is_binding(e, self.t.binding) {
+                self.found = Some(e.span);
+            } else {
+                walk_expr(self, e);
+            }
+            return;
+        }
+        if self.access(e) {
+            self.found = Some(e.span);
+            return;
+        }
+        // A condition that reads the number may access the field itself
+        // (`if self.items[n] > 0`, `match self.items.remove(n)`); if it does
+        // not, the branches under it are gated on the number.
+        match &e.kind {
+            ExprKind::If(cond, then, els) if mentions(self.cx, cond, self.t.binding) => {
+                self.visit_expr(cond);
+                self.gated += 1;
+                self.visit_expr(then);
+                if let Some(els) = els {
+                    self.visit_expr(els);
+                }
+                self.gated -= 1;
+            }
+            ExprKind::Match(scrut, arms, _) if mentions(self.cx, scrut, self.t.binding) => {
+                self.visit_expr(scrut);
+                self.gated += 1;
+                for arm in *arms {
+                    self.visit_expr(arm.body);
+                }
+                self.gated -= 1;
+            }
+            _ => walk_expr(self, e),
+        }
+    }
+}
+
+fn reuse_in<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>, t: &Tracked) -> Option<Span> {
+    let mut v = Reuse {
+        cx,
+        t,
+        gated: 0,
+        found: None,
+    };
+    v.visit_expr(e);
+    v.found
+}
+
+impl<'tcx> LateLintPass<'tcx> for StaleAcrossReentry {
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        let mut access = None;
+        for (i, stmt) in block.stmts.iter().enumerate() {
+            let Some(t) = tracked_of(cx, stmt) else {
+                continue;
+            };
+            let Some(access) = *access.get_or_insert_with(|| self_access(cx, block)) else {
+                return;
+            };
+            let later = block.stmts[i + 1..]
+                .iter()
+                .filter_map(stmt_expr)
+                .chain(block.expr);
+            let mut reentered: Option<Span> = None;
+            for e in later {
+                match reentered {
+                    None => {
+                        if refreshes(cx, e, &t, false) {
+                            break;
+                        }
+                        reentered = self.reentry(cx, e, &t, access);
+                    }
+                    Some(call) => {
+                        if refreshes(cx, e, &t, true) {
+                            break;
+                        }
+                        if let Some(at) = reuse_in(cx, e, &t) {
+                            let place = render(&t.place);
+                            let name = t.name;
+                            let msg = match t.fact {
+                                Fact::Count | Fact::Flag => format!(
+                                    "`{name}` describes `{place}` as it stood before a call that can re-enter and change it"
+                                ),
+                                Fact::Pointer => format!(
+                                    "`{name}` points into `{place}` as it stood before a call that can re-enter and move or free it"
+                                ),
+                            };
+                            emit_with_note(
+                                cx,
+                                STALE_ACROSS_REENTRY,
+                                at,
+                                msg,
+                                call,
+                                "control leaves this function here, with `self` reachable from whatever runs",
+                                t.fact.help(),
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/stale_safety_comment.rs
+++ b/src/stale_safety_comment.rs
@@ -10,6 +10,12 @@ rustc_session::declare_lint! {
     /// this crate or a crate it links. A safety justification that names a
     /// guard which a refactor has since removed is documentation asserting an
     /// invariant nothing provides.
+    ///
+    /// Runs only with `stale-safety-comment-enabled = true` in `dylint.toml`.
+    /// The crate cannot see names defined in C++, in scripts, or in crates
+    /// that depend on it, and once a codebase's genuinely stale comments have
+    /// been fixed those are most of what remains, so it is a survey to run
+    /// once, not a gate to keep on.
     pub STALE_SAFETY_COMMENT,
     Warn,
     "SAFETY comment names an identifier that no longer exists"

--- a/src/stored_projection.rs
+++ b/src/stored_projection.rs
@@ -2,11 +2,12 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Symbol;
 
 use crate::MordantConfig;
+use crate::adt_facts::{has_fixed_repr, has_positional_fields, struct_literal};
 use crate::baseline::emit;
 
 rustc_session::declare_lint! {
@@ -196,47 +197,29 @@ impl<'tcx> LateLintPass<'tcx> for StoredProjection {
             self.note_assignment(cx, place);
             return;
         }
-        let ExprKind::Struct(qpath, fields, _) = expr.kind else {
+        let Some(lit) = struct_literal(cx, expr) else {
             return;
         };
         // A `..base` literal overrides part of a value that already exists, so
         // the fields written are the ones deliberately being made to differ.
-        if !matches!(
-            expr.kind,
-            ExprKind::Struct(_, _, rustc_hir::StructTailExpr::None)
-        ) {
+        if !matches!(lit.tail, StructTailExpr::None) {
             return;
         }
-        let Some(adt) = cx.typeck_results().expr_ty(expr).ty_adt_def() else {
-            return;
-        };
-        if !adt.did().is_local() {
+        if !lit.adt.did().is_local() {
             return;
         }
-        // An explicit repr means something outside Rust fixes the layout, and
-        // a wire record legitimately restates what a sibling implies.
-        let repr = adt.repr();
-        if repr.c() || repr.packed() || repr.transparent() || repr.simd() || repr.int.is_some() {
-            return;
-        }
-        let res = cx.qpath_res(qpath, expr.hir_id);
-        let variant = adt.variant_of_res(res);
-        // Tuple fields are named "0", "1", …; the message wants names.
-        if variant
-            .fields
-            .iter()
-            .any(|f| f.name.as_str().starts_with(|c: char| c.is_ascii_digit()))
-        {
+        // A wire record legitimately restates what a sibling implies.
+        if has_fixed_repr(lit.adt) || has_positional_fields(lit.variant) {
             return;
         }
         let mut vals = BTreeMap::new();
-        for f in fields {
+        for f in lit.fields {
             if let Some(v) = classify(cx, f.expr) {
                 vals.insert(f.ident.name, v);
             }
         }
         self.seen
-            .entry(variant.def_id)
+            .entry(lit.variant.def_id)
             .or_default()
             .push(Site { fields: vals });
     }

--- a/src/stringified_error.rs
+++ b/src/stringified_error.rs
@@ -1,8 +1,8 @@
+use crate::adt_facts::result_err_ty;
 use crate::baseline::emit;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
-use rustc_span::sym;
 
 rustc_session::declare_lint! {
     /// Flags the site where a typed error is collapsed into a string:
@@ -25,13 +25,9 @@ impl<'tcx> LateLintPass<'tcx> for StringifiedError {
             return;
         }
         let recv_ty = cx.typeck_results().expr_ty_adjusted(recv);
-        let ty::Adt(adt, args) = recv_ty.peel_refs().kind() else {
+        let Some(err_ty) = result_err_ty(cx.tcx, recv_ty.peel_refs()) else {
             return;
         };
-        if !cx.tcx.is_diagnostic_item(sym::Result, adt.did()) {
-            return;
-        }
-        let err_ty = args.type_at(1);
         // Already a string, or opaque to us: nothing is being destroyed.
         let ty::Adt(err_adt, _) = err_ty.peel_refs().kind() else {
             return;
@@ -45,13 +41,9 @@ impl<'tcx> LateLintPass<'tcx> for StringifiedError {
         // The call must actually produce a string error, or nothing was
         // collapsed.
         let out_ty = cx.typeck_results().expr_ty(expr);
-        let ty::Adt(out_adt, out_args) = out_ty.kind() else {
+        let Some(out_err) = result_err_ty(cx.tcx, out_ty) else {
             return;
         };
-        if !cx.tcx.is_diagnostic_item(sym::Result, out_adt.did()) {
-            return;
-        }
-        let out_err = out_args.type_at(1);
         let is_string_out = match out_err.peel_refs().kind() {
             ty::Adt(a, _) => cx.tcx.is_lang_item(a.did(), rustc_hir::LangItem::String),
             _ => out_err.peel_refs().is_str(),
@@ -87,7 +79,7 @@ fn closure_body_stringifies(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
     }
     match body.kind {
         ExprKind::MethodCall(seg, recv, [], _) => {
-            seg.ident.as_str() == "to_string" && is_param(cx, recv)
+            seg.ident.as_str() == "to_string" && is_param(recv)
         }
         ExprKind::Call(callee, [inner]) => {
             let ExprKind::Path(qpath) = &callee.kind else {
@@ -97,13 +89,12 @@ fn closure_body_stringifies(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
             let Some(def_id) = res.opt_def_id() else {
                 return false;
             };
-            cx.tcx.def_path_str(def_id) == "std::string::String::from" && is_param(cx, inner)
+            cx.tcx.def_path_str(def_id) == "std::string::String::from" && is_param(inner)
         }
         _ => false,
     }
 }
 
-fn is_param(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    let _ = cx;
+fn is_param(expr: &Expr<'_>) -> bool {
     matches!(expr.kind, ExprKind::Path(_))
 }

--- a/src/stringly_error.rs
+++ b/src/stringly_error.rs
@@ -1,3 +1,4 @@
+use crate::adt_facts::result_err_ty;
 use crate::baseline::emit;
 use clippy_utils::ty::ty_from_hir_ty;
 use rustc_hir::def_id::LocalDefId;
@@ -39,7 +40,7 @@ impl StringlyError {
             return;
         };
         let output = ty_from_hir_ty(cx, ret_hir_ty);
-        let Some(err_ty) = result_err_ty(cx, output) else {
+        let Some(err_ty) = result_err_ty(cx.tcx, output) else {
             return;
         };
         if let Some(desc) = self.stringy_desc(cx, err_ty) {
@@ -71,16 +72,6 @@ impl StringlyError {
             ty::Ref(_, inner, _) if inner.is_str() => Some("&str"),
             _ => None,
         }
-    }
-}
-
-fn result_err_ty<'tcx>(cx: &LateContext<'tcx>, output: Ty<'tcx>) -> Option<Ty<'tcx>> {
-    if let ty::Adt(adt, args) = output.kind()
-        && cx.tcx.is_diagnostic_item(sym::Result, adt.did())
-    {
-        Some(args.type_at(1))
-    } else {
-        None
     }
 }
 

--- a/src/unchecked_input_len.rs
+++ b/src/unchecked_input_len.rs
@@ -1,0 +1,1054 @@
+//! An integer the function received is bounded by a branch somewhere in the
+//! body and handed to something that turns it into memory somewhere else,
+//! and that site is not dominated by any branch that tests it.
+//!
+//! The analysis is over MIR. A *seed* is an integer-typed place rooted at a
+//! parameter other than `self` (`len`, `hdr.len`, `frame.header.count`, a
+//! closure's capture), identified by its field path with dereferences
+//! elided, so `hdr.len`, `(*hdr).len`, `let n = hdr.len` and a `&hdr.len`
+//! read through later are one seed. `self` is the type's own state, and a
+//! value the body computes itself -- a call's result or payload, `buf.len()`,
+//! `n.min(cap)`, a loop variable -- is not input; bun's first run showed a
+//! comparison of either is nearly always about something other than
+//! trusting it. A parameter place the body writes or hands out as `&mut` is
+//! not a seed either, since the analysis is flow-insensitive over its value;
+//! a write through a copy of the parameter's pointer (`let q = p;
+//! (*q).len = ..`) is a write to the same place.
+//!
+//! Reads are followed through single-assignment copies and borrows exactly,
+//! and otherwise as marks. A cast or an aggregate (a `Range`, a tuple, a
+//! `Some`) keeps the seed's [`Mark::Value`]; a borrow of it is a
+//! [`Mark::Pointer`], which a read through a dereference turns back into the
+//! `Value` and which sizes nothing itself (`from_raw_parts(&hdr.len, 1)`
+//! views the field, it does not trust it); arithmetic turns either into a
+//! [`Mark::Derived`] (`off + len` is a different quantity), as does storing
+//! the value into a place some other store gives something else (`let mut q
+//! = p; q += 1`, `n = n.min(cap)` on one path, `n = buf.len()` on another:
+//! flow-insensitively, what such a place holds at a use is unknown); an
+//! ordering comparison of the value or a derived quantity turns it into a
+//! [`Mark::Bounded`] bool and an equality test into a [`Mark::Compared`] one,
+//! followed the same way through `!` and `&&`; a call's result carries
+//! `Compared` for whatever the arguments carried, by value or by reference
+//! (`buf.get(i)?` judges `i`, so do `fits(&i)` and `i.cmp(&cap)`). A *check*
+//! is a `SwitchInt` on a marked bool, hoisted out of the constant branch a
+//! `debug_assert!` wraps its test in (`hoist_out_of_assertions`) so it counts
+//! from where it is written. A seed qualifies only if some check bounds it:
+//! an equality test, a judging call or the range test of a `match` arm
+//! (`1..=8 =>` dispatches on the value like `0 =>` does) alone says nothing
+//! about a size, but once the seed is bounded somewhere, any of them
+//! dominating a use does cover it. A *sink* is a call from [`SIZE_SINKS`] or
+//! [`PTR_SINKS`] given the seed's `Value`; safe indexing and slicing were
+//! sinks in the first bun run and were removed (TRIAGE.md), since a panic on
+//! a value the caller vouched for is what most of those turned out to be. A
+//! sink is reported when the seed qualifies and no check dominates the
+//! sink's block (rustc's forward dominators).
+
+use std::collections::{HashMap, HashSet};
+
+use rustc_abi::FieldIdx;
+use rustc_hir::intravisit::{FnKind, Visitor, walk_pat};
+use rustc_hir::{Body as HirBody, FnDecl, Pat, PatKind};
+use rustc_index::IndexVec;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::mir::{
+    AggregateKind, BasicBlock, BinOp, Body, BorrowKind, Local, Operand, Place, ProjectionElem,
+    RawPtrKind, Rvalue, StatementKind, TerminatorKind, VarDebugInfoContents,
+};
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::def_id::LocalDefId;
+use rustc_span::symbol::kw;
+use rustc_span::{Span, Symbol};
+
+use crate::baseline::emit_with_note;
+use crate::mir_flow::{dominates, mir_for};
+
+rustc_session::declare_lint! {
+    /// Flags an integer the function received (a parameter other than
+    /// `self`, or a field reached from one) handed to `split_at`,
+    /// `get_unchecked`, `with_capacity`, `reserve`, `set_len`,
+    /// `from_raw_parts`, `copy_nonoverlapping` or a raw-pointer
+    /// `add`/`offset` on a path that has not compared it, when some other
+    /// branch of the same function bounds it (`<`, `<=`, `>`, `>=`, also via
+    /// arithmetic on it): the author knew it needed a bound and this path
+    /// skips it. Reported at the use; the note points at the bound.
+    ///
+    /// Silent when every such use is dominated by a branch that tests the
+    /// value (a clamp, an early return, an equality test, a `debug_assert!`,
+    /// a `?` on a call it was passed to, by value or by reference), when no
+    /// branch in the body bounds it at all (a check in the caller is
+    /// invisible here, and a `match` arm's range is a dispatch, not a bound),
+    /// when what reaches the use is arithmetic on the value or a copy the
+    /// body re-assigns on some path rather than the value itself, when the
+    /// value is `self`'s or one the body computed (a call's result or
+    /// payload, `buf.len()`, a loop variable), when the place is written or
+    /// `&mut`-borrowed anywhere in the body, directly or through a copy of
+    /// its pointer, and on safe indexing and slicing, which panic rather than
+    /// corrupt.
+    ///
+    /// Opt-in: runs when `dylint.toml` sets `unchecked-input-len-enabled`.
+    /// The residual noise on bun (TRIAGE.md) is a value the caller vouches
+    /// for that the function also uses as the limit of something else, which
+    /// nothing inside the function separates from a real miss.
+    pub UNCHECKED_INPUT_LEN,
+    Warn,
+    "received length turned into memory on a path that never checked it"
+}
+
+rustc_session::declare_lint_pass!(UncheckedInputLen => [UNCHECKED_INPUT_LEN]);
+
+/// Calls that turn an integer argument into memory or a bound on it.
+const SIZE_SINKS: &[&str] = &[
+    "split_at",
+    "split_at_mut",
+    "split_at_unchecked",
+    "split_at_mut_unchecked",
+    "get_unchecked",
+    "get_unchecked_mut",
+    "with_capacity",
+    "reserve",
+    "reserve_exact",
+    "set_len",
+    "from_raw_parts",
+    "from_raw_parts_mut",
+    "copy_nonoverlapping",
+    "copy_from_nonoverlapping",
+    "copy_to_nonoverlapping",
+];
+
+/// Offsets on a raw pointer receiver. `add` on anything else is arithmetic.
+const PTR_SINKS: &[&str] = &[
+    "add",
+    "sub",
+    "offset",
+    "byte_add",
+    "byte_sub",
+    "byte_offset",
+];
+
+/// One step of a place's field path. Derefs are not steps.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+enum Step {
+    Field(u32),
+    Variant(u32),
+}
+
+/// A place with its dereferences elided: what the lint calls one value.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+struct Key {
+    local: Local,
+    path: Vec<Step>,
+}
+
+/// A local assigned exactly once from another place: reads of it are reads
+/// of that place.
+enum Alias<'tcx> {
+    /// `_l = copy p` / `_l = move p` / `_l = deref_copy p`: `_l.x` is `p.x`.
+    Value(Place<'tcx>),
+    /// `_l = &p` / `&raw p`: `(*_l).x` is `p.x`; `_l` itself is the borrow.
+    Address(Place<'tcx>),
+}
+
+/// What a value carries about a seed, by seed id.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+enum Mark {
+    /// The seed's value, possibly cast or wrapped: usable as a size.
+    Value(usize),
+    /// A borrow or raw pointer to the seed's value: reading through it yields
+    /// the `Value`, a call given it has looked at the seed, and it sizes
+    /// nothing itself.
+    Pointer(usize),
+    /// Arithmetic on the seed, or a place that holds the seed on one path and
+    /// something else on another: not the seed's size, but a comparison of
+    /// it is still a check on the seed.
+    Derived(usize),
+    /// A bool that depends on an ordering comparison of the seed: the branch
+    /// on it bounds the seed.
+    Bounded(usize),
+    /// A bool that depends on an equality test of the seed: the branch on it
+    /// is a check, but not evidence that the seed needed bounding.
+    Compared(usize),
+}
+
+type Marks = HashSet<Mark>;
+
+struct Analysis<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'a Body<'tcx>,
+    aliases: HashMap<Local, Alias<'tcx>>,
+    /// Single-assignment bools holding a constant: a branch on one is not a
+    /// decision (`if cfg!(debug_assertions)`), and a check inside it counts
+    /// from the branch itself.
+    static_bools: HashSet<Local>,
+    /// Parameter places the body writes or lends mutably; every seed they
+    /// cover is dead. `self` and its fields are here from the start: the
+    /// receiver's state is the type's own, not this call's input.
+    killed: HashMap<Local, Vec<Vec<Step>>>,
+    /// Places that hold a seed's value after one store and something else
+    /// after another (`q += 1`, `n = n.min(cap)`, `n = buf.len()`): a copy of
+    /// a seed stored into one of these is a different quantity, since the
+    /// analysis cannot tell which store a use sees. Found by one propagation
+    /// and applied by the next, until no new ones appear.
+    accumulators: HashSet<Key>,
+    found_accumulators: HashSet<Key>,
+    /// Spans of the body's range patterns: the comparisons a `match` lowers
+    /// them to are dispatches on the value, not bounds.
+    range_patterns: Vec<Span>,
+    seeds: Vec<Key>,
+    seed_ids: HashMap<Key, usize>,
+    /// Places holding values derived from seeds, by base local.
+    taint: HashMap<Local, Vec<(Vec<Step>, Marks)>>,
+}
+
+fn is_prefix(short: &[Step], long: &[Step]) -> bool {
+    long.len() >= short.len() && short.iter().zip(long).all(|(a, b)| a == b)
+}
+
+fn overlap(a: &[Step], b: &[Step]) -> bool {
+    is_prefix(a, b) || is_prefix(b, a)
+}
+
+/// The field path of a place, and whether every projection was one the path
+/// represents. An index or subslice ends the path inexactly: what was read is
+/// some part of the prefix.
+fn key_of(place: Place<'_>) -> (Key, bool) {
+    let mut path = Vec::new();
+    for elem in place.projection.iter() {
+        match elem {
+            ProjectionElem::Deref => {}
+            ProjectionElem::Field(f, _) => path.push(Step::Field(f.as_u32())),
+            ProjectionElem::Downcast(_, v) => path.push(Step::Variant(v.as_u32())),
+            ProjectionElem::Index(_)
+            | ProjectionElem::ConstantIndex { .. }
+            | ProjectionElem::Subslice { .. }
+            | ProjectionElem::OpaqueCast(_)
+            | ProjectionElem::UnwrapUnsafeBinder(_) => {
+                return (
+                    Key {
+                        local: place.local,
+                        path,
+                    },
+                    false,
+                );
+            }
+        }
+    }
+    (
+        Key {
+            local: place.local,
+            path,
+        },
+        true,
+    )
+}
+
+fn mutably_lent<'tcx>(rvalue: &Rvalue<'tcx>) -> Option<Place<'tcx>> {
+    match rvalue {
+        Rvalue::Ref(_, BorrowKind::Mut { .. }, p) => Some(*p),
+        Rvalue::RawPtr(RawPtrKind::Mut, p) => Some(*p),
+        _ => None,
+    }
+}
+
+impl<'a, 'tcx> Analysis<'a, 'tcx> {
+    fn new(tcx: TyCtxt<'tcx>, body: &'a Body<'tcx>, range_patterns: Vec<Span>) -> Self {
+        // Every write to a local's own storage (the whole of it or a field),
+        // including lending it out mutably; a write through it (`(*q).len =
+        // ..`) is a write to what it points at, which `collect_kills` charges
+        // to the resolved place. Arguments carry one implicit write.
+        let mut writes: IndexVec<Local, u32> = IndexVec::from_elem_n(0, body.local_decls.len());
+        for l in body.args_iter() {
+            writes[l] += 1;
+        }
+        let mut written = |p: Place<'tcx>| {
+            if !p.is_indirect() {
+                writes[p.local] += 1;
+            }
+        };
+        for data in body.basic_blocks.iter() {
+            for stmt in &data.statements {
+                match &stmt.kind {
+                    StatementKind::Assign(a) => {
+                        let (dest, rvalue) = &**a;
+                        written(*dest);
+                        if let Some(p) = mutably_lent(rvalue) {
+                            written(p);
+                        }
+                    }
+                    StatementKind::SetDiscriminant { place, .. } => written(**place),
+                    _ => {}
+                }
+            }
+            match &data.terminator().kind {
+                TerminatorKind::Call { destination, .. } => written(*destination),
+                TerminatorKind::Yield { resume_arg, .. } => written(*resume_arg),
+                _ => {}
+            }
+        }
+
+        let mut aliases = HashMap::new();
+        let mut static_bools = HashSet::new();
+        for data in body.basic_blocks.iter() {
+            for stmt in &data.statements {
+                let StatementKind::Assign(a) = &stmt.kind else {
+                    continue;
+                };
+                let (dest, rvalue) = &**a;
+                if !dest.projection.is_empty() || writes[dest.local] != 1 {
+                    continue;
+                }
+                let alias = match rvalue {
+                    Rvalue::Use(op, _) => {
+                        if op.place().is_none() {
+                            static_bools.insert(dest.local);
+                        }
+                        op.place().map(Alias::Value)
+                    }
+                    // A reborrow is a bitwise copy of a reference-like ADT.
+                    Rvalue::CopyForDeref(p) | Rvalue::Reborrow(_, _, p) => Some(Alias::Value(*p)),
+                    Rvalue::Ref(_, _, p) | Rvalue::RawPtr(_, p) => Some(Alias::Address(*p)),
+                    _ => None,
+                };
+                if let Some(alias) = alias {
+                    aliases.insert(dest.local, alias);
+                }
+            }
+        }
+
+        let mut this = Analysis {
+            tcx,
+            body,
+            aliases,
+            static_bools,
+            killed: HashMap::new(),
+            accumulators: HashSet::new(),
+            found_accumulators: HashSet::new(),
+            range_patterns,
+            seeds: Vec::new(),
+            seed_ids: HashMap::new(),
+            taint: HashMap::new(),
+        };
+        this.collect_kills();
+        this
+    }
+
+    /// Writes and mutable borrows whose target, once aliases are resolved,
+    /// lies under a parameter; plus the receiver itself.
+    fn collect_kills(&mut self) {
+        let mut targets: Vec<Place<'tcx>> = Vec::new();
+        for info in &self.body.var_debug_info {
+            if info.name == kw::SelfLower
+                && let VarDebugInfoContents::Place(p) = info.value
+            {
+                targets.push(p);
+            }
+        }
+        for data in self.body.basic_blocks.iter() {
+            for stmt in &data.statements {
+                match &stmt.kind {
+                    StatementKind::Assign(a) => {
+                        let (dest, rvalue) = &**a;
+                        targets.push(*dest);
+                        targets.extend(mutably_lent(rvalue));
+                    }
+                    StatementKind::SetDiscriminant { place, .. } => targets.push(**place),
+                    _ => {}
+                }
+            }
+            match &data.terminator().kind {
+                TerminatorKind::Call { destination, .. } => targets.push(*destination),
+                TerminatorKind::Yield { resume_arg, .. } => targets.push(*resume_arg),
+                _ => {}
+            }
+        }
+        for target in targets {
+            // A bare write to an alias local is the alias's own definition,
+            // not a write to what it reads.
+            if target.projection.is_empty() && self.aliases.contains_key(&target.local) {
+                continue;
+            }
+            let (key, _) = key_of(self.resolve(target));
+            if self.is_arg(key.local) {
+                self.killed.entry(key.local).or_default().push(key.path);
+            }
+        }
+    }
+
+    fn resolve(&self, mut place: Place<'tcx>) -> Place<'tcx> {
+        // Alias chains are acyclic (each link is a single definition read
+        // after it), so this bounds work, not correctness.
+        for _ in 0..16 {
+            match self.aliases.get(&place.local) {
+                Some(Alias::Value(base)) => {
+                    place = base.project_deeper(place.projection, self.tcx);
+                }
+                Some(Alias::Address(base)) => match place.projection.split_first() {
+                    Some((ProjectionElem::Deref, rest)) => {
+                        place = base.project_deeper(rest, self.tcx);
+                    }
+                    _ => return place,
+                },
+                None => return place,
+            }
+        }
+        place
+    }
+
+    fn is_arg(&self, local: Local) -> bool {
+        (1..=self.body.arg_count).contains(&local.as_usize())
+    }
+
+    fn killed(&self, key: &Key) -> bool {
+        self.killed
+            .get(&key.local)
+            .is_some_and(|paths| paths.iter().any(|p| overlap(p, &key.path)))
+    }
+
+    /// The seeds a read of `place` yields: the place itself, when it is one,
+    /// plus whatever derived values were stored into or around it. Reading a
+    /// borrow itself (`&len` handed to a call or put in a tuple) yields
+    /// pointers to what it borrows; a read that ends in a dereference yields
+    /// what the pointers stored there point at.
+    fn marks_of_place(&mut self, place: Place<'tcx>) -> Marks {
+        let resolved = self.resolve(place);
+        if resolved.projection.is_empty()
+            && let Some(Alias::Address(borrowed)) = self.aliases.get(&resolved.local)
+        {
+            let borrowed = *borrowed;
+            return point_at(self.marks_of_place(borrowed));
+        }
+        let mut out = Marks::new();
+        let (key, exact) = key_of(resolved);
+        if exact
+            && self.is_arg(key.local)
+            && !self.killed(&key)
+            && place.ty(&self.body.local_decls, self.tcx).ty.is_integral()
+        {
+            out.insert(Mark::Value(self.intern(key.clone())));
+        }
+        if let Some(entries) = self.taint.get(&key.local) {
+            for (path, seeds) in entries {
+                if overlap(path, &key.path) {
+                    out.extend(seeds);
+                }
+            }
+        }
+        if let Some(ProjectionElem::Deref) = resolved.projection.last() {
+            out = out
+                .into_iter()
+                .map(|m| match m {
+                    Mark::Pointer(id) => Mark::Value(id),
+                    Mark::Value(_) | Mark::Derived(_) | Mark::Bounded(_) | Mark::Compared(_) => m,
+                })
+                .collect();
+        }
+        out
+    }
+
+    fn marks_of_operand(&mut self, op: &Operand<'tcx>) -> Marks {
+        match op.place() {
+            Some(p) => self.marks_of_place(p),
+            None => Marks::new(),
+        }
+    }
+
+    fn intern(&mut self, key: Key) -> usize {
+        if let Some(&id) = self.seed_ids.get(&key) {
+            return id;
+        }
+        let id = self.seeds.len();
+        self.seeds.push(key.clone());
+        self.seed_ids.insert(key, id);
+        id
+    }
+
+    /// Records `marks` as stored at `dest` plus `extra` steps below it.
+    /// Returns whether anything new was learned.
+    fn store(&mut self, dest: Place<'tcx>, extra: &[Step], marks: Marks) -> bool {
+        let (mut key, _) = key_of(self.resolve(dest));
+        key.path.extend_from_slice(extra);
+        let accumulates = self.accumulators.contains(&key);
+        let held = self
+            .taint
+            .get_mut(&key.local)
+            .and_then(|entries| entries.iter_mut().find(|(p, _)| *p == key.path));
+        let Some((_, held)) = held else {
+            if marks.is_empty() {
+                return false;
+            }
+            let marks = if accumulates {
+                derive(marks, Mark::Derived)
+            } else {
+                marks
+            };
+            self.taint
+                .entry(key.local)
+                .or_default()
+                .push((key.path, marks));
+            return true;
+        };
+        // Some earlier store gave this place something other than what this
+        // one does (or nothing at all), and one of them was a seed's value:
+        // which of the two a use sees is not known here.
+        if !accumulates && *held != marks && held.iter().chain(&marks).any(|m| sizes(*m)) {
+            self.found_accumulators.insert(key);
+        }
+        let before = held.len();
+        if accumulates {
+            held.extend(derive(marks, Mark::Derived));
+        } else {
+            held.extend(marks);
+        }
+        held.len() != before
+    }
+
+    /// Flow-insensitive propagation of seeds through the body's assignments
+    /// and calls, to a fixpoint (a loop can define a value from one assigned
+    /// later), repeated from scratch while it turns up new accumulators.
+    fn propagate(&mut self) {
+        loop {
+            self.taint.clear();
+            self.found_accumulators.clear();
+            self.propagate_once();
+            if self.found_accumulators.is_empty() {
+                return;
+            }
+            let found = std::mem::take(&mut self.found_accumulators);
+            self.accumulators.extend(found);
+        }
+    }
+
+    fn propagate_once(&mut self) {
+        loop {
+            let mut changed = false;
+            for data in self.body.basic_blocks.iter() {
+                for stmt in &data.statements {
+                    let StatementKind::Assign(a) = &stmt.kind else {
+                        continue;
+                    };
+                    let (dest, rvalue) = &**a;
+                    // An alias's own definition: reads of it resolve to its
+                    // source directly. A store through it is a store there.
+                    if dest.projection.is_empty() && self.aliases.contains_key(&dest.local) {
+                        continue;
+                    }
+                    changed |= self.propagate_assign(*dest, rvalue);
+                }
+                // What a call makes of its arguments is not their size, but a
+                // branch on it (`buf.get(i)?`, `n.checked_add(4)?`) has judged
+                // them, so it covers later uses without qualifying them.
+                if let TerminatorKind::Call {
+                    args, destination, ..
+                } = &data.terminator().kind
+                {
+                    let mut marks = Marks::new();
+                    for arg in args.iter() {
+                        marks.extend(self.marks_of_operand(&arg.node));
+                    }
+                    changed |= self.store(*destination, &[], judged(marks));
+                }
+            }
+            if !changed {
+                return;
+            }
+        }
+    }
+
+    fn propagate_assign(&mut self, dest: Place<'tcx>, rvalue: &Rvalue<'tcx>) -> bool {
+        match rvalue {
+            Rvalue::Use(op, _)
+            | Rvalue::Repeat(op, _)
+            | Rvalue::Cast(_, op, _)
+            | Rvalue::WrapUnsafeBinder(op, _) => {
+                let marks = self.marks_of_operand(op);
+                self.store(dest, &[], marks)
+            }
+            Rvalue::UnaryOp(_, op) => {
+                let marks = derive(self.marks_of_operand(op), Mark::Derived);
+                self.store(dest, &[], marks)
+            }
+            Rvalue::BinaryOp(op, ops) => {
+                let mut marks = self.marks_of_operand(&ops.0);
+                marks.extend(self.marks_of_operand(&ops.1));
+                let marks = match op {
+                    BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge | BinOp::Cmp => {
+                        derive(marks, Mark::Bounded)
+                    }
+                    BinOp::Eq | BinOp::Ne => derive(marks, Mark::Compared),
+                    _ => derive(marks, Mark::Derived),
+                };
+                self.store(dest, &[], marks)
+            }
+            Rvalue::Discriminant(p) => {
+                let marks = derive(self.marks_of_place(*p), Mark::Derived);
+                self.store(dest, &[], marks)
+            }
+            Rvalue::Aggregate(kind, ops) => {
+                let mut changed = false;
+                for (i, op) in ops.iter_enumerated() {
+                    let s = self.marks_of_operand(op);
+                    let steps = self.aggregate_steps(kind, i);
+                    changed |= self.store(dest, &steps, s);
+                }
+                changed
+            }
+            // A borrow that is not an alias: stored into a field, or into a
+            // local some other path re-assigns.
+            Rvalue::Ref(_, _, p) | Rvalue::RawPtr(_, p) => {
+                let marks = point_at(self.marks_of_place(*p));
+                self.store(dest, &[], marks)
+            }
+            Rvalue::Reborrow(..) | Rvalue::CopyForDeref(_) | Rvalue::ThreadLocalRef(_) => false,
+        }
+    }
+
+    /// Where operand `i` of an aggregate lands, relative to the destination.
+    fn aggregate_steps(&self, kind: &AggregateKind<'tcx>, i: FieldIdx) -> Vec<Step> {
+        match kind {
+            AggregateKind::Adt(did, vidx, _, _, active_field) => {
+                let adt = self.tcx.adt_def(*did);
+                let field = active_field.unwrap_or(i);
+                if adt.is_enum() {
+                    vec![Step::Variant(vidx.as_u32()), Step::Field(field.as_u32())]
+                } else {
+                    vec![Step::Field(field.as_u32())]
+                }
+            }
+            AggregateKind::Tuple
+            | AggregateKind::Closure(..)
+            | AggregateKind::Coroutine(..)
+            | AggregateKind::CoroutineClosure(..) => vec![Step::Field(i.as_u32())],
+            // Elements are read through an index, which resolves to the
+            // whole array; a raw pointer's parts are never read back.
+            AggregateKind::Array(_) | AggregateKind::RawPtr(..) => Vec::new(),
+        }
+    }
+
+    /// The branches that test each seed, keyed by seed, for the seeds at
+    /// least one branch bounds. A seed only ever tested for equality is not
+    /// in the map: nothing says it needed bounding. A branch on the integer
+    /// itself (`match n`) is a dispatch, not a check, and is not in it
+    /// either; the `<=` pair an arm's `1..=8` lowers to is the same dispatch,
+    /// so it covers the arms like any test but bounds nothing.
+    fn checks(&mut self) -> HashMap<usize, Checks> {
+        let mut out: HashMap<usize, Checks> = HashMap::new();
+        for (bb, data) in self.body.basic_blocks.iter_enumerated() {
+            let term = data.terminator();
+            let TerminatorKind::SwitchInt { discr, .. } = &term.kind else {
+                continue;
+            };
+            let marks = self.marks_of_operand(discr);
+            if marks.is_empty() {
+                continue;
+            }
+            let span = term.source_info.span;
+            let dispatches = self.range_patterns.iter().any(|p| p.contains(span));
+            let from = self.hoist_out_of_assertions(bb, span);
+            for mark in marks {
+                let (id, bounds) = match mark {
+                    Mark::Bounded(id) => (id, !dispatches),
+                    Mark::Compared(id) => (id, false),
+                    Mark::Value(_) | Mark::Pointer(_) | Mark::Derived(_) => continue,
+                };
+                out.entry(id).or_default().push((from, span, bounds));
+            }
+        }
+        out.retain(|_, branches| branches.iter().any(|(_, _, bounds)| *bounds));
+        out
+    }
+
+    /// `debug_assert!(n < cap)` is `if true { if !(n < cap) { panic } }`: the
+    /// comparison's block is one arm of a branch on a constant and dominates
+    /// nothing after the assertion, so the check counts from the outermost
+    /// branch on a constant whose source encloses it. On the way up, a branch
+    /// with a single non-diverging arm (the first half of `debug_assert!(a <
+    /// n && b < n)`, an `assert!`, a `let .. else { panic }`) is stepped
+    /// over: it turns nothing away, so it changes what the check dominates
+    /// neither way, and counting the check from it would cover a use that
+    /// sits between the two. Any other branch ends the climb.
+    fn hoist_out_of_assertions(&self, check: BasicBlock, check_span: Span) -> BasicBlock {
+        let dominators = self.body.basic_blocks.dominators();
+        let mut from = check;
+        let mut cur = check;
+        while let Some(idom) = dominators.immediate_dominator(cur) {
+            let term = self.body.basic_blocks[idom].terminator();
+            if let TerminatorKind::SwitchInt { discr, targets } = &term.kind {
+                let is_static = match discr.place() {
+                    None => true,
+                    Some(p) => p.projection.is_empty() && self.static_bools.contains(&p.local),
+                };
+                if is_static && term.source_info.span.source_callsite().contains(check_span) {
+                    from = idom;
+                } else {
+                    // Exactly one way on: with `match` arms besides the
+                    // panicking one, the check is only on its own arm's way.
+                    let ways_on: HashSet<BasicBlock> = targets
+                        .all_targets()
+                        .iter()
+                        .copied()
+                        .filter(|t| !self.diverges(*t))
+                        .collect();
+                    if ways_on.len() != 1 {
+                        break;
+                    }
+                }
+            }
+            cur = idom;
+        }
+        from
+    }
+
+    /// Control entering `bb` never comes back: a panic call, possibly behind
+    /// the blocks that build its message.
+    fn diverges(&self, mut bb: BasicBlock) -> bool {
+        for _ in 0..8 {
+            match &self.body.basic_blocks[bb].terminator().kind {
+                TerminatorKind::Unreachable | TerminatorKind::UnwindTerminate(_) => return true,
+                TerminatorKind::Call { target: None, .. } => return true,
+                TerminatorKind::Call {
+                    target: Some(next), ..
+                }
+                | TerminatorKind::Goto { target: next } => bb = *next,
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    /// The seeds whose value is in `place`, paired with `place` when it is
+    /// the seed itself.
+    fn sized_by(&mut self, place: Place<'tcx>) -> Vec<(usize, Option<Place<'tcx>>)> {
+        let marks = self.marks_of_place(place);
+        let (key, _) = key_of(self.resolve(place));
+        sized_by_values(marks)
+            .into_iter()
+            .map(|id| (id, (self.seeds[id] == key).then_some(place)))
+            .collect()
+    }
+
+    fn sinks(&mut self) -> Vec<Sink<'tcx>> {
+        let mut out = Vec::new();
+        for (bb, data) in self.body.basic_blocks.iter_enumerated() {
+            let TerminatorKind::Call {
+                func,
+                args,
+                fn_span,
+                ..
+            } = &data.terminator().kind
+            else {
+                continue;
+            };
+            let Some((callee, _)) = func.const_fn_def() else {
+                continue;
+            };
+            let Some(name) = self.tcx.opt_item_name(callee) else {
+                continue;
+            };
+            let sized_by = if SIZE_SINKS.contains(&name.as_str()) {
+                0..args.len()
+            } else if PTR_SINKS.contains(&name.as_str())
+                && args
+                    .first()
+                    .is_some_and(|a| a.node.ty(&self.body.local_decls, self.tcx).is_raw_ptr())
+            {
+                1..args.len()
+            } else {
+                continue;
+            };
+            let mut seeds: Vec<(usize, Option<Place<'tcx>>)> = Vec::new();
+            for arg in &args[sized_by] {
+                let Some(place) = arg.node.place() else {
+                    continue;
+                };
+                for (id, via) in self.sized_by(place) {
+                    match seeds.iter_mut().find(|(seen, _)| *seen == id) {
+                        Some((_, known)) => {
+                            if known.is_none() {
+                                *known = via;
+                            }
+                        }
+                        None => seeds.push((id, via)),
+                    }
+                }
+            }
+            seeds.sort_by_key(|(id, _)| *id);
+            if !seeds.is_empty() {
+                out.push(Sink {
+                    block: bb,
+                    span: *fn_span,
+                    callee: name,
+                    seeds,
+                });
+            }
+        }
+        out
+    }
+
+    /// The name the use spells the seed by: from the first user-named local
+    /// on the copy chain the operand came through (`n` in `let n = hdr.len;
+    /// ..(n)`, `q.len` in `let q = p; ..((*q).len)`), else from the parameter
+    /// itself (`hdr.len`, a closure's captured `len`).
+    fn name(&self, id: usize, via: Option<Place<'tcx>>) -> String {
+        let key = &self.seeds[id];
+        let mut cur = via;
+        while let Some(place) = cur {
+            if place.local == key.local {
+                break;
+            }
+            if let Some(name) = self.user_name_of(place.local) {
+                let (read, _) = key_of(place);
+                return self.spell(name.to_string(), place.local, &read.path, 0);
+            }
+            cur = match self.aliases.get(&place.local) {
+                Some(Alias::Value(base)) => Some(*base),
+                Some(Alias::Address(_)) | None => None,
+            };
+        }
+        // Debug entries rooted at the parameter's own local: the parameter,
+        // a pattern binding in it, or a closure's capture. Deepest wins.
+        let mut best: Option<(usize, Symbol)> = None;
+        for info in &self.body.var_debug_info {
+            let VarDebugInfoContents::Place(p) = info.value else {
+                continue;
+            };
+            if info.composite.is_some() || p.local != key.local {
+                continue;
+            }
+            let (k, exact) = key_of(p);
+            if exact && is_prefix(&k.path, &key.path) && best.is_none_or(|(d, _)| k.path.len() > d)
+            {
+                best = Some((k.path.len(), info.name));
+            }
+        }
+        let (named_depth, out) = match best {
+            Some((depth, name)) => (depth, name.to_string()),
+            None => (0, format!("_{}", key.local.as_usize())),
+        };
+        self.spell(out, key.local, &key.path, named_depth)
+    }
+
+    /// `out`, which names the first `named_depth` steps of `path` below
+    /// `local`, extended with the field names of the remaining steps.
+    fn spell(&self, mut out: String, local: Local, path: &[Step], named_depth: usize) -> String {
+        let mut ty = self.body.local_decls[local].ty;
+        let mut variant = None;
+        for (depth, step) in path.iter().enumerate() {
+            while let Some(inner) = ty.builtin_deref(true) {
+                ty = inner;
+            }
+            match step {
+                Step::Variant(v) => variant = Some(rustc_abi::VariantIdx::from_u32(*v)),
+                Step::Field(f) => {
+                    let idx = FieldIdx::from_u32(*f);
+                    let (label, next) = match ty.kind() {
+                        ty::Adt(adt, args) => {
+                            let var = match (variant.take(), adt.is_enum()) {
+                                (Some(v), true) => adt.variant(v),
+                                (None, false) => adt.non_enum_variant(),
+                                (Some(_), false) | (None, true) => return out,
+                            };
+                            let Some(field) = var.fields.get(idx) else {
+                                return out;
+                            };
+                            (
+                                field.name.to_string(),
+                                field.ty(self.tcx, args).skip_normalization(),
+                            )
+                        }
+                        ty::Tuple(tys) => match tys.get(idx.as_usize()) {
+                            Some(t) => (f.to_string(), *t),
+                            None => return out,
+                        },
+                        ty::Closure(_, args) => {
+                            match args.as_closure().upvar_tys().get(idx.as_usize()) {
+                                Some(t) => (f.to_string(), *t),
+                                None => return out,
+                            }
+                        }
+                        _ => return out,
+                    };
+                    if depth >= named_depth {
+                        out.push('.');
+                        out.push_str(&label);
+                    }
+                    ty = next;
+                }
+            }
+        }
+        out
+    }
+}
+
+/// The branches testing one seed: block, span, and whether the test is an
+/// ordering comparison rather than an equality.
+type Checks = Vec<(BasicBlock, Span, bool)>;
+
+impl<'tcx> Analysis<'_, 'tcx> {
+    /// The name the source gives a whole local, when it is one the user
+    /// wrote (a `?` desugaring names its payload `val`).
+    fn user_name_of(&self, local: Local) -> Option<Symbol> {
+        self.body
+            .var_debug_info
+            .iter()
+            .find_map(|info| match info.value {
+                VarDebugInfoContents::Place(p)
+                    if p.as_local() == Some(local)
+                        && info.composite.is_none()
+                        && !info.source_info.span.from_expansion() =>
+                {
+                    Some(info.name)
+                }
+                VarDebugInfoContents::Place(_) | VarDebugInfoContents::Const(_) => None,
+            })
+    }
+}
+
+struct Sink<'tcx> {
+    block: BasicBlock,
+    span: Span,
+    callee: Symbol,
+    /// The seeds whose value sizes it, each with the operand it arrived in
+    /// when that operand is the seed itself (rather than a range built from
+    /// it), for naming.
+    seeds: Vec<(usize, Option<Place<'tcx>>)>,
+}
+
+/// What an operation on marked operands produces: a seed's value or a
+/// quantity derived from it becomes `to` of that seed; arithmetic on or a
+/// comparison of a pointer to it is neither its value nor a test of it; a
+/// bool that already records a test passes through (`!(a < b)`, `x && y` as
+/// `BitAnd`).
+fn derive(marks: Marks, to: fn(usize) -> Mark) -> Marks {
+    marks
+        .into_iter()
+        .map(|m| match m {
+            Mark::Value(id) | Mark::Derived(id) => to(id),
+            Mark::Pointer(id) => Mark::Derived(id),
+            Mark::Bounded(_) | Mark::Compared(_) => m,
+        })
+        .collect()
+}
+
+/// What a call's result carries: it has looked at every seed it was given,
+/// by value, derived, or by reference.
+fn judged(marks: Marks) -> Marks {
+    marks
+        .into_iter()
+        .map(|m| match m {
+            Mark::Value(id) | Mark::Derived(id) | Mark::Pointer(id) => Mark::Compared(id),
+            Mark::Bounded(_) | Mark::Compared(_) => m,
+        })
+        .collect()
+}
+
+/// What a borrow of a place carrying `marks` carries: a way to the seed's
+/// value or a quantity derived from it. A borrow of a bool that recorded a
+/// test, or of a call's result (`iter.next()` on a range built from the
+/// seed), says nothing about the seed.
+fn point_at(marks: Marks) -> Marks {
+    marks
+        .into_iter()
+        .filter_map(|m| match m {
+            Mark::Value(id) => Some(Mark::Pointer(id)),
+            Mark::Pointer(_) | Mark::Derived(_) => Some(m),
+            Mark::Bounded(_) | Mark::Compared(_) => None,
+        })
+        .collect()
+}
+
+/// A mark that can reach a sink as a seed's size, directly or read through.
+fn sizes(mark: Mark) -> bool {
+    matches!(mark, Mark::Value(_) | Mark::Pointer(_))
+}
+
+/// The seeds whose value itself is in `marks`, in a stable order.
+fn sized_by_values(marks: Marks) -> Vec<usize> {
+    let mut ids: Vec<usize> = marks
+        .into_iter()
+        .filter_map(|m| match m {
+            Mark::Value(id) => Some(id),
+            Mark::Pointer(_) | Mark::Derived(_) | Mark::Bounded(_) | Mark::Compared(_) => None,
+        })
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// The spans of every range pattern in a body.
+struct RangePatterns(Vec<Span>);
+
+impl<'tcx> Visitor<'tcx> for RangePatterns {
+    fn visit_pat(&mut self, pat: &'tcx Pat<'tcx>) {
+        if let PatKind::Range(..) = pat.kind {
+            self.0.push(pat.span);
+        }
+        walk_pat(self, pat);
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for UncheckedInputLen {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _kind: FnKind<'tcx>,
+        _decl: &'tcx FnDecl<'tcx>,
+        hir_body: &'tcx HirBody<'tcx>,
+        span: Span,
+        def_id: LocalDefId,
+    ) {
+        if span.from_expansion() {
+            return;
+        }
+        let Some(mir) = mir_for(cx.tcx, def_id) else {
+            return;
+        };
+        let body: &Body<'tcx> = &mir;
+        let mut range_patterns = RangePatterns(Vec::new());
+        range_patterns.visit_body(hir_body);
+        let mut an = Analysis::new(cx.tcx, body, range_patterns.0);
+        an.propagate();
+        let checks = an.checks();
+        if checks.is_empty() {
+            return;
+        }
+        let dominators = body.basic_blocks.dominators();
+        let mut findings: Vec<(Span, String, Symbol, Span)> = Vec::new();
+        for sink in an.sinks() {
+            if !dominators.is_reachable(sink.block) {
+                continue;
+            }
+            for (id, via) in sink.seeds {
+                let Some(cs) = checks.get(&id) else {
+                    continue;
+                };
+                // A sink is a call terminator and a check a switch terminator,
+                // so the two are never one block and plain dominance is exact.
+                if cs.iter().any(|(c, ..)| dominates(body, *c, sink.block)) {
+                    continue;
+                }
+                let Some(bound) = cs
+                    .iter()
+                    .filter(|(_, _, bounds)| *bounds)
+                    .map(|(_, s, _)| *s)
+                    .min_by_key(|s| s.lo())
+                else {
+                    continue;
+                };
+                findings.push((sink.span, an.name(id, via), sink.callee, bound));
+            }
+        }
+        findings.sort_by_key(|(span, name, ..)| (span.lo(), name.clone()));
+        for (span, name, callee, bound) in findings {
+            emit_with_note(
+                cx,
+                UNCHECKED_INPUT_LEN,
+                span,
+                format!(
+                    "`{name}` reaches `{callee}` here without having been checked, though this function bounds it elsewhere"
+                ),
+                bound,
+                "the bound that does not cover this use",
+                "check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes",
+            );
+        }
+    }
+}

--- a/src/unread_error_variant.rs
+++ b/src/unread_error_variant.rs
@@ -1,12 +1,13 @@
 use std::collections::{HashMap, HashSet};
 
-use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{BinOpKind, Expr, ExprKind, Pat, PatExpr, PatExprKind, PatKind, UnOp};
+use rustc_hir::{BinOpKind, Expr, ExprKind, Pat, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 
+use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit;
+use crate::enum_facts::{arm_variant, ctor_literal_variant, private_enum_of};
 
 rustc_session::declare_lint! {
     /// Flags a crate-private enum variant that is constructed somewhere but
@@ -46,21 +47,6 @@ impl UnreadErrorVariant {
     }
 }
 
-/// The crate-private local enum owning `variant_res`, with the variant.
-fn variant_of_private_enum(cx: &LateContext<'_>, res: Res) -> Option<(DefId, DefId)> {
-    let variant = match res {
-        Res::Def(DefKind::Variant, id) => id,
-        Res::Def(DefKind::Ctor(CtorOf::Variant, _), id) => cx.tcx.parent(id),
-        _ => return None,
-    };
-    let enum_did = cx.tcx.parent(variant);
-    let local = enum_did.as_local()?;
-    if cx.effective_visibilities.is_exported(local) {
-        return None;
-    }
-    Some((enum_did, variant))
-}
-
 /// True when `hir_id` sits inside a TRAIT impl whose self type is `enum_did`.
 /// `Display`, `Debug`, `From` and derive expansions must match every variant
 /// to exist, so their patterns prove nothing. Inherent methods are not
@@ -72,17 +58,9 @@ fn inside_own_trait_impl(cx: &LateContext<'_>, hir_id: rustc_hir::HirId, enum_di
         if matches!(
             cx.tcx.def_kind(cur),
             rustc_hir::def::DefKind::Impl { of_trait: true }
-        ) {
-            let self_ty = cx
-                .tcx
-                .type_of(cur)
-                .instantiate_identity()
-                .skip_normalization();
-            if let ty::Adt(adt, _) = self_ty.kind()
-                && adt.did() == enum_did
-            {
-                return true;
-            }
+        ) && impl_self_adt(cx, cur).is_some_and(|adt| adt.did() == enum_did)
+        {
+            return true;
         }
         match cx.tcx.opt_parent(cur) {
             Some(p) => cur = p,
@@ -92,20 +70,10 @@ fn inside_own_trait_impl(cx: &LateContext<'_>, hir_id: rustc_hir::HirId, enum_di
 }
 
 /// The private-enum variant `expr` constructs, if it is a variant path, call
-/// or struct expression.
+/// or struct expression, as `(enum, variant)`.
 fn constructed_variant(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<(DefId, DefId)> {
-    let res = match expr.kind {
-        ExprKind::Call(callee, _) => {
-            let ExprKind::Path(qpath) = &callee.kind else {
-                return None;
-            };
-            cx.qpath_res(qpath, callee.hir_id)
-        }
-        ExprKind::Path(ref qpath) => cx.qpath_res(qpath, expr.hir_id),
-        ExprKind::Struct(qpath, ..) => cx.qpath_res(qpath, expr.hir_id),
-        _ => return None,
-    };
-    variant_of_private_enum(cx, res)
+    let variant = ctor_literal_variant(cx, expr)?;
+    Some((private_enum_of(cx, variant)?, variant))
 }
 
 fn peel_operand<'tcx>(mut e: &'tcx Expr<'tcx>) -> &'tcx Expr<'tcx> {
@@ -168,16 +136,10 @@ impl<'tcx> LateLintPass<'tcx> for UnreadErrorVariant {
     }
 
     fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'tcx>) {
-        let qpath = match &pat.kind {
-            PatKind::TupleStruct(qpath, ..) | PatKind::Struct(qpath, ..) => qpath,
-            PatKind::Expr(PatExpr {
-                kind: PatExprKind::Path(qpath),
-                ..
-            }) => qpath,
-            _ => return,
+        let Some(variant) = arm_variant(cx, pat) else {
+            return;
         };
-        let res = cx.qpath_res(qpath, pat.hir_id);
-        let Some((enum_did, variant)) = variant_of_private_enum(cx, res) else {
+        let Some(enum_did) = private_enum_of(cx, variant) else {
             return;
         };
         if inside_own_trait_impl(cx, pat.hir_id, enum_did) {

--- a/src/unread_error_variant.rs
+++ b/src/unread_error_variant.rs
@@ -7,7 +7,7 @@ use rustc_middle::ty;
 
 use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit;
-use crate::enum_facts::{arm_variant, ctor_literal_variant, private_enum_of};
+use crate::enum_facts::{arm_variant, private_enum_of};
 
 rustc_session::declare_lint! {
     /// Flags a crate-private enum variant that is constructed somewhere but
@@ -69,10 +69,11 @@ fn inside_own_trait_impl(cx: &LateContext<'_>, hir_id: rustc_hir::HirId, enum_di
     }
 }
 
-/// The private-enum variant `expr` constructs, if it is a variant path, call
-/// or struct expression, as `(enum, variant)`.
+/// The private-enum variant `expr` constructs, if it is a variant path
+/// (including a bare tuple constructor passed as a function), call or struct
+/// expression, as `(enum, variant)`.
 fn constructed_variant(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<(DefId, DefId)> {
-    let variant = ctor_literal_variant(cx, expr)?;
+    let variant = crate::enum_facts::constructed_variant(cx, expr)?;
     Some((private_enum_of(cx, variant)?, variant))
 }
 

--- a/src/unread_none.rs
+++ b/src/unread_none.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, Node};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty;
-use rustc_span::{Symbol, sym};
+use rustc_span::Symbol;
 
+use crate::adt_facts::{field_ty, is_option_ty, private_local_struct, struct_field};
 use crate::baseline::emit;
 
 rustc_session::declare_lint! {
@@ -47,34 +47,8 @@ fn option_field_of<'tcx>(
     base: &Expr<'tcx>,
     field: Symbol,
 ) -> Option<DefId> {
-    let ty::Adt(adt, _) = cx
-        .typeck_results()
-        .expr_ty_adjusted(base)
-        .peel_refs()
-        .kind()
-    else {
-        return None;
-    };
-    if !adt.is_struct() || !adt.did().is_local() {
-        return None;
-    }
-    if cx
-        .effective_visibilities
-        .is_exported(adt.did().expect_local())
-    {
-        return None;
-    }
-    let is_option = adt.non_enum_variant().fields.iter().any(|f| {
-        f.name == field
-            && matches!(
-                cx.tcx
-                    .type_of(f.did)
-                    .instantiate_identity()
-                    .skip_normalization()
-                    .kind(),
-                ty::Adt(fadt, _) if cx.tcx.is_diagnostic_item(sym::Option, fadt.did())
-            )
-    });
+    let adt = private_local_struct(cx, cx.typeck_results().expr_ty_adjusted(base))?;
+    let is_option = struct_field(adt, field).is_some_and(|f| is_option_ty(cx, field_ty(cx, f)));
     is_option.then(|| adt.did())
 }
 
@@ -140,14 +114,7 @@ impl<'tcx> LateLintPass<'tcx> for UnreadNone {
             if facts.handled > 0 || facts.panicking.len() < 2 {
                 continue;
             }
-            let Some(fdef) = cx
-                .tcx
-                .adt_def(*adt)
-                .non_enum_variant()
-                .fields
-                .iter()
-                .find(|f| f.name == *field)
-            else {
+            let Some(fdef) = struct_field(cx.tcx.adt_def(*adt), *field) else {
                 continue;
             };
             emit(

--- a/src/variant_flow.rs
+++ b/src/variant_flow.rs
@@ -22,7 +22,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty;
 use rustc_span::def_id::LocalDefId;
 
-use crate::ctor_flow::mir_for;
+use crate::mir_flow::mir_for;
 
 enum Source {
     Variant(VariantIdx),

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -1,8 +1,9 @@
 use clippy_utils::source::snippet_opt;
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
+use rustc_hir::def::Res;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Arm, Expr, ExprKind, MatchSource, Pat, PatKind};
+use rustc_hir::{Arm, Expr, ExprKind, HirId, MatchSource, Pat, PatKind, QPath, StmtKind, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
@@ -16,6 +17,12 @@ rustc_session::declare_lint! {
     /// enum. The wildcard absorbs every future variant: adding one compiles
     /// without a whisper, and this match silently routes it to the old
     /// behavior. Listing the variants keeps exhaustiveness checking alive.
+    ///
+    /// Silent on an arm that answers "not this shape" (`None`, `false`, an
+    /// empty slice, string or collection, or a `return` of one of those, with
+    /// or without braces), and on a binding arm whose whole body is another
+    /// `match` on that binding: the inner match is the dispatch, and is
+    /// judged on its own.
     pub WILDCARD_LOCAL_ENUM,
     Warn,
     "wildcard arm over a small crate-local enum"
@@ -37,7 +44,13 @@ impl WildcardLocalEnum {
 
 fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
     match body.kind {
-        ExprKind::Lit(lit) => matches!(lit.node, LitKind::Bool(false)),
+        // `""` and `b""` are the empty-slice answer spelled as a literal.
+        ExprKind::Lit(lit) => match lit.node {
+            LitKind::Bool(b) => !b,
+            LitKind::Str(s, _) => s.as_str().is_empty(),
+            LitKind::ByteStr(s, _) => s.as_byte_str().is_empty(),
+            _ => false,
+        },
         ExprKind::Path(_) => clippy_utils::is_none_expr(cx, body),
         // `&[]` and `[]`: the empty-slice answer.
         ExprKind::AddrOf(_, _, inner) => is_negative_extractor(cx, inner),
@@ -59,8 +72,44 @@ fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
         // `return None` / `return false`: the early-exit spelling of the same
         // empty answers.
         ExprKind::Ret(Some(inner)) => is_negative_extractor(cx, inner),
+        // `{ None }` and `{ return None; }`: the same answers inside the
+        // braces rustfmt or a comment puts around them. Any other statement
+        // is behavior the arm gives future variants.
+        ExprKind::Block(block, None) => match (block.stmts, block.expr) {
+            ([], Some(tail)) => is_negative_extractor(cx, tail),
+            ([stmt], None) => match stmt.kind {
+                StmtKind::Semi(e) | StmtKind::Expr(e) => {
+                    matches!(e.kind, ExprKind::Ret(Some(_))) && is_negative_extractor(cx, e)
+                }
+                _ => false,
+            },
+            _ => false,
+        },
         _ => false,
     }
+}
+
+/// A binding arm whose whole body is another `match` on the binding passes
+/// the dispatch on; the inner match is where the variants are or are not
+/// listed, and this lint judges it on its own.
+fn redispatches(body: &Expr<'_>, binding: HirId) -> bool {
+    let mut body = body;
+    while let ExprKind::Block(block, None) = body.kind
+        && block.stmts.is_empty()
+        && let Some(tail) = block.expr
+    {
+        body = tail;
+    }
+    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = body.kind else {
+        return false;
+    };
+    while let ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) = scrut.kind {
+        scrut = inner;
+    }
+    matches!(
+        scrut.kind,
+        ExprKind::Path(QPath::Resolved(None, path)) if path.res == Res::Local(binding)
+    )
 }
 
 /// Every variant the non-catch-all arms cover, or None when an arm's shape is
@@ -156,17 +205,18 @@ impl<'tcx> LateLintPass<'tcx> for WildcardLocalEnum {
             if arm.guard.is_some() {
                 continue;
             }
-            let catch_all = matches!(
-                arm.pat.kind,
-                PatKind::Wild | PatKind::Binding(_, _, _, None)
-            );
+            let binding = match arm.pat.kind {
+                PatKind::Wild => None,
+                PatKind::Binding(_, id, _, None) => Some(id),
+                _ => continue,
+            };
             // `_ => None` and `_ => false` are extractors asking "is it this
             // one shape?" — future variants are correctly not that shape, so
             // absorption is the right behavior, not a hazard.
             if is_negative_extractor(cx, arm.body) {
                 continue;
             }
-            if !catch_all {
+            if binding.is_some_and(|b| redispatches(arm.body, b)) {
                 continue;
             }
             // The fix replaces the catch-all with the uncovered variants,

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -1,15 +1,15 @@
-use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::snippet_opt;
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
-use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Arm, Expr, ExprKind, MatchSource, Pat, PatExpr, PatExprKind, PatKind, QPath};
+use rustc_hir::{Arm, Expr, ExprKind, MatchSource, Pat, PatKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
 
 use crate::MordantConfig;
+use crate::baseline::emit_hir_then;
+use crate::enum_facts::{pat_head_qpath, variant_of_res};
 
 rustc_session::declare_lint! {
     /// Flags `_` (or a catch-all binding) matching over a small crate-local
@@ -63,18 +63,6 @@ fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
     }
 }
 
-/// The variant a pattern head names, resolved through either the variant path
-/// or its constructor.
-fn pat_variant(cx: &LateContext<'_>, pat: &Pat<'_>, qpath: &QPath<'_>) -> Option<(DefId, Span)> {
-    let res = cx.qpath_res(qpath, pat.hir_id);
-    let variant = match res {
-        Res::Def(DefKind::Variant, id) => id,
-        Res::Def(DefKind::Ctor(CtorOf::Variant, _), id) => cx.tcx.parent(id),
-        _ => return None,
-    };
-    Some((variant, qpath.span()))
-}
-
 /// Every variant the non-catch-all arms cover, or None when an arm's shape is
 /// beyond this analysis (then no fix is offered). `qspan` is a variant path
 /// span to copy the file's path style from.
@@ -104,26 +92,19 @@ fn covered_variants(
         covered: &mut Vec<DefId>,
         qspan: &mut Option<Span>,
     ) -> Option<()> {
-        match &pat.kind {
-            PatKind::Expr(PatExpr {
-                kind: PatExprKind::Path(qpath),
-                ..
-            })
-            | PatKind::TupleStruct(qpath, ..)
-            | PatKind::Struct(qpath, ..) => {
-                let (variant, span) = pat_variant(cx, pat, qpath)?;
-                covered.push(variant);
-                qspan.get_or_insert(span);
-                Some(())
-            }
-            PatKind::Or(pats) => {
-                for p in *pats {
-                    collect(cx, p, covered, qspan)?;
-                }
-                Some(())
-            }
-            _ => None,
+        if let Some(qpath) = pat_head_qpath(pat) {
+            let variant = variant_of_res(cx, cx.qpath_res(qpath, pat.hir_id))?;
+            covered.push(variant);
+            qspan.get_or_insert(qpath.span());
+            return Some(());
         }
+        let PatKind::Or(pats) = pat.kind else {
+            return None;
+        };
+        for p in pats {
+            collect(cx, p, covered, qspan)?;
+        }
+        Some(())
     }
 }
 
@@ -188,9 +169,6 @@ impl<'tcx> LateLintPass<'tcx> for WildcardLocalEnum {
             if !catch_all {
                 continue;
             }
-            if crate::baseline::suppressed(cx, WILDCARD_LOCAL_ENUM, arm.pat.span) {
-                continue;
-            }
             // The fix replaces the catch-all with the uncovered variants,
             // spelled with the same path prefix the sibling arms use. Offered
             // only when every sibling arm's coverage is provable.
@@ -223,7 +201,7 @@ impl<'tcx> LateLintPass<'tcx> for WildcardLocalEnum {
             // Emitted against the ARM's hir id, so an #[allow] placed on the
             // arm itself is honored; a plain span emission would only see the
             // enclosing match's lint level.
-            span_lint_hir_and_then(
+            emit_hir_then(
                 cx,
                 WILDCARD_LOCAL_ENUM,
                 arm.hir_id,

--- a/ui/asymmetric_guard.rs
+++ b/ui/asymmetric_guard.rs
@@ -80,6 +80,75 @@ impl Sched {
             }
         }
     }
+
+    fn can_touch_conns(&self) -> bool {
+        self.conns.is_empty()
+    }
+
+    // Fine: two stacked guards approve `detach`, and between them they read
+    // both fields it touches.
+    fn donate_checked(&mut self) {
+        if !self.can_donate() {
+            return;
+        }
+        if !self.can_touch_conns() {
+            return;
+        }
+        self.detach();
+    }
+
+    // Fine: same, one guard nested in the other's then-branch.
+    fn donate_checked_nested(&mut self) {
+        if self.can_donate() {
+            if self.can_touch_conns() {
+                self.detach();
+            }
+        }
+    }
+
+    fn can_log(&self) -> bool {
+        self.queue.len() < 8
+    }
+
+    // Flagged once, naming both guards: together they still never read
+    // `conns`.
+    fn donate_logged(&mut self) {
+        if !self.can_donate() {
+            return;
+        }
+        if self.can_log() {
+            self.detach();
+        }
+    }
+
+    // Fine: `can_shed` hands `self` to a free function, so what it reads is
+    // unknown; a guard whose coverage cannot be computed accuses nothing.
+    fn can_shed(&self) -> bool {
+        policy_allows(self)
+    }
+
+    fn shed(&mut self) {
+        if !self.can_shed() {
+            return;
+        }
+        self.detach();
+    }
+
+    // Fine: same one call away — `can_shed_now` is followed into `can_shed`,
+    // and the escape there makes this coverage unknown too.
+    fn can_shed_now(&self) -> bool {
+        self.queue.is_empty() && self.can_shed()
+    }
+
+    fn shed_now(&mut self) {
+        if self.can_shed_now() {
+            self.detach();
+        }
+    }
+}
+
+fn policy_allows(s: &Sched) -> bool {
+    s.queue.is_empty()
 }
 
 fn main() {
@@ -95,5 +164,11 @@ fn main() {
     s.report();
     s.donate_when_idle();
     s.donate_if_idle();
+    s.donate_checked();
+    s.donate_checked_nested();
+    s.donate_logged();
+    let _ = s.can_touch_conns() && s.can_log();
+    s.shed();
+    s.shed_now();
     s.detach();
 }

--- a/ui/asymmetric_guard.stderr
+++ b/ui/asymmetric_guard.stderr
@@ -15,5 +15,13 @@ LL |         let n = self.drain();
    |
    = help: a guard blind to part of the state its action manipulates cannot be sound; align what the pair reads
 
-warning: 2 warnings emitted
+warning: `detach` is gated by `can_donate` and `can_log`, but touches `conns` which none of the guards read
+  --> $DIR/asymmetric_guard.rs:120:13
+   |
+LL |             self.detach();
+   |             ^^^^^^^^^^^^^
+   |
+   = help: a guard blind to part of the state its action manipulates cannot be sound; align what the pair reads
+
+warning: 3 warnings emitted
 

--- a/ui/bypassed_validator.rs
+++ b/ui/bypassed_validator.rs
@@ -1,6 +1,6 @@
-// A literal that bypasses a validating constructor from outside the type's
-// module is flagged. Literals in the type's own module or impls, and types
-// with no validator, are not.
+// Outside a validated type's module and impls, a literal, a write to a checked
+// field, or mem::zeroed/transmute/assume_init producing it is flagged. Its own
+// module and impls, unchecked fields, and types with no validator are not.
 
 mod port {
     pub struct Port {
@@ -297,4 +297,221 @@ fn main() {
     let _ = validators::Small::new(Some(3)).map(|s| s.n);
     let _ = validators::NonZero::new(1).map(|z| z.n);
     let _ = validators::NonZero { n: 0 };
+    outside::sites();
+}
+
+// Every probe above gets one site here, in a module that is none of theirs:
+// the validated ones are flagged once each, the rest stay silent.
+mod outside {
+    use crate::not_validators::{Buf, Config, Narrow};
+    use crate::not_validators_2::{Header, Parser};
+    use crate::validators::{Checked, Even, Small};
+    use crate::{Alias, Free, Node, gate, inner};
+
+    // Writes to a checked field, through `&mut`, compound, and through a Box.
+    fn header(h: &mut Header) {
+        h.port = 0;
+    }
+    fn even(e: &mut Even) {
+        e.n += 1;
+    }
+    fn small(s: &mut Box<Small>) {
+        s.n = 200;
+    }
+
+    // A `..base` literal is a bypass only when it supplies a checked field
+    // itself; `port` taken from `base` was checked when `base` was made, and
+    // `host` was never checked at all.
+    fn checked(base: Checked, other: Checked, c: &mut Checked) -> (Checked, Checked) {
+        c.host = String::new();
+        (
+            Checked { port: 0, ..base },
+            Checked { host: String::new(), ..other },
+        )
+    }
+
+    // Values that never went through the constructor at all.
+    fn conjured() -> (inner::Level, gate::Gate, gate::Gate, Free) {
+        unsafe {
+            (
+                std::mem::zeroed::<inner::Level>(),
+                std::mem::transmute::<u8, gate::Gate>(0),
+                std::mem::MaybeUninit::<gate::Gate>::zeroed().assume_init(),
+                std::mem::zeroed::<Free>(),
+            )
+        }
+    }
+
+    // A trait impl is the type's own code wherever it is written.
+    pub trait Reset {
+        fn reset(&mut self);
+    }
+    impl Reset for inner::Level {
+        fn reset(&mut self) {
+            self.value = 0;
+        }
+    }
+
+    // The same sites on types whose constructors check nothing they store.
+    fn unvalidated(n: &mut Narrow, c: &mut Config, node: &mut Node, a: &mut Alias) -> (Buf, Parser) {
+        n.n = 0;
+        c.port = 0;
+        node.depth = 1;
+        a.to = "node:x";
+        (Buf { bytes: Vec::new(), cap: 0 }, Parser { log: 0, pos: 0 })
+    }
+
+    pub fn sites() {
+        if let (Ok(mut h), Some(mut e), Some(s)) =
+            (Header::decode(0, &[1, 2], 1), Even::new(2), Small::new(Some(1)))
+        {
+            header(&mut h);
+            even(&mut e);
+            small(&mut Box::new(s));
+        }
+        if let (Ok(a), Ok(b), Ok(mut c)) = (
+            Checked::from_pairs(&[("port", "1"), ("host", "a")]),
+            Checked::from_pairs(&[("port", "1"), ("host", "b")]),
+            Checked::from_pairs(&[("port", "1"), ("host", "c")]),
+        ) {
+            let _ = checked(a, b, &mut c);
+        }
+        let (mut level, g1, g2, free) = conjured();
+        level.reset();
+        let _ = (level.value, g1.v, g2.v, free.n);
+        if let Some(mut g) = gate::Gate::new(0) {
+            gate::open(&mut g);
+        }
+        if let (Ok(mut n), Ok(mut c)) = (
+            Narrow::new(1),
+            Config::from_pairs(&[("port", "1"), ("host", "h")]),
+        ) {
+            let mut node = Node { depth: 0, up: None };
+            let mut alias = Alias { from: "x", to: "node:x" };
+            let (buf, parser) = unvalidated(&mut n, &mut c, &mut node, &mut alias);
+            let _ = (buf.cap, parser.pos, node.depth, alias.to);
+        }
+    }
+}
+
+mod gate {
+    // Validated with a pub field; written only from inside here, which is the
+    // type's own module and so not a bypass. Its outside sites are conjured.
+    pub struct Gate {
+        pub v: u8,
+    }
+
+    impl Gate {
+        pub fn new(v: u8) -> Option<Gate> {
+            if v < 2 { Some(Gate { v }) } else { None }
+        }
+    }
+
+    pub fn open(g: &mut Gate) {
+        g.v = 1;
+    }
+}
+
+mod widened {
+    pub struct Tag<'a> {
+        pub s: &'a str,
+    }
+
+    impl<'a> Tag<'a> {
+        pub fn new(s: &'a str) -> Option<Tag<'a>> {
+            if s.is_empty() { None } else { Some(Tag { s }) }
+        }
+    }
+
+    mod elsewhere {
+        use super::Tag;
+
+        // The transmute only widens the lifetime of a value that already went
+        // through `Tag::new`; the write is a bypass.
+        pub fn widen(t: Tag<'_>, u: &mut Tag<'_>) -> Tag<'static> {
+            u.s = "";
+            unsafe { std::mem::transmute::<Tag<'_>, Tag<'static>>(t) }
+        }
+    }
+}
+
+mod promoted {
+    use std::marker::PhantomData;
+
+    pub struct Raw;
+    pub struct Ok;
+
+    pub struct Slot<State> {
+        pub n: u8,
+        pub state: PhantomData<State>,
+    }
+
+    impl Slot<Ok> {
+        pub fn promote(n: u8) -> Option<Slot<Ok>> {
+            if n == 0 { None } else { Some(Slot { n, state: PhantomData }) }
+        }
+    }
+
+    pub fn raw(n: u8) -> Slot<Raw> {
+        Slot { n, state: PhantomData }
+    }
+
+    mod elsewhere {
+        use super::{Ok, Raw, Slot};
+
+        // Same type, different parameter: this is the promotion `promote`
+        // gates, not a lifetime change.
+        pub fn promote(s: Slot<Raw>) -> Slot<Ok> {
+            unsafe { std::mem::transmute::<Slot<Raw>, Slot<Ok>>(s) }
+        }
+    }
+}
+
+mod two_validators {
+    pub struct Pair {
+        pub a: u8,
+        pub b: u8,
+    }
+
+    impl Pair {
+        pub fn new(a: u8) -> Option<Pair> {
+            if a > 9 { None } else { Some(Pair { a, b: 0 }) }
+        }
+
+        pub fn parse(b: u8) -> Option<Pair> {
+            if b > 99 { None } else { Some(Pair { a: 0, b }) }
+        }
+    }
+
+    mod elsewhere {
+        use super::Pair;
+
+        // `b` is checked by the second constructor, so the tail literal is
+        // charged to that one.
+        pub fn rebuild(base: Pair) -> Pair {
+            Pair { b: 200, ..base }
+        }
+    }
+}
+
+mod tuple {
+    pub struct Digit(pub u8);
+
+    impl Digit {
+        pub fn new(d: u8) -> Option<Digit> {
+            if d > 9 { None } else { Some(Digit(d)) }
+        }
+    }
+
+    pub struct Plain(pub u8);
+
+    mod elsewhere {
+        use super::{Digit, Plain};
+
+        // Calling the tuple constructor is the literal; `Plain` has no
+        // validator to go around.
+        pub fn make() -> (Digit, Plain) {
+            (Digit(10), Plain(10))
+        }
+    }
 }

--- a/ui/bypassed_validator.stderr
+++ b/ui/bypassed_validator.stderr
@@ -1,95 +1,3 @@
-warning: `Port::new` rejects some values of `n` before storing it, but the field is assignable outside its module
-  --> $DIR/bypassed_validator.rs:7:9
-   |
-LL |         pub(crate) n: u16,
-   |         ^^^^^^^^^^^^^^^^^
-   |
-note: the check a direct write skips
-  --> $DIR/bypassed_validator.rs:13:16
-   |
-LL |             if n <= u16::MAX as u32 {
-   |                ^^^^^^^^^^^^^^^^^^^^
-   = help: make the field private; the checked invariant otherwise holds only until the first outside write
-   = note: `#[warn(pub_invariant_fields)]` on by default
-
-warning: `Header::decode` rejects some values of `port` before storing it, but the field is assignable outside its module
-  --> $DIR/bypassed_validator.rs:151:9
-   |
-LL |         pub port: u32,
-   |         ^^^^^^^^^^^^^
-   |
-note: the check a direct write skips
-  --> $DIR/bypassed_validator.rs:159:16
-   |
-LL |             if port == 0 {
-   |                ^^^^^^^^^
-   = help: make the field private; the checked invariant otherwise holds only until the first outside write
-
-warning: `Even::new` rejects some values of `n` before storing it, but the field is assignable outside its module
-  --> $DIR/bypassed_validator.rs:194:9
-   |
-LL |         pub n: u32,
-   |         ^^^^^^^^^^
-   |
-note: the check a direct write skips
-  --> $DIR/bypassed_validator.rs:201:17
-   |
-LL |             if !is_even(n) {
-   |                 ^^^^^^^^^^
-   = help: make the field private; the checked invariant otherwise holds only until the first outside write
-
-warning: `Checked::from_pairs` rejects some values of `port` before storing it, but the field is assignable outside its module
-  --> $DIR/bypassed_validator.rs:211:9
-   |
-LL |         pub port: u32,
-   |         ^^^^^^^^^^^^^
-   |
-note: the check a direct write skips
-  --> $DIR/bypassed_validator.rs:218:16
-   |
-LL |             if port > 65535 {
-   |                ^^^^^^^^^^^^
-   = help: make the field private; the checked invariant otherwise holds only until the first outside write
-
-warning: `Small::new` rejects some values of `n` before storing it, but the field is assignable outside its module
-  --> $DIR/bypassed_validator.rs:227:9
-   |
-LL |         pub n: u8,
-   |         ^^^^^^^^^
-   |
-note: the check a direct write skips
-  --> $DIR/bypassed_validator.rs:231:31
-   |
-LL |             n.and_then(|n| if n < 10 { Some(Small { n }) } else { None })
-   |                               ^^^^^^
-   = help: make the field private; the checked invariant otherwise holds only until the first outside write
-
-warning: `NonZero::new` rejects some values of `n` before storing it, but the field is assignable outside its module
-  --> $DIR/bypassed_validator.rs:237:9
-   |
-LL |         pub n: i32,
-   |         ^^^^^^^^^^
-   |
-note: the check a direct write skips
-  --> $DIR/bypassed_validator.rs:241:13
-   |
-LL |             match n {
-   |             ^^^^^^^
-   = help: make the field private; the checked invariant otherwise holds only until the first outside write
-
-warning: `Level::new` rejects some values of `value` before storing it, but the field is assignable outside its module
-  --> $DIR/bypassed_validator.rs:252:9
-   |
-LL |         pub value: u8,
-   |         ^^^^^^^^^^^^^
-   |
-note: the check a direct write skips
-  --> $DIR/bypassed_validator.rs:257:16
-   |
-LL |             if v <= 10 { Ok(Level { value: v }) } else { Err(()) }
-   |                ^^^^^^^
-   = help: make the field private; the checked invariant otherwise holds only until the first outside write
-
 warning: `port::Port` is constructed by literal here, but `Port::new` checks `n` before constructing one
   --> $DIR/bypassed_validator.rs:37:5
    |
@@ -117,5 +25,148 @@ LL |             match n {
    |             ^^^^^^^
    = help: construct through the validating function, or move this literal into the type's module
 
-warning: 9 warnings emitted
+warning: `not_validators_2::Header::port` is written directly here, but `Header::decode` rejects some values of `port` before storing one
+  --> $DIR/bypassed_validator.rs:313:9
+   |
+LL |         h.port = 0;
+   |         ^^^^^^^^^^
+   |
+note: the check this write never runs
+  --> $DIR/bypassed_validator.rs:159:16
+   |
+LL |             if port == 0 {
+   |                ^^^^^^^^^
+   = help: change the value through the validating function, or make the field private and move this write into the type's module
+
+warning: `validators::Even::n` is written directly here, but `Even::new` rejects some values of `n` before storing one
+  --> $DIR/bypassed_validator.rs:316:9
+   |
+LL |         e.n += 1;
+   |         ^^^^^^^^
+   |
+note: the check this write never runs
+  --> $DIR/bypassed_validator.rs:201:17
+   |
+LL |             if !is_even(n) {
+   |                 ^^^^^^^^^^
+   = help: change the value through the validating function, or make the field private and move this write into the type's module
+
+warning: `validators::Small::n` is written directly here, but `Small::new` rejects some values of `n` before storing one
+  --> $DIR/bypassed_validator.rs:319:9
+   |
+LL |         s.n = 200;
+   |         ^^^^^^^^^
+   |
+note: the check this write never runs
+  --> $DIR/bypassed_validator.rs:231:31
+   |
+LL |             n.and_then(|n| if n < 10 { Some(Small { n }) } else { None })
+   |                               ^^^^^^
+   = help: change the value through the validating function, or make the field private and move this write into the type's module
+
+warning: `validators::Checked` is constructed by literal here, but `Checked::from_pairs` checks `port` before constructing one
+  --> $DIR/bypassed_validator.rs:328:13
+   |
+LL |             Checked { port: 0, ..base },
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check this literal never runs
+  --> $DIR/bypassed_validator.rs:218:16
+   |
+LL |             if port > 65535 {
+   |                ^^^^^^^^^^^^
+   = help: construct through the validating function, or move this literal into the type's module
+
+warning: `inner::Level` is produced by `mem::zeroed` here, but `Level::new` checks `value` before constructing one
+  --> $DIR/bypassed_validator.rs:337:17
+   |
+LL |                 std::mem::zeroed::<inner::Level>(),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check this value never went through
+  --> $DIR/bypassed_validator.rs:257:16
+   |
+LL |             if v <= 10 { Ok(Level { value: v }) } else { Err(()) }
+   |                ^^^^^^^
+   = help: construct through the validating function
+
+warning: `gate::Gate` is produced by `mem::transmute` here, but `Gate::new` checks `v` before constructing one
+  --> $DIR/bypassed_validator.rs:338:17
+   |
+LL |                 std::mem::transmute::<u8, gate::Gate>(0),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check this value never went through
+  --> $DIR/bypassed_validator.rs:406:16
+   |
+LL |             if v < 2 { Some(Gate { v }) } else { None }
+   |                ^^^^^
+   = help: construct through the validating function
+
+warning: `gate::Gate` is produced by `MaybeUninit::assume_init` here, but `Gate::new` checks `v` before constructing one
+  --> $DIR/bypassed_validator.rs:339:17
+   |
+LL |                 std::mem::MaybeUninit::<gate::Gate>::zeroed().assume_init(),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check this value never went through
+  --> $DIR/bypassed_validator.rs:406:16
+   |
+LL |             if v < 2 { Some(Gate { v }) } else { None }
+   |                ^^^^^
+   = help: construct through the validating function
+
+warning: `widened::Tag::s` is written directly here, but `Tag::new` rejects some values of `s` before storing one
+  --> $DIR/bypassed_validator.rs:432:13
+   |
+LL |             u.s = "";
+   |             ^^^^^^^^
+   |
+note: the check this write never runs
+  --> $DIR/bypassed_validator.rs:422:16
+   |
+LL |             if s.is_empty() { None } else { Some(Tag { s }) }
+   |                ^^^^^^^^^^^^
+   = help: change the value through the validating function, or make the field private and move this write into the type's module
+
+warning: `promoted::Slot` is produced by `mem::transmute` here, but `Slot::promote` checks `n` before constructing one
+  --> $DIR/bypassed_validator.rs:465:22
+   |
+LL |             unsafe { std::mem::transmute::<Slot<Raw>, Slot<Ok>>(s) }
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check this value never went through
+  --> $DIR/bypassed_validator.rs:451:16
+   |
+LL |             if n == 0 { None } else { Some(Slot { n, state: PhantomData }) }
+   |                ^^^^^^
+   = help: construct through the validating function
+
+warning: `two_validators::Pair` is constructed by literal here, but `Pair::parse` checks `b` before constructing one
+  --> $DIR/bypassed_validator.rs:492:13
+   |
+LL |             Pair { b: 200, ..base }
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check this literal never runs
+  --> $DIR/bypassed_validator.rs:482:16
+   |
+LL |             if b > 99 { None } else { Some(Pair { a: 0, b }) }
+   |                ^^^^^^
+   = help: construct through the validating function, or move this literal into the type's module
+
+warning: `tuple::Digit` is constructed by literal here, but `Digit::new` checks `0` before constructing one
+  --> $DIR/bypassed_validator.rs:514:14
+   |
+LL |             (Digit(10), Plain(10))
+   |              ^^^^^^^^^
+   |
+note: the check this literal never runs
+  --> $DIR/bypassed_validator.rs:502:16
+   |
+LL |             if d > 9 { None } else { Some(Digit(d)) }
+   |                ^^^^^
+   = help: construct through the validating function, or move this literal into the type's module
+
+warning: 13 warnings emitted
 

--- a/ui/defaulted_failure.rs
+++ b/ui/defaulted_failure.rs
@@ -1,0 +1,396 @@
+// A callee that rejects some of its argument, and a caller that replaces the
+// rejection with a fixed value and carries on. The `ui` config lists
+// `from_str_radix` and `listed_by_config` under `defaulted-failure-callees`
+// and `Pending` under `defaulted-failure-ignored-errors`.
+
+enum ParseError {
+    Empty,
+    TooBig,
+}
+
+fn describe(e: &ParseError) -> &'static str {
+    match e {
+        ParseError::Empty => "empty",
+        ParseError::TooBig => "too big",
+    }
+}
+
+// Rejects on the argument: a validator.
+fn parse_port(s: &str) -> Result<u16, ParseError> {
+    if s.is_empty() {
+        return Err(ParseError::Empty);
+    }
+    let n: u32 = s.len() as u32 * 1000;
+    if n > u16::MAX as u32 {
+        return Err(ParseError::TooBig);
+    }
+    Ok(n as u16)
+}
+
+// Rejects on the argument, but as an `Option`: absent, not refused.
+fn parse_flag(s: &str) -> Option<bool> {
+    match s {
+        "on" => Some(true),
+        "off" => Some(false),
+        _ => None,
+    }
+}
+
+// Rejects through `?` on a check of the argument.
+fn parse_pair(s: &str) -> Result<(u16, u16), ParseError> {
+    let (a, b) = s.split_once(':').ok_or(ParseError::Empty)?;
+    Ok((parse_port(a)?, parse_port(b)?))
+}
+
+struct Header {
+    limit: u32,
+    pos: usize,
+}
+
+impl Header {
+    // A method whose failure the argument decides (together with `self`).
+    fn parse_limit(&self, s: &str) -> Result<u32, ParseError> {
+        let n = s.len() as u32;
+        if n > self.limit {
+            return Err(ParseError::TooBig);
+        }
+        Ok(n)
+    }
+
+    // A method whose failure only its own state decides.
+    fn next_field(&mut self, s: &str) -> Result<u32, ParseError> {
+        if self.pos >= 4 {
+            return Err(ParseError::Empty);
+        }
+        self.pos += 1;
+        Ok(s.len() as u32)
+    }
+
+    // A `bool` answer.
+    fn is_open(&self, s: &str) -> Result<bool, ParseError> {
+        if s.is_empty() {
+            return Err(ParseError::Empty);
+        }
+        Ok(s.len() < 3)
+    }
+
+    // The argument decides an early success; only its own state decides the
+    // failure behind that.
+    fn send(&self, s: &str) -> Result<u32, ParseError> {
+        if s.is_empty() {
+            return Ok(0);
+        }
+        if self.pos >= 4 {
+            return Err(ParseError::Empty);
+        }
+        Ok(s.len() as u32)
+    }
+
+    // The other way round: the argument decides the failure, once its own
+    // state has let it get that far.
+    fn send_checked(&self, s: &str) -> Result<u32, ParseError> {
+        if self.pos >= 4 {
+            if s.is_empty() {
+                return Err(ParseError::Empty);
+            }
+        }
+        Ok(s.len() as u32)
+    }
+}
+
+// Rejects on the argument, with nothing to hand back on success.
+fn check_port(s: &str) -> Result<(), ParseError> {
+    parse_port(s)?;
+    Ok(())
+}
+
+// An error that is recorded elsewhere by the time it is returned; the config
+// lists it, so defaulting it hides nothing.
+struct Pending;
+
+fn schedule(s: &str, log: &mut Vec<String>) -> Result<u32, Pending> {
+    if s.is_empty() {
+        log.push("empty".to_string());
+        return Err(Pending);
+    }
+    Ok(s.len() as u32)
+}
+
+// Fails only because a resource refused: never a verdict on the path.
+fn read_size(path: &str) -> Result<u64, std::io::Error> {
+    std::fs::metadata(path).map(|m| m.len())
+}
+
+// Fails on state it was not handed, not on the argument.
+fn next_slot(tag: &str) -> Option<u32> {
+    let free = std::env::var_os("SLOTS").is_some();
+    if !free {
+        return None;
+    }
+    Some(tag.len() as u32)
+}
+
+// The same, as a `Result`, behind an early success the argument decides.
+fn slot_for(tag: &str) -> Result<u32, ParseError> {
+    if tag.is_empty() {
+        return Ok(0);
+    }
+    if std::env::var_os("SLOTS").is_none() {
+        return Err(ParseError::Empty);
+    }
+    Ok(tag.len() as u32)
+}
+
+// Cannot fail.
+fn always(s: &str) -> Option<usize> {
+    Some(s.len())
+}
+
+// Its failure is built by a combinator, so the body shows no check of its
+// own; only the config makes it visible.
+fn listed_by_config(s: &str) -> Option<u32> {
+    s.parse().ok()
+}
+
+fn unwrap_or_literal_is_flagged(s: &str) -> u16 {
+    parse_port(s).unwrap_or(0)
+}
+
+fn unwrap_or_default_is_flagged(s: &str) -> u16 {
+    parse_port(s).unwrap_or_default()
+}
+
+fn unwrap_or_else_const_is_flagged(s: &str) -> u16 {
+    parse_port(s).unwrap_or_else(|_| u16::MAX)
+}
+
+fn unwrap_or_else_default_call_is_flagged(s: &str) -> u16 {
+    parse_port(s).unwrap_or_else(|_| Default::default())
+}
+
+fn ok_then_unwrap_or_is_flagged(s: &str) -> u16 {
+    parse_port(s).ok().unwrap_or(80)
+}
+
+fn bool_defaulted_to_true_is_flagged(h: &Header, s: &str) -> bool {
+    h.is_open(s).unwrap_or(true)
+}
+
+fn question_mark_callee_is_flagged(s: &str) -> (u16, u16) {
+    parse_pair(s).unwrap_or((0, 0))
+}
+
+fn method_callee_is_flagged(h: &Header, s: &str) -> u32 {
+    h.parse_limit(s).unwrap_or(0)
+}
+
+fn let_else_ok_unit_is_flagged(s: &str, out: &mut Vec<u16>) -> Result<(), ParseError> {
+    let Ok(port) = parse_port(s) else {
+        return Ok(());
+    };
+    out.push(port);
+    Ok(())
+}
+
+fn let_else_bare_return_is_flagged(s: &str, out: &mut Vec<u16>) {
+    let Ok(port) = parse_port(s) else { return };
+    out.push(port);
+}
+
+fn let_else_some_of_ok_unit_is_flagged(s: &str, out: &mut Vec<u16>) -> Result<(), ParseError> {
+    let Some(port) = parse_port(s).ok() else {
+        return Ok(());
+    };
+    out.push(port);
+    Ok(())
+}
+
+fn let_else_some_of_ok_bare_return_is_flagged(s: &str, out: &mut Vec<u16>) {
+    let Some(port) = parse_port(s).ok() else { return };
+    out.push(port);
+}
+
+fn argument_check_behind_receiver_check_is_flagged(h: &Header, s: &str) -> u32 {
+    h.send_checked(s).unwrap_or(0)
+}
+
+fn unit_default_in_value_position_is_flagged(s: &str) {
+    check_port(s).unwrap_or_default()
+}
+
+fn listed_callee_is_flagged(s: &str) -> u32 {
+    listed_by_config(s).unwrap_or(0)
+}
+
+fn listed_foreign_callee_is_flagged(s: &str) -> u32 {
+    u32::from_str_radix(s, 16).unwrap_or(0)
+}
+
+fn option_callee_is_fine(s: &str) -> bool {
+    parse_flag(s).unwrap_or(true)
+}
+
+fn option_callee_default_fn_is_fine(s: &str) -> bool {
+    parse_flag(s).unwrap_or_else(Default::default)
+}
+
+fn receiver_decided_is_fine(h: &mut Header, s: &str) -> u32 {
+    h.next_field(s).unwrap_or(0)
+}
+
+fn bool_defaulted_to_false_is_fine(h: &Header, s: &str) -> bool {
+    h.is_open(s).unwrap_or(false)
+}
+
+fn bool_defaulted_by_default_is_fine(h: &Header, s: &str) -> bool {
+    h.is_open(s).unwrap_or_default()
+}
+
+fn bool_defaulted_to_false_by_thunk_is_fine(h: &Header, s: &str) -> bool {
+    h.is_open(s).unwrap_or_else(|_| false)
+}
+
+fn bool_defaulted_by_default_call_in_thunk_is_fine(h: &Header, s: &str) -> bool {
+    h.is_open(s).unwrap_or_else(|_| Default::default())
+}
+
+fn bool_defaulted_by_default_fn_is_fine(h: &Header, s: &str) -> bool {
+    h.is_open(s).ok().unwrap_or_else(Default::default)
+}
+
+fn early_success_before_receiver_check_is_fine(h: &Header, s: &str) -> u32 {
+    h.send(s).unwrap_or(0)
+}
+
+fn early_success_before_state_check_is_fine(tag: &str) -> u32 {
+    slot_for(tag).unwrap_or(0)
+}
+
+fn statement_position_default_is_a_discard(s: &str) {
+    check_port(s).unwrap_or_default();
+}
+
+fn ignored_error_is_fine(s: &str, log: &mut Vec<String>) -> u32 {
+    schedule(s, log).unwrap_or(0)
+}
+
+fn foreign_callee_is_fine(s: &str) -> u32 {
+    s.parse().unwrap_or(0)
+}
+
+fn resource_failure_is_fine(path: &str) -> u64 {
+    read_size(path).unwrap_or(0)
+}
+
+fn state_failure_is_fine(tag: &str) -> u32 {
+    next_slot(tag).unwrap_or(0)
+}
+
+fn infallible_is_fine(s: &str) -> usize {
+    always(s).unwrap_or(0)
+}
+
+fn computed_fallback_is_fine(s: &str, prev: u16) -> u16 {
+    parse_port(s).unwrap_or(prev)
+}
+
+fn computed_thunk_is_fine(s: &str, prev: u16) -> u16 {
+    parse_port(s).unwrap_or_else(|_| prev + 1)
+}
+
+fn handled_is_fine(s: &str) -> u16 {
+    match parse_port(s) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{}", describe(&e));
+            0
+        }
+    }
+}
+
+fn propagated_is_fine(s: &str) -> Result<u16, ParseError> {
+    let p = parse_port(s)?;
+    Ok(p)
+}
+
+#[allow(unknown_lints, discarded_error)]
+fn statement_ok_is_another_lints(s: &str) {
+    parse_port(s).ok();
+}
+
+fn let_else_some_is_fine(s: &str, out: &mut Vec<bool>) {
+    let Some(flag) = parse_flag(s) else { return };
+    out.push(flag);
+}
+
+fn let_else_reporting_failure_is_fine(s: &str, out: &mut Vec<u16>) -> bool {
+    let Ok(port) = parse_port(s) else {
+        return false;
+    };
+    out.push(port);
+    true
+}
+
+fn let_else_returning_none_is_fine(s: &str) -> Option<u16> {
+    let Ok(port) = parse_port(s) else {
+        return None;
+    };
+    Some(port)
+}
+
+fn let_else_doing_work_is_fine(s: &str, log: &mut Vec<String>) {
+    let Ok(port) = parse_port(s) else {
+        log.push(format!("bad port {s}"));
+        return;
+    };
+    log.push(port.to_string());
+}
+
+fn main() {
+    let h = Header { limit: 4, pos: 0 };
+    let mut hm = Header { limit: 4, pos: 0 };
+    let mut ports = Vec::new();
+    let mut flags = Vec::new();
+    let mut log = Vec::new();
+    let _ = unwrap_or_literal_is_flagged("a");
+    let _ = unwrap_or_default_is_flagged("a");
+    let _ = unwrap_or_else_const_is_flagged("a");
+    let _ = unwrap_or_else_default_call_is_flagged("a");
+    let _ = ok_then_unwrap_or_is_flagged("a");
+    let _ = bool_defaulted_to_true_is_flagged(&h, "a");
+    let _ = question_mark_callee_is_flagged("a:b");
+    let _ = method_callee_is_flagged(&h, "a");
+    let _ = let_else_ok_unit_is_flagged("a", &mut ports);
+    let_else_bare_return_is_flagged("a", &mut ports);
+    let _ = let_else_some_of_ok_unit_is_flagged("a", &mut ports);
+    let_else_some_of_ok_bare_return_is_flagged("a", &mut ports);
+    let _ = argument_check_behind_receiver_check_is_flagged(&h, "a");
+    unit_default_in_value_position_is_flagged("a");
+    let _ = listed_callee_is_flagged("1");
+    let _ = listed_foreign_callee_is_flagged("ff");
+    let _ = option_callee_is_fine("on");
+    let _ = option_callee_default_fn_is_fine("on");
+    let _ = receiver_decided_is_fine(&mut hm, "a");
+    let _ = bool_defaulted_to_false_is_fine(&h, "a");
+    let _ = bool_defaulted_by_default_is_fine(&h, "a");
+    let _ = bool_defaulted_to_false_by_thunk_is_fine(&h, "a");
+    let _ = bool_defaulted_by_default_call_in_thunk_is_fine(&h, "a");
+    let _ = bool_defaulted_by_default_fn_is_fine(&h, "a");
+    let _ = early_success_before_receiver_check_is_fine(&h, "a");
+    let _ = early_success_before_state_check_is_fine("a");
+    statement_position_default_is_a_discard("a");
+    let _ = ignored_error_is_fine("a", &mut log);
+    let _ = foreign_callee_is_fine("1");
+    let _ = resource_failure_is_fine("/");
+    let _ = state_failure_is_fine("a");
+    let _ = infallible_is_fine("a");
+    let _ = computed_fallback_is_fine("a", 1);
+    let _ = computed_thunk_is_fine("a", 1);
+    let _ = handled_is_fine("a");
+    let _ = propagated_is_fine("a");
+    statement_ok_is_another_lints("a");
+    let_else_some_is_fine("on", &mut flags);
+    let _ = let_else_reporting_failure_is_fine("a", &mut ports);
+    let _ = let_else_returning_none_is_fine("a");
+    let_else_doing_work_is_fine("a", &mut log);
+}

--- a/ui/defaulted_failure.stderr
+++ b/ui/defaulted_failure.stderr
@@ -1,0 +1,205 @@
+warning: `parse_port` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:156:5
+   |
+LL |     parse_port(s).unwrap_or(0)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = note: `#[warn(defaulted_failure)]` on by default
+
+warning: `parse_port` rejects some of what it is handed, and `unwrap_or_default` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:160:5
+   |
+LL |     parse_port(s).unwrap_or_default()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_port` rejects some of what it is handed, and `unwrap_or_else` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:164:5
+   |
+LL |     parse_port(s).unwrap_or_else(|_| u16::MAX)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_port` rejects some of what it is handed, and `unwrap_or_else` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:168:5
+   |
+LL |     parse_port(s).unwrap_or_else(|_| Default::default())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_port` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:172:5
+   |
+LL |     parse_port(s).ok().unwrap_or(80)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `Header::is_open` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:176:5
+   |
+LL |     h.is_open(s).unwrap_or(true)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:71:12
+   |
+LL |         if s.is_empty() {
+   |            ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_pair` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:180:5
+   |
+LL |     parse_pair(s).unwrap_or((0, 0))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:41:18
+   |
+LL |     let (a, b) = s.split_once(':').ok_or(ParseError::Empty)?;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `Header::parse_limit` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:184:5
+   |
+LL |     h.parse_limit(s).unwrap_or(0)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:54:12
+   |
+LL |         if n > self.limit {
+   |            ^^^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+  --> $DIR/defaulted_failure.rs:188:5
+   |
+LL | /     let Ok(port) = parse_port(s) else {
+LL | |         return Ok(());
+LL | |     };
+   | |______^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+  --> $DIR/defaulted_failure.rs:196:5
+   |
+LL |     let Ok(port) = parse_port(s) else { return };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+  --> $DIR/defaulted_failure.rs:201:5
+   |
+LL | /     let Some(port) = parse_port(s).ok() else {
+LL | |         return Ok(());
+LL | |     };
+   | |______^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+  --> $DIR/defaulted_failure.rs:209:5
+   |
+LL |     let Some(port) = parse_port(s).ok() else { return };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:20:8
+   |
+LL |     if s.is_empty() {
+   |        ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `Header::send_checked` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:214:5
+   |
+LL |     h.send_checked(s).unwrap_or(0)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:93:16
+   |
+LL |             if s.is_empty() {
+   |                ^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `check_port` rejects some of what it is handed, and `unwrap_or_default` carries on with a fixed value in place of the rejection
+  --> $DIR/defaulted_failure.rs:218:5
+   |
+LL |     check_port(s).unwrap_or_default()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the check whose failure is replaced
+  --> $DIR/defaulted_failure.rs:103:5
+   |
+LL |     parse_port(s)?;
+   |     ^^^^^^^^^^^^^^
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `listed_by_config` is listed in `defaulted-failure-callees`, and `unwrap_or` carries on with a fixed value in place of its failure
+  --> $DIR/defaulted_failure.rs:222:5
+   |
+LL |     listed_by_config(s).unwrap_or(0)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: `core::num::<impl u32>::from_str_radix` is listed in `defaulted-failure-callees`, and `unwrap_or` carries on with a fixed value in place of its failure
+  --> $DIR/defaulted_failure.rs:226:5
+   |
+LL |     u32::from_str_radix(s, 16).unwrap_or(0)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: propagate the failure, or handle the failing arm where its cause is still visible
+
+warning: 16 warnings emitted
+

--- a/ui/exclusive_options.rs
+++ b/ui/exclusive_options.rs
@@ -89,6 +89,31 @@ fn one_site() -> OneSite {
     }
 }
 
+// Fine: the later assignment goes through a Box, which is still a write to
+// the field.
+struct Boxed {
+    x: Option<u32>,
+    y: Option<u32>,
+}
+
+fn boxed_x() -> Box<Boxed> {
+    Box::new(Boxed {
+        x: Some(1),
+        y: None,
+    })
+}
+
+fn boxed_y() -> Box<Boxed> {
+    Box::new(Boxed {
+        x: None,
+        y: Some(2),
+    })
+}
+
+fn reopen(b: &mut Box<Boxed>) {
+    b.y = Some(3);
+}
+
 fn main() {
     let _ = success();
     let _ = failure();
@@ -99,4 +124,7 @@ fn main() {
     let _ = from_var(Some(1));
     let _ = from_var_other();
     let _ = one_site();
+    let mut b = boxed_x();
+    reopen(&mut b);
+    let _ = boxed_y();
 }

--- a/ui/guard_flag.rs
+++ b/ui/guard_flag.rs
@@ -24,6 +24,11 @@ impl Conn {
     fn reset(&mut self) {
         self.sent = 0;
     }
+
+    // The transition that makes `ready` a state and not a setting.
+    fn connect(&mut self) {
+        self.ready = true;
+    }
 }
 
 struct Once {
@@ -40,11 +45,35 @@ impl Once {
     }
 }
 
+struct Printer {
+    minify: bool,
+    out: String,
+}
+
+impl Printer {
+    // Fine: `minify` is set once, in the literal, and never written again;
+    // bailing on it is a mode, not an order of operations.
+    fn newline(&mut self) {
+        if self.minify {
+            return;
+        }
+        self.out.push('\n');
+    }
+
+    fn space(&mut self) {
+        if self.minify {
+            return;
+        }
+        self.out.push(' ');
+    }
+}
+
 fn main() {
     let mut c = Conn {
         ready: true,
         sent: 0,
     };
+    c.connect();
     c.send();
     c.flush();
     c.reset();
@@ -54,4 +83,11 @@ fn main() {
         fired: 0,
     };
     o.fire();
+
+    let mut p = Printer {
+        minify: true,
+        out: String::new(),
+    };
+    p.newline();
+    p.space();
 }

--- a/ui/insert_then_unwrap.rs
+++ b/ui/insert_then_unwrap.rs
@@ -40,10 +40,64 @@ fn different_key_is_fine() -> u32 {
     *m.get(&3).unwrap_or(&0)
 }
 
+fn rebound_key_is_fine(k: u32) -> u32 {
+    let mut m: HashMap<u32, u32> = HashMap::new();
+    m.insert(k + 1, 0);
+    m.insert(k, 2);
+    let k = k + 1;
+    let v = m.get(&k).unwrap();
+    *v
+}
+
+fn rebound_map_is_fine(k: u32, other: HashMap<u32, u32>) -> u32 {
+    let mut m: HashMap<u32, u32> = HashMap::new();
+    m.insert(k, 2);
+    let m = other;
+    let v = m.get(&k).unwrap();
+    *v
+}
+
+fn rebound_in_tuple_is_fine(k: u32) -> u32 {
+    let mut m: HashMap<u32, u32> = HashMap::new();
+    m.insert(k + 1, 0);
+    m.insert(k, 2);
+    let (k, other) = (k + 1, 1);
+    let v = m.get(&k).unwrap();
+    *v + other
+}
+
+fn negated_key_is_fine(k: i32) -> i32 {
+    let mut m: HashMap<i32, i32> = HashMap::new();
+    m.insert(k, 0);
+    m.insert(-k, 2);
+    let v = m.get(&k).unwrap();
+    *v
+}
+
+fn deref_key_is_flagged(k: &u32) -> u32 {
+    let mut m: HashMap<u32, u32> = HashMap::new();
+    m.insert(*k, 2);
+    let v = m.get(k).unwrap();
+    *v
+}
+
+fn lookup_in_the_rebinding_let_is_flagged(k: u32) -> u32 {
+    let mut m: HashMap<u32, u32> = HashMap::new();
+    m.insert(k, 2);
+    let k = m.get(&k).unwrap();
+    *k
+}
+
 fn main() {
     let _ = adjacent_is_flagged()
         + pure_statement_between_is_flagged()
         + call_between_is_fine()
         + remove_between_is_fine()
-        + different_key_is_fine();
+        + different_key_is_fine()
+        + rebound_key_is_fine(1)
+        + rebound_map_is_fine(1, HashMap::from([(1, 0)]))
+        + rebound_in_tuple_is_fine(1)
+        + deref_key_is_flagged(&1)
+        + lookup_in_the_rebinding_let_is_flagged(1);
+    let _ = negated_key_is_fine(1);
 }

--- a/ui/insert_then_unwrap.stderr
+++ b/ui/insert_then_unwrap.stderr
@@ -15,5 +15,21 @@ LL |     let v = m.get(&7).unwrap();
    |
    = help: keep the inserted value, or use the entry API; the panic path and the second lookup both vanish
 
-warning: 2 warnings emitted
+warning: this unwrap re-fetches `m[k]`, which the insert above just proved present
+  --> $DIR/insert_then_unwrap.rs:80:13
+   |
+LL |     let v = m.get(k).unwrap();
+   |             ^^^^^^^^^^^^^^^^^
+   |
+   = help: keep the inserted value, or use the entry API; the panic path and the second lookup both vanish
+
+warning: this unwrap re-fetches `m[k]`, which the insert above just proved present
+  --> $DIR/insert_then_unwrap.rs:87:13
+   |
+LL |     let k = m.get(&k).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = help: keep the inserted value, or use the entry API; the panic path and the second lookup both vanish
+
+warning: 4 warnings emitted
 

--- a/ui/lock_order.rs
+++ b/ui/lock_order.rs
@@ -52,6 +52,57 @@ impl T {
     }
 }
 
+struct Pool {
+    x: Mutex<u32>,
+    y: Mutex<u32>,
+}
+
+impl Pool {
+    fn xy(&self) -> u32 {
+        let gx = self.x.lock().unwrap();
+        let gy = self.y.lock().unwrap();
+        *gx + *gy
+    }
+}
+
+struct Cache {
+    x: Mutex<u32>,
+    y: Mutex<u32>,
+}
+
+impl Cache {
+    // Fine: `Cache::y` and `Cache::x` are not `Pool::x` and `Pool::y`; a
+    // field name shared by two types is not one lock.
+    fn yx(&self) -> u32 {
+        let gy = self.y.lock().unwrap();
+        let gx = self.x.lock().unwrap();
+        *gx + *gy
+    }
+}
+
+struct Deferred {
+    e: Mutex<u32>,
+    f: Mutex<u32>,
+}
+
+impl Deferred {
+    fn ef(&self) -> u32 {
+        let ge = self.e.lock().unwrap();
+        let gf = self.f.lock().unwrap();
+        *ge + *gf
+    }
+
+    // Fine: the reverse order is only inside a closure built while `f` is
+    // held; here it runs after the drop, and in general when its holder says.
+    fn fe_later(&self) -> u32 {
+        let gf = self.f.lock().unwrap();
+        let job = || *self.e.lock().unwrap();
+        let v = *gf;
+        drop(gf);
+        v + job()
+    }
+}
+
 fn main() {
     let s = S {
         a: Mutex::new(1),
@@ -63,4 +114,18 @@ fn main() {
         d: Mutex::new(4),
     };
     let _ = t.first() + t.second();
+    let p = Pool {
+        x: Mutex::new(5),
+        y: Mutex::new(6),
+    };
+    let c = Cache {
+        x: Mutex::new(7),
+        y: Mutex::new(8),
+    };
+    let _ = p.xy() + c.yx();
+    let d = Deferred {
+        e: Mutex::new(9),
+        f: Mutex::new(10),
+    };
+    let _ = d.ef() + d.fe_later();
 }

--- a/ui/overwide_parameter.rs
+++ b/ui/overwide_parameter.rs
@@ -39,10 +39,47 @@ fn pick(n: u32) -> Shape {
     if n > 2 { Shape::Circle(n) } else { Shape::Square(n) }
 }
 
+impl Shape {
+    // Fine: `pick(1).sides()` sends whatever `pick` returned to `self`, so
+    // the one path-style call passing Circle proves nothing about Line.
+    fn sides(self) -> u32 {
+        match self {
+            Shape::Circle(_) => 0,
+            Shape::Square(_) => 4,
+            Shape::Line => unreachable!("lines have no sides"),
+        }
+    }
+
+    // Flagged: every receiver is a literal, and none of them is Line.
+    fn corners(self) -> u32 {
+        match self {
+            Shape::Circle(_) => 0,
+            Shape::Square(_) => 4,
+            Shape::Line => unreachable!("lines have no corners"),
+        }
+    }
+}
+
+// Fine: `Shape::Circle` in the first argument position is a constructor
+// passed as a function, not a value of `Shape`, so it names no variant; the
+// second argument is what `build` matches on, and a call passes `Line`.
+fn build(make: fn(u32) -> Shape, seed: Shape) -> Shape {
+    match seed {
+        Shape::Circle(n) | Shape::Square(n) => make(n),
+        Shape::Line => panic!("nothing to build from"),
+    }
+}
+
 fn main() {
     let _ = area(Shape::Circle(2));
     let _ = area(Shape::Square(3));
     let _ = perimeter(Shape::Circle(2));
     let _ = perimeter(Shape::Line);
     let _ = diameter(pick(4));
+    let _ = Shape::sides(Shape::Circle(1));
+    let _ = pick(1).sides();
+    let _ = Shape::Circle(1).corners();
+    let _ = Shape::Square(2).corners();
+    let _ = build(Shape::Circle, Shape::Square(1));
+    let _ = build(Shape::Square, Shape::Line);
 }

--- a/ui/overwide_parameter.stderr
+++ b/ui/overwide_parameter.stderr
@@ -20,5 +20,13 @@ LL |         Shape::Line => unreachable!("lines have no area"),
    = help: the parameter is wider than the function's domain; narrow the type and the panic becomes a compile error for future callers
    = note: `#[warn(overwide_parameter)]` on by default
 
-warning: 2 warnings emitted
+warning: all 2 call sites of `corners` pass `Circle`, `Square`; this arm panics on `Line`, which no existing caller sends
+  --> $DIR/overwide_parameter.rs:58:13
+   |
+LL |             Shape::Line => unreachable!("lines have no corners"),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: the parameter is wider than the function's domain; narrow the type and the panic becomes a compile error for future callers
+
+warning: 3 warnings emitted
 

--- a/ui/parallel_bools.rs
+++ b/ui/parallel_bools.rs
@@ -36,6 +36,50 @@ impl Independent {
     }
 }
 
+// Fine: the lone write to `open` goes through a Box, and is still a write.
+struct Boxed {
+    open: bool,
+    ready: bool,
+}
+
+impl Boxed {
+    fn up(&mut self) {
+        self.open = true;
+        self.ready = true;
+    }
+
+    fn down(&mut self) {
+        self.open = false;
+        self.ready = false;
+    }
+}
+
+fn close_boxed(b: &mut Box<Boxed>) {
+    b.open = false;
+}
+
+// Fine: the lone write to `dirty` is a compound assignment.
+struct Ored {
+    dirty: bool,
+    seen: bool,
+}
+
+impl Ored {
+    fn reset(&mut self) {
+        self.dirty = false;
+        self.seen = false;
+    }
+
+    fn mark(&mut self) {
+        self.dirty = true;
+        self.seen = true;
+    }
+
+    fn touch(&mut self, changed: bool) {
+        self.dirty |= changed;
+    }
+}
+
 fn main() {
     let mut t = Task {
         running: false,
@@ -49,4 +93,20 @@ fn main() {
     let mut i = Independent { a: false, b: false };
     i.set_a();
     i.set_both();
+
+    let mut b = Box::new(Boxed {
+        open: false,
+        ready: false,
+    });
+    b.up();
+    b.down();
+    close_boxed(&mut b);
+
+    let mut o = Ored {
+        dirty: false,
+        seen: false,
+    };
+    o.reset();
+    o.mark();
+    o.touch(true);
 }

--- a/ui/stale_across_reentry.rs
+++ b/ui/stale_across_reentry.rs
@@ -1,0 +1,494 @@
+// compile-flags: --edition=2021
+//
+// A fact about a field of `self` (a length, a flag, a pointer), then a
+// statement that runs code this function cannot see and which can reach the
+// field, then the fact used against the field as if nothing had happened.
+// The ui config names `Vm::run_callback`, `dispatch*`, and the trait-impl
+// methods `Worker::run_job` and `Runner::schedule` as this project's own
+// re-entry points; those count without any argument analysis.
+
+use std::cell::RefCell;
+use std::ptr::NonNull;
+
+trait Sink {
+    fn notify(&self);
+    fn drain(&self, items: &mut Vec<u32>);
+}
+
+struct Stdout;
+
+impl Sink for Stdout {
+    fn notify(&self) {}
+    fn drain(&self, items: &mut Vec<u32>) {
+        items.clear();
+    }
+}
+
+struct Vm;
+
+impl Vm {
+    fn run_callback(&self) {}
+    fn tick(&self) {}
+}
+
+trait Runner {
+    fn run_job(&self);
+    fn schedule(&self);
+    fn poll(&self);
+}
+
+struct Worker;
+
+impl Runner for Worker {
+    fn run_job(&self) {}
+    fn schedule(&self) {}
+    fn poll(&self) {}
+}
+
+/// A collection of this crate: its methods may mutate through `&self`, so a
+/// fact about it can go stale in a `&self` method.
+struct Log {
+    lines: RefCell<Vec<u32>>,
+}
+
+impl Log {
+    fn len(&self) -> usize {
+        self.lines.borrow().len()
+    }
+    fn at(&self, i: usize) -> u32 {
+        self.lines.borrow()[i]
+    }
+    fn remove(&self, i: usize) -> u32 {
+        self.lines.borrow_mut().remove(i)
+    }
+}
+
+/// The same, with the cell behind a pointer: `Freeze` on its own, but a
+/// shared reference still gets to the cell.
+struct Journal {
+    lines: Box<RefCell<Vec<u32>>>,
+}
+
+impl Journal {
+    fn len(&self) -> usize {
+        self.lines.borrow().len()
+    }
+    fn remove(&self, i: usize) -> u32 {
+        self.lines.borrow_mut().remove(i)
+    }
+}
+
+/// A collection of this crate that nothing can change through `&`.
+struct Ring(Vec<u32>);
+
+impl Ring {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl std::ops::Index<usize> for Ring {
+    type Output = u32;
+    fn index(&self, i: usize) -> &u32 {
+        &self.0[i]
+    }
+}
+
+async fn yield_now() {}
+
+struct Host {
+    items: Vec<u32>,
+    buf: Vec<u8>,
+    pending: Option<u32>,
+    log: Log,
+    journal: Journal,
+    ring: Ring,
+    raw: NonNull<u8>,
+    borrowed: &'static [u8],
+    on_event: fn(&mut Host),
+    sink: Box<dyn Sink>,
+    vm: Vm,
+    worker: Worker,
+    tasks: Vec<Box<dyn Fn(&Vm)>>,
+}
+
+fn no_op(_: &mut Host) {}
+
+fn peek(_: &Host) {}
+
+fn peek_items(_: &Vec<u32>) {}
+
+impl Host {
+    fn dispatch_event(&self) {}
+
+    fn plain(&self) {}
+
+    fn count_across_fn_pointer_field_given_self_is_flagged(&mut self) -> u32 {
+        let n = self.items.len();
+        (self.on_event)(self);
+        self.items[n - 1]
+    }
+
+    fn position_across_dyn_given_the_field_is_flagged(&mut self) -> u32 {
+        let last = self.items.len() - 1;
+        self.sink.drain(&mut self.items);
+        self.items.remove(last)
+    }
+
+    fn gated_count_across_closure_given_self_is_flagged<F: FnMut(&mut Host)>(
+        &mut self,
+        mut f: F,
+    ) -> u32 {
+        let n = self.items.len();
+        f(self);
+        if n > 0 { self.items[0] } else { 0 }
+    }
+
+    fn loop_bound_across_closure_given_self_is_flagged<F: FnMut(&mut Host)>(
+        &mut self,
+        mut f: F,
+    ) -> u32 {
+        let n = self.items.len();
+        f(self);
+        let mut total = 0;
+        for i in 0..n {
+            total += self.items[i];
+        }
+        total
+    }
+
+    fn flag_across_fn_pointer_param_given_self_is_flagged(&mut self, f: fn(&mut Host)) -> u32 {
+        let had = self.pending.is_some();
+        f(self);
+        if had { self.pending.take().unwrap() } else { 0 }
+    }
+
+    fn pointer_across_dyn_given_self_is_flagged(&mut self, f: &dyn Fn(&mut Host)) -> u8 {
+        let p = self.buf.as_ptr();
+        f(self);
+        unsafe { *p }
+    }
+
+    fn crate_collection_across_dyn_in_shared_method_is_flagged(&self) -> u32 {
+        let n = self.log.len();
+        self.sink.notify();
+        self.log.remove(n - 1)
+    }
+
+    async fn crate_collection_across_await_in_shared_method_is_flagged(&self) -> u32 {
+        let n = self.log.len();
+        yield_now().await;
+        self.log.remove(n - 1)
+    }
+
+    fn count_across_configured_callee_is_flagged(&mut self) -> u32 {
+        let n = self.items.len() as u32;
+        self.vm.run_callback();
+        self.items[n as usize - 1]
+    }
+
+    fn count_across_configured_prefix_is_flagged(&mut self) -> u32 {
+        let n = self.items.len();
+        self.dispatch_event();
+        self.items[n - 1]
+    }
+
+    fn closure_not_given_self_is_fine<F: FnMut(&[u32])>(&mut self, mut f: F) -> u32 {
+        let n = self.items.len();
+        f(&self.items);
+        self.items[n - 1]
+    }
+
+    fn dyn_not_given_the_field_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        self.sink.notify();
+        self.items[n - 1]
+    }
+
+    fn std_collection_in_shared_method_is_fine(&self) -> u32 {
+        let n = self.items.len();
+        self.sink.notify();
+        self.items[n - 1]
+    }
+
+    async fn await_in_exclusive_method_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        yield_now().await;
+        self.items[n - 1]
+    }
+
+    fn crate_collection_read_after_reentry_is_fine(&self) -> u32 {
+        let n = self.log.len();
+        self.sink.notify();
+        self.log.at(0) + n as u32
+    }
+
+    fn pointer_copied_out_of_a_wrapper_is_fine(&mut self, f: fn(&mut Host)) -> u8 {
+        let p = self.raw.as_ptr();
+        f(self);
+        unsafe { *p }
+    }
+
+    fn fact_about_a_reference_field_is_fine(&mut self, f: fn(&mut Host)) -> u8 {
+        let n = self.borrowed.len();
+        f(self);
+        self.borrowed[n - 1]
+    }
+
+    fn count_across_plain_method_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        self.plain();
+        self.items[n - 1]
+    }
+
+    fn count_across_unconfigured_method_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        self.vm.tick();
+        self.items[n - 1]
+    }
+
+    fn requeried_after_reentry_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        (self.on_event)(self);
+        if n <= self.items.len() { self.items[n - 1] } else { 0 }
+    }
+
+    fn used_only_before_reentry_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        let v = self.items[n - 1];
+        (self.on_event)(self);
+        v
+    }
+
+    fn fact_about_a_local_is_fine(&mut self) -> u32 {
+        let local = vec![1, 2, 3];
+        let n = local.len();
+        (self.on_event)(self);
+        local[n - 1]
+    }
+
+    fn non_panicking_reuse_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        (self.on_event)(self);
+        self.items.truncate(n);
+        self.items.get(n).copied().unwrap_or(0)
+    }
+
+    fn field_replaced_after_reentry_is_fine(&mut self) -> usize {
+        let n = self.items.len();
+        (self.on_event)(self);
+        self.items = Vec::new();
+        self.items.get(n).map_or(n, |v| *v as usize)
+    }
+
+    fn binding_reassigned_after_reentry_is_fine(&mut self) -> u32 {
+        let mut n = self.items.len();
+        (self.on_event)(self);
+        n = 0;
+        self.items[n]
+    }
+
+    fn other_field_is_fine(&mut self) -> u8 {
+        let n = self.items.len();
+        (self.on_event)(self);
+        self.buf[n]
+    }
+
+    fn local_closure_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        let bump = |_: &mut Host| 1;
+        let extra = bump(self);
+        self.items[n - 1] + extra
+    }
+
+    fn pending_is_read_properly(&self) -> u32 {
+        if let Some(p) = self.pending { p } else { 0 }
+    }
+
+    fn index_in_a_condition_is_flagged(&mut self) -> u32 {
+        let n = self.items.len();
+        (self.on_event)(self);
+        if self.items[n - 1] > 0 { 1 } else { 0 }
+    }
+
+    fn removal_in_a_scrutinee_is_flagged(&mut self) -> u32 {
+        let n = self.items.len();
+        (self.on_event)(self);
+        match self.items.remove(n - 1) {
+            0 => 0,
+            v => v,
+        }
+    }
+
+    fn reentry_before_a_break_inside_the_statement_is_flagged(&mut self) -> u32 {
+        let n = self.items.len();
+        for i in 0..2 {
+            if i == 1 {
+                (self.on_event)(self);
+                break;
+            }
+        }
+        self.items[n - 1]
+    }
+
+    fn configured_impl_method_named_by_its_type_is_flagged(&mut self) -> u32 {
+        let n = self.items.len();
+        self.worker.run_job();
+        self.items[n - 1]
+    }
+
+    fn configured_impl_method_named_by_its_trait_is_flagged(&mut self) -> u32 {
+        let n = self.items.len();
+        self.worker.schedule();
+        self.items[n - 1]
+    }
+
+    fn crate_type_with_the_cell_behind_a_box_is_flagged(&self) -> u32 {
+        let n = self.journal.len();
+        self.sink.notify();
+        self.journal.remove(n - 1)
+    }
+
+    fn frozen_crate_type_given_self_is_flagged(&mut self) -> u32 {
+        let n = self.ring.len();
+        (self.on_event)(self);
+        self.ring[n - 1]
+    }
+
+    fn crate_collection_given_shared_self_is_flagged(&mut self, f: fn(&Host)) -> u32 {
+        let n = self.log.len();
+        f(self);
+        self.log.remove(n - 1)
+    }
+
+    fn reentry_in_a_returning_branch_is_fine(&mut self, early: bool) -> u32 {
+        let n = self.items.len();
+        if early {
+            (self.on_event)(self);
+            return 0;
+        }
+        self.items[n - 1]
+    }
+
+    fn returned_reentry_is_fine(&mut self, early: bool, f: fn(&mut Host) -> u32) -> u32 {
+        let n = self.items.len();
+        if early {
+            return f(self);
+        }
+        self.items[n - 1]
+    }
+
+    fn reentry_before_a_break_out_of_the_block_is_fine(&mut self, early: bool) -> u32 {
+        let mut total = 0;
+        for _ in 0..2 {
+            let n = self.items.len();
+            if early {
+                (self.on_event)(self);
+                break;
+            }
+            total += self.items[n - 1];
+        }
+        total
+    }
+
+    fn configured_callee_inside_a_stored_closure_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        self.tasks.push(Box::new(|vm: &Vm| vm.run_callback()));
+        self.items[n - 1]
+    }
+
+    fn frozen_crate_type_in_shared_method_is_fine(&self) -> u32 {
+        let n = self.ring.len();
+        self.sink.notify();
+        self.ring[n - 1]
+    }
+
+    fn fn_pointer_taking_shared_self_is_fine(&mut self, f: fn(&Host)) -> u32 {
+        let n = self.items.len();
+        f(self);
+        self.items[n - 1]
+    }
+
+    fn field_handed_out_shared_by_coercion_is_fine(&mut self, f: fn(&Vec<u32>)) -> u32 {
+        let n = self.items.len();
+        f(&mut self.items);
+        self.items[n - 1]
+    }
+
+    fn unconfigured_impl_method_is_fine(&mut self) -> u32 {
+        let n = self.items.len();
+        self.worker.poll();
+        self.items[n - 1]
+    }
+}
+
+fn main() {
+    static BYTES: [u8; 2] = [1, 2];
+    let mut byte = 7u8;
+    let mut h = Host {
+        items: vec![1, 2, 3],
+        buf: vec![4],
+        pending: Some(5),
+        log: Log {
+            lines: RefCell::new(vec![6]),
+        },
+        journal: Journal {
+            lines: Box::new(RefCell::new(vec![7])),
+        },
+        ring: Ring(vec![8]),
+        raw: NonNull::from(&mut byte),
+        borrowed: &BYTES,
+        on_event: no_op,
+        sink: Box::new(Stdout),
+        vm: Vm,
+        worker: Worker,
+        tasks: Vec::new(),
+    };
+    let _ = h.count_across_fn_pointer_field_given_self_is_flagged()
+        + h.gated_count_across_closure_given_self_is_flagged(|_| ())
+        + h.loop_bound_across_closure_given_self_is_flagged(|_| ())
+        + h.flag_across_fn_pointer_param_given_self_is_flagged(no_op)
+        + u32::from(h.pointer_across_dyn_given_self_is_flagged(&|_| ()))
+        + h.crate_collection_across_dyn_in_shared_method_is_flagged()
+        + h.count_across_configured_callee_is_flagged()
+        + h.count_across_configured_prefix_is_flagged()
+        + h.closure_not_given_self_is_fine(|_| ())
+        + h.dyn_not_given_the_field_is_fine()
+        + h.std_collection_in_shared_method_is_fine()
+        + h.crate_collection_read_after_reentry_is_fine()
+        + u32::from(h.pointer_copied_out_of_a_wrapper_is_fine(no_op))
+        + u32::from(h.fact_about_a_reference_field_is_fine(no_op))
+        + h.count_across_plain_method_is_fine()
+        + h.count_across_unconfigured_method_is_fine()
+        + h.requeried_after_reentry_is_fine()
+        + h.used_only_before_reentry_is_fine()
+        + h.fact_about_a_local_is_fine()
+        + h.local_closure_is_fine()
+        + h.pending_is_read_properly()
+        + h.position_across_dyn_given_the_field_is_flagged();
+    let _ = h.crate_collection_across_await_in_shared_method_is_flagged();
+    let _ = h.await_in_exclusive_method_is_fine();
+    let _ = h.non_panicking_reuse_is_fine();
+    let _ = h.binding_reassigned_after_reentry_is_fine();
+    let _ = u32::from(h.other_field_is_fine());
+    let _ = h.field_replaced_after_reentry_is_fine();
+    let _ = h.index_in_a_condition_is_flagged()
+        + h.removal_in_a_scrutinee_is_flagged()
+        + h.reentry_before_a_break_inside_the_statement_is_flagged()
+        + h.configured_impl_method_named_by_its_type_is_flagged()
+        + h.configured_impl_method_named_by_its_trait_is_flagged()
+        + h.crate_type_with_the_cell_behind_a_box_is_flagged()
+        + h.frozen_crate_type_given_self_is_flagged()
+        + h.crate_collection_given_shared_self_is_flagged(peek)
+        + h.reentry_in_a_returning_branch_is_fine(false)
+        + h.returned_reentry_is_fine(false, |_| 0)
+        + h.reentry_before_a_break_out_of_the_block_is_fine(false)
+        + h.configured_callee_inside_a_stored_closure_is_fine()
+        + h.frozen_crate_type_in_shared_method_is_fine()
+        + h.fn_pointer_taking_shared_self_is_fine(peek)
+        + h.field_handed_out_shared_by_coercion_is_fine(peek_items)
+        + h.unconfigured_impl_method_is_fine();
+    for task in &h.tasks {
+        task(&h.vm);
+    }
+}

--- a/ui/stale_across_reentry.stderr
+++ b/ui/stale_across_reentry.stderr
@@ -1,0 +1,237 @@
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:129:9
+   |
+LL |         self.items[n - 1]
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:128:9
+   |
+LL |         (self.on_event)(self);
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+   = note: `#[warn(stale_across_reentry)]` on by default
+
+warning: `last` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:135:9
+   |
+LL |         self.items.remove(last)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:134:9
+   |
+LL |         self.sink.drain(&mut self.items);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:144:20
+   |
+LL |         if n > 0 { self.items[0] } else { 0 }
+   |                    ^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:143:9
+   |
+LL |         f(self);
+   |         ^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:155:22
+   |
+LL |             total += self.items[i];
+   |                      ^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:152:9
+   |
+LL |         f(self);
+   |         ^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `had` describes `self.pending` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:163:18
+   |
+LL |         if had { self.pending.take().unwrap() } else { 0 }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:162:9
+   |
+LL |         f(self);
+   |         ^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `p` points into `self.buf` as it stood before a call that can re-enter and move or free it
+  --> $DIR/stale_across_reentry.rs:169:19
+   |
+LL |         unsafe { *p }
+   |                   ^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:168:9
+   |
+LL |         f(self);
+   |         ^^^^^^^
+   = help: take the pointer after the call, or keep what it points at alive across it by value
+
+warning: `n` describes `self.log` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:175:9
+   |
+LL |         self.log.remove(n - 1)
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:174:9
+   |
+LL |         self.sink.notify();
+   |         ^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.log` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:181:9
+   |
+LL |         self.log.remove(n - 1)
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:180:9
+   |
+LL |         yield_now().await;
+   |         ^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:187:9
+   |
+LL |         self.items[n as usize - 1]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:186:9
+   |
+LL |         self.vm.run_callback();
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:193:9
+   |
+LL |         self.items[n - 1]
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:192:9
+   |
+LL |         self.dispatch_event();
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:311:12
+   |
+LL |         if self.items[n - 1] > 0 { 1 } else { 0 }
+   |            ^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:310:9
+   |
+LL |         (self.on_event)(self);
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:317:15
+   |
+LL |         match self.items.remove(n - 1) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:316:9
+   |
+LL |         (self.on_event)(self);
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:331:9
+   |
+LL |         self.items[n - 1]
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:327:17
+   |
+LL |                 (self.on_event)(self);
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:337:9
+   |
+LL |         self.items[n - 1]
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:336:9
+   |
+LL |         self.worker.run_job();
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:343:9
+   |
+LL |         self.items[n - 1]
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:342:9
+   |
+LL |         self.worker.schedule();
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.journal` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:349:9
+   |
+LL |         self.journal.remove(n - 1)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:348:9
+   |
+LL |         self.sink.notify();
+   |         ^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.ring` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:355:9
+   |
+LL |         self.ring[n - 1]
+   |         ^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:354:9
+   |
+LL |         (self.on_event)(self);
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: `n` describes `self.log` as it stood before a call that can re-enter and change it
+  --> $DIR/stale_across_reentry.rs:361:9
+   |
+LL |         self.log.remove(n - 1)
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: control leaves this function here, with `self` reachable from whatever runs
+  --> $DIR/stale_across_reentry.rs:360:9
+   |
+LL |         f(self);
+   |         ^^^^^^^
+   = help: re-read the field after the call, or hold the item itself rather than its position
+
+warning: 18 warnings emitted
+

--- a/ui/unchecked_input_len.rs
+++ b/ui/unchecked_input_len.rs
@@ -1,0 +1,478 @@
+// A parameter, or a field reached from one, that one path bounds (an ordering
+// comparison, possibly of arithmetic on it) and another path, or the same path
+// earlier, hands to something that turns it into memory is flagged at the use;
+// an assertion about something else in front of the use is not the check. Not
+// flagged: uses every path checks first (debug_assert!, `.get(i)?`, a call or
+// assert_eq! given `&value` included), arithmetic on the value, a copy the body
+// advances or re-assigns, `&value` itself, `self`'s fields, values only tested
+// for equality or against a range, never compared, computed, written to, slicing.
+
+pub struct Header {
+    pub kind: u8,
+    pub len: usize,
+    pub count: u32,
+}
+
+pub struct Frame {
+    pub header: Header,
+    pub payload: Vec<u8>,
+}
+
+fn sibling_arm_is_flagged<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 {
+        if hdr.len > buf.len() {
+            return &[];
+        }
+        return unsafe { buf.get_unchecked(..hdr.len) };
+    }
+    unsafe { buf.get_unchecked(..hdr.len) }
+}
+
+fn use_before_check_is_flagged(len: usize, buf: &[u8]) -> Option<&[u8]> {
+    let (head, _) = buf.split_at(len);
+    if len > buf.len() {
+        return None;
+    }
+    Some(head)
+}
+
+fn nested_field_through_local_is_flagged(f: &Frame) -> Vec<u8> {
+    let n = f.header.len;
+    let out = Vec::with_capacity(n);
+    if n > 1 << 20 {
+        return Vec::new();
+    }
+    out
+}
+
+fn conditional_check_then_unconditional_use_is_flagged(hdr: &Header, out: &mut Vec<u8>) {
+    if hdr.kind == 2 && hdr.count > 1024 {
+        return;
+    }
+    out.reserve(hdr.count as usize);
+}
+
+fn capture_is_flagged(len: usize, buf: &[u8]) -> impl Fn(bool) -> usize + '_ {
+    move |strict| {
+        if strict && len > buf.len() {
+            return 0;
+        }
+        unsafe { buf.get_unchecked(..len) }.len()
+    }
+}
+
+fn check_through_arithmetic_is_flagged<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 {
+        if hdr.len + 4 > buf.len() {
+            return &[];
+        }
+        return &buf[4..];
+    }
+    unsafe { buf.get_unchecked(..hdr.len) }
+}
+
+fn pointer_offset_is_flagged(off: usize, base: *const u8, cap: usize) -> *const u8 {
+    let p = unsafe { base.add(off) };
+    if off >= cap {
+        return base;
+    }
+    p
+}
+
+fn check_in_one_arm_beside_a_panicking_arm_is_flagged(hdr: &Header, buf: &[u8]) -> usize {
+    match hdr.kind {
+        0 => {
+            if hdr.len > buf.len() {
+                return 0;
+            }
+        }
+        1 => {}
+        _ => unreachable!(),
+    }
+    buf.split_at(hdr.len).0.len()
+}
+
+fn assertion_about_something_else_before_the_use_is_flagged(
+    ok: bool,
+    len: usize,
+    buf: &[u8],
+) -> Option<&[u8]> {
+    assert!(ok);
+    let (head, _) = buf.split_at(len);
+    if len > buf.len() {
+        return None;
+    }
+    Some(head)
+}
+
+fn let_else_before_the_use_is_flagged(first: Option<u8>, len: usize, buf: &[u8]) -> Option<&[u8]> {
+    let Some(_first) = first else { panic!() };
+    let (head, _) = buf.split_at(len);
+    if len > buf.len() {
+        return None;
+    }
+    Some(head)
+}
+
+fn assertion_beside_the_use_in_an_arm_is_flagged(
+    strict: bool,
+    len: usize,
+    buf: &[u8],
+) -> *const u8 {
+    if strict {
+        assert!(!buf.is_empty());
+        let p = unsafe { buf.as_ptr().add(len) };
+        if len > buf.len() {
+            return buf.as_ptr();
+        }
+        return p;
+    }
+    buf.as_ptr()
+}
+
+fn judging_call_that_does_not_dominate_is_flagged<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 && (hdr.len > buf.len() || !fits(&hdr.len, buf)) {
+        return &[];
+    }
+    buf.split_at(hdr.len).0
+}
+
+unsafe fn read_through_a_copied_pointer_is_flagged(p: *const Header, buf: &[u8]) -> usize {
+    let q = p;
+    if unsafe { (*q).kind } == 1 && unsafe { (*q).len } > buf.len() {
+        return 0;
+    }
+    buf.split_at(unsafe { (*q).len }).0.len()
+}
+
+fn loop_over_a_range_of_it_is_not_a_check_so_is_flagged(len: usize, buf: &[u8]) -> usize {
+    let mut sum = 0;
+    for i in 0..len {
+        sum += i;
+    }
+    if sum == 0 && len > buf.len() {
+        return 0;
+    }
+    buf.split_at(len).0.len()
+}
+
+fn fits(len: &usize, buf: &[u8]) -> bool {
+    *len <= buf.len()
+}
+
+fn every_path_checked_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.len > buf.len() {
+        return &[];
+    }
+    if hdr.kind == 1 {
+        return buf.split_at(hdr.len).0;
+    }
+    buf.split_at(hdr.len).1
+}
+
+fn clamp_dominates_is_fine(len: usize, buf: &[u8]) -> &[u8] {
+    let mut n = len;
+    if n > buf.len() {
+        n = buf.len();
+    }
+    buf.split_at(n).0
+}
+
+fn assert_dominates_is_fine(len: usize, buf: &[u8]) -> &[u8] {
+    assert!(len <= buf.len());
+    if len == 0 {
+        return &[];
+    }
+    buf.split_at(len).0
+}
+
+fn debug_assert_dominates_is_fine(len: usize, buf: &[u8]) -> &[u8] {
+    debug_assert!(len <= buf.len());
+    if len == 0 {
+        return &[];
+    }
+    buf.split_at(len).0
+}
+
+fn conjunction_in_assertion_is_fine<'a>(a: usize, b: usize, buf: &'a [u8]) -> (&'a [u8], &'a [u8]) {
+    debug_assert!(a <= buf.len() && b <= buf.len());
+    (buf.split_at(a).0, buf.split_at(b).0)
+}
+
+fn match_arms_are_fine(len: usize, buf: &[u8]) -> &[u8] {
+    match len {
+        0 => &[],
+        1..=8 => buf.split_at(len).0,
+        n => buf.split_at(n.min(buf.len())).0,
+    }
+}
+
+fn never_compared_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    buf.split_at(hdr.len).0
+}
+
+fn through_a_call_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        return &[];
+    }
+    let n = hdr.len.min(buf.len());
+    buf.split_at(n).0
+}
+
+fn own_length_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    let n = buf.len();
+    if hdr.kind == 1 && n < 4 {
+        return &[];
+    }
+    buf.split_at(n).0
+}
+
+fn payload_of_call_is_fine(input: Option<usize>, buf: &[u8]) -> Option<&[u8]> {
+    let n = input?;
+    let tail = unsafe { buf.get_unchecked(..n) };
+    if n > buf.len() {
+        return None;
+    }
+    Some(tail)
+}
+
+fn written_place_is_fine<'a>(hdr: &mut Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        hdr.len = buf.len();
+    }
+    buf.split_at(hdr.len).0
+}
+
+fn sibling_field_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 && hdr.count > 8 {
+        return &[];
+    }
+    buf.split_at(hdr.len).0
+}
+
+impl Header {
+    fn own_field_is_fine<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
+        let out = buf.split_at(self.len).0;
+        if self.len < 16 {
+            return &[];
+        }
+        out
+    }
+}
+
+fn equality_is_not_a_bound_so_is_fine(len: usize, buf: &[u8]) -> &[u8] {
+    let head = buf.split_at(len).0;
+    if len == 0 || len != buf.len() {
+        return &[];
+    }
+    head
+}
+
+fn equality_check_still_covers_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 {
+        if hdr.len != 8 {
+            return &[];
+        }
+        return buf.split_at(hdr.len).0;
+    }
+    if hdr.len > buf.len() {
+        return &[];
+    }
+    buf.split_at(hdr.len).0
+}
+
+fn judging_call_covers_is_fine(p: usize, buf: &[u8]) -> Option<&[u8]> {
+    let first = *buf.get(p)?;
+    if first == b'-' {
+        return Some(buf.split_at(p).0);
+    }
+    if p > 4 {
+        return None;
+    }
+    Some(buf.split_at(p).1)
+}
+
+fn derived_quantity_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    let end = 4 + hdr.len;
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        return &[];
+    }
+    buf.split_at(end).0
+}
+
+fn copy_that_is_later_advanced_is_fine(p: usize, buf: &[u8]) -> usize {
+    let mut q = p;
+    let (head, _) = buf.split_at(q);
+    while q < buf.len() && buf[q] != b',' {
+        q += 1;
+    }
+    q + head.len()
+}
+
+fn safe_indexing_is_not_a_sink_so_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> (&'a [u8], u8) {
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        return (&[], 0);
+    }
+    (&buf[..hdr.len], buf[hdr.count as usize])
+}
+
+fn copy_reassigned_on_the_other_path_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    let mut n = hdr.len;
+    if hdr.kind == 1 {
+        if hdr.len > buf.len() {
+            return &[];
+        }
+    } else {
+        n = buf.len();
+    }
+    buf.split_at(n).0
+}
+
+fn copy_clamped_on_the_other_path_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    let mut n = hdr.len;
+    if hdr.kind == 1 {
+        if n > buf.len() {
+            return &[];
+        }
+    } else {
+        n = n.min(buf.len());
+    }
+    unsafe { buf.get_unchecked(..n) }
+}
+
+fn call_given_a_reference_covers_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        return &[];
+    }
+    if !fits(&hdr.len, buf) {
+        return &[];
+    }
+    buf.split_at(hdr.len).0
+}
+
+fn assert_eq_covers_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        return &[];
+    }
+    assert_eq!(hdr.len, buf.len());
+    buf.split_at(hdr.len).0
+}
+
+fn cmp_covers_is_fine<'a>(hdr: &Header, buf: &'a [u8]) -> &'a [u8] {
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        return &[];
+    }
+    if let std::cmp::Ordering::Greater = hdr.len.cmp(&buf.len()) {
+        return &[];
+    }
+    buf.split_at(hdr.len).0
+}
+
+fn address_of_the_value_is_not_the_value_so_is_fine<'a>(
+    hdr: &'a Header,
+    buf: &[u8],
+) -> &'a [usize] {
+    if hdr.kind == 1 && hdr.len > buf.len() {
+        return &[];
+    }
+    unsafe { std::slice::from_raw_parts(&hdr.len, 1) }
+}
+
+fn assertion_before_a_debug_assert_is_fine(ok: bool, len: usize, buf: &[u8]) -> &[u8] {
+    assert!(ok);
+    debug_assert!(len <= buf.len());
+    if len == 0 {
+        return &[];
+    }
+    buf.split_at(len).0
+}
+
+fn range_pattern_is_a_dispatch_so_is_fine(len: usize, buf: &[u8]) -> usize {
+    let mut weight = 0;
+    match len {
+        0 => weight += 1,
+        1..=8 => weight += 2,
+        _ => weight += 3,
+    }
+    buf.split_at(len).0.len() + weight
+}
+
+unsafe fn write_through_a_copied_pointer_is_fine(p: *mut Header, buf: &[u8]) -> usize {
+    let q = p;
+    unsafe { (*q).len = buf.len() };
+    if unsafe { (*p).kind } == 1 && unsafe { (*p).len } > buf.len() {
+        return 0;
+    }
+    buf.split_at(unsafe { (*p).len }).0.len()
+}
+
+fn main() {
+    let hdr = Header {
+        kind: 1,
+        len: 2,
+        count: 1,
+    };
+    let frame = Frame {
+        header: Header {
+            kind: 0,
+            len: 0,
+            count: 0,
+        },
+        payload: Vec::new(),
+    };
+    let buf = [0u8; 8];
+    let mut owned = Header {
+        kind: 1,
+        len: 99,
+        count: 0,
+    };
+    let whole = Header {
+        kind: 0,
+        len: buf.len(),
+        count: 0,
+    };
+    let mut out = Vec::new();
+    let _ = sibling_arm_is_flagged(&hdr, &buf);
+    let _ = use_before_check_is_flagged(2, &buf);
+    let _ = nested_field_through_local_is_flagged(&frame);
+    let _ = frame.payload.len();
+    conditional_check_then_unconditional_use_is_flagged(&hdr, &mut out);
+    let _ = capture_is_flagged(2, &buf)(true);
+    let _ = check_through_arithmetic_is_flagged(&hdr, &buf);
+    let _ = pointer_offset_is_flagged(1, buf.as_ptr(), buf.len());
+    let _ = check_in_one_arm_beside_a_panicking_arm_is_flagged(&hdr, &buf);
+    let _ = assertion_about_something_else_before_the_use_is_flagged(true, 2, &buf);
+    let _ = let_else_before_the_use_is_flagged(Some(0), 2, &buf);
+    let _ = assertion_beside_the_use_in_an_arm_is_flagged(true, 2, &buf);
+    let _ = judging_call_that_does_not_dominate_is_flagged(&hdr, &buf);
+    let _ = unsafe { read_through_a_copied_pointer_is_flagged(&hdr, &buf) };
+    let _ = loop_over_a_range_of_it_is_not_a_check_so_is_flagged(2, &buf);
+    let _ = every_path_checked_is_fine(&hdr, &buf);
+    let _ = clamp_dominates_is_fine(2, &buf);
+    let _ = assert_dominates_is_fine(2, &buf);
+    let _ = debug_assert_dominates_is_fine(2, &buf);
+    let _ = conjunction_in_assertion_is_fine(1, 2, &buf);
+    let _ = match_arms_are_fine(2, &buf);
+    let _ = never_compared_is_fine(&hdr, &buf);
+    let _ = through_a_call_is_fine(&hdr, &buf);
+    let _ = own_length_is_fine(&hdr, &buf);
+    let _ = payload_of_call_is_fine(Some(2), &buf);
+    let _ = written_place_is_fine(&mut owned, &buf);
+    let _ = sibling_field_is_fine(&hdr, &buf);
+    let _ = hdr.own_field_is_fine(&buf);
+    let _ = equality_is_not_a_bound_so_is_fine(2, &buf);
+    let _ = equality_check_still_covers_is_fine(&hdr, &buf);
+    let _ = judging_call_covers_is_fine(1, &buf);
+    let _ = derived_quantity_is_fine(&hdr, &buf);
+    let _ = copy_that_is_later_advanced_is_fine(1, &buf);
+    let _ = safe_indexing_is_not_a_sink_so_is_fine(&hdr, &buf);
+    let _ = copy_reassigned_on_the_other_path_is_fine(&hdr, &buf);
+    let _ = copy_clamped_on_the_other_path_is_fine(&hdr, &buf);
+    let _ = call_given_a_reference_covers_is_fine(&hdr, &buf);
+    let _ = assert_eq_covers_is_fine(&whole, &buf);
+    let _ = cmp_covers_is_fine(&hdr, &buf);
+    let _ = address_of_the_value_is_not_the_value_so_is_fine(&hdr, &buf);
+    let _ = assertion_before_a_debug_assert_is_fine(true, 2, &buf);
+    let _ = range_pattern_is_a_dispatch_so_is_fine(2, &buf);
+    let _ = unsafe { write_through_a_copied_pointer_is_fine(&mut owned, &buf) };
+}

--- a/ui/unchecked_input_len.stderr
+++ b/ui/unchecked_input_len.stderr
@@ -1,0 +1,185 @@
+warning: `hdr.len` reaches `get_unchecked` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:28:18
+   |
+LL |     unsafe { buf.get_unchecked(..hdr.len) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:23:12
+   |
+LL |         if hdr.len > buf.len() {
+   |            ^^^^^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = note: `#[warn(unchecked_input_len)]` on by default
+
+warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:32:25
+   |
+LL |     let (head, _) = buf.split_at(len);
+   |                         ^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:33:8
+   |
+LL |     if len > buf.len() {
+   |        ^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `n` reaches `with_capacity` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:41:15
+   |
+LL |     let out = Vec::with_capacity(n);
+   |               ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:42:8
+   |
+LL |     if n > 1 << 20 {
+   |        ^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `hdr.count` reaches `reserve` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:52:9
+   |
+LL |     out.reserve(hdr.count as usize);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:49:25
+   |
+LL |     if hdr.kind == 2 && hdr.count > 1024 {
+   |                         ^^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `len` reaches `get_unchecked` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:60:22
+   |
+LL |         unsafe { buf.get_unchecked(..len) }.len()
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:57:22
+   |
+LL |         if strict && len > buf.len() {
+   |                      ^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `hdr.len` reaches `get_unchecked` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:71:18
+   |
+LL |     unsafe { buf.get_unchecked(..hdr.len) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:66:12
+   |
+LL |         if hdr.len + 4 > buf.len() {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `off` reaches `add` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:75:27
+   |
+LL |     let p = unsafe { base.add(off) };
+   |                           ^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:76:8
+   |
+LL |     if off >= cap {
+   |        ^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `hdr.len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:92:9
+   |
+LL |     buf.split_at(hdr.len).0.len()
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:85:16
+   |
+LL |             if hdr.len > buf.len() {
+   |                ^^^^^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:101:25
+   |
+LL |     let (head, _) = buf.split_at(len);
+   |                         ^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:102:8
+   |
+LL |     if len > buf.len() {
+   |        ^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:110:25
+   |
+LL |     let (head, _) = buf.split_at(len);
+   |                         ^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:111:8
+   |
+LL |     if len > buf.len() {
+   |        ^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `len` reaches `add` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:124:39
+   |
+LL |         let p = unsafe { buf.as_ptr().add(len) };
+   |                                       ^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:125:12
+   |
+LL |         if len > buf.len() {
+   |            ^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `hdr.len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:137:9
+   |
+LL |     buf.split_at(hdr.len).0
+   |         ^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:134:26
+   |
+LL |     if hdr.kind == 1 && (hdr.len > buf.len() || !fits(&hdr.len, buf)) {
+   |                          ^^^^^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `q.len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:145:9
+   |
+LL |     buf.split_at(unsafe { (*q).len }).0.len()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:142:37
+   |
+LL |     if unsafe { (*q).kind } == 1 && unsafe { (*q).len } > buf.len() {
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+  --> $DIR/unchecked_input_len.rs:156:9
+   |
+LL |     buf.split_at(len).0.len()
+   |         ^^^^^^^^^^^^^
+   |
+note: the bound that does not cover this use
+  --> $DIR/unchecked_input_len.rs:153:20
+   |
+LL |     if sum == 0 && len > buf.len() {
+   |                    ^^^^^^^^^^^^^^^
+   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+
+warning: 14 warnings emitted
+

--- a/ui/unread_error_variant.rs
+++ b/ui/unread_error_variant.rs
@@ -161,6 +161,29 @@ fn trace() {
     println!("{} {}", Trace::Enter, Trace::Exit);
 }
 
+// A tuple constructor handed to `map_err` constructs the variant just as a
+// written-out call does: `Malformed` is built that way and never named, so it
+// is flagged; `Missing` is built the same way and named, so it is not.
+enum ParseError {
+    Missing,
+    Malformed(std::num::ParseIntError),
+}
+
+fn parse(s: &str) -> Result<u32, ParseError> {
+    if s.is_empty() {
+        return Err(ParseError::Missing);
+    }
+    s.parse::<u32>().map_err(ParseError::Malformed)
+}
+
+fn parse_or_zero(s: &str) -> u32 {
+    match parse(s) {
+        Ok(n) => n,
+        Err(ParseError::Missing) => 0,
+        Err(_) => 1,
+    }
+}
+
 fn main() {
     let _ = handle(0);
     let _ = resolve(10);
@@ -170,4 +193,5 @@ fn main() {
     let _ = speeds();
     let _ = run();
     let _ = levels();
+    let _ = parse_or_zero("7");
 }

--- a/ui/unread_error_variant.stderr
+++ b/ui/unread_error_variant.stderr
@@ -23,5 +23,13 @@ LL |     speed(Mode::Fast) + speed(Mode::Slow) + speed(Mode::Crawl) + speed(Mode
    |
    = help: the variant's structure is never read; handle it distinctly or collapse it into another variant
 
-warning: 3 warnings emitted
+warning: `ParseError::Malformed` is constructed here, but no pattern outside `ParseError`'s trait impls ever names it
+  --> $DIR/unread_error_variant.rs:176:30
+   |
+LL |     s.parse::<u32>().map_err(ParseError::Malformed)
+   |                              ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: the variant's structure is never read; handle it distinctly or collapse it into another variant
+
+warning: 4 warnings emitted
 

--- a/ui/wildcard_local_enum.rs
+++ b/ui/wildcard_local_enum.rs
@@ -120,6 +120,111 @@ fn non_enum_is_fine(x: u32) -> u32 {
     }
 }
 
+// `b""` and `""` are the empty-slice answer spelled as a literal.
+fn extractor_empty_bytestr_is_fine(o: &Op) -> &'static [u8] {
+    match o {
+        Op::Add => b"+",
+        _ => b"",
+    }
+}
+
+fn extractor_empty_str_is_fine(o: &Op) -> &'static str {
+    match o {
+        Op::Add => "+",
+        _ => "",
+    }
+}
+
+// The same answers inside braces.
+fn extractor_braced_return_is_fine(o: &Op) -> Option<u32> {
+    let n = match o {
+        Op::Add => 1,
+        _ => {
+            return None;
+        }
+    };
+    Some(n)
+}
+
+fn extractor_braced_tail_is_fine(o: &Op) -> Option<u32> {
+    match o {
+        Op::Add => Some(1),
+        _ => {
+            // Nothing else has a cost.
+            None
+        }
+    }
+}
+
+// A statement before the answer is behavior the arm gives future variants.
+fn braced_statement_is_flagged(o: &Op) -> Option<u32> {
+    match o {
+        Op::Add => Some(1),
+        _ => {
+            note();
+            None
+        }
+    }
+}
+
+fn note() {}
+
+// A binding arm whose whole body is another match on the binding hands the
+// dispatch on; the inner match is judged on its own.
+fn redispatch_is_fine(o: Op) -> i32 {
+    match o {
+        Op::Add => 1,
+        other => match other {
+            Op::Add => 0,
+            Op::Sub => 2,
+            Op::Mul => 3,
+        },
+    }
+}
+
+macro_rules! dispatch {
+    ($o:expr) => {
+        match $o {
+            Op::Add => 1,
+            Op::Sub => 2,
+            Op::Mul => 3,
+        }
+    };
+}
+
+fn redispatch_via_macro_is_fine(o: Op) -> i32 {
+    match o {
+        Op::Mul => 30,
+        other => dispatch!(other),
+    }
+}
+
+// Only the inner match's own wildcard is flagged.
+fn redispatch_flags_inner_only(o: Op) -> i32 {
+    match o {
+        Op::Add => 1,
+        other => match other {
+            Op::Sub => 2,
+            _ => 0,
+        },
+    }
+}
+
+// A statement before the inner match runs for future variants too.
+fn redispatch_after_statement_is_flagged(o: Op) -> i32 {
+    match o {
+        Op::Add => 1,
+        other => {
+            note();
+            match other {
+                Op::Add => 0,
+                Op::Sub => 2,
+                Op::Mul => 3,
+            }
+        }
+    }
+}
+
 fn main() {
     let _ = wild_is_flagged(Op::Add);
     let _ = binding_is_flagged(Op::Sub);
@@ -135,4 +240,13 @@ fn main() {
     let _ = non_exhaustive_listed_is_fine(Entry::Irq);
     let _ = foreign_enum_is_fine(Some(1));
     let _ = non_enum_is_fine(1);
+    let _ = extractor_empty_bytestr_is_fine(&Op::Add);
+    let _ = extractor_empty_str_is_fine(&Op::Sub);
+    let _ = extractor_braced_return_is_fine(&Op::Mul);
+    let _ = extractor_braced_tail_is_fine(&Op::Add);
+    let _ = braced_statement_is_flagged(&Op::Sub);
+    let _ = redispatch_is_fine(Op::Mul);
+    let _ = redispatch_via_macro_is_fine(Op::Add);
+    let _ = redispatch_flags_inner_only(Op::Sub);
+    let _ = redispatch_after_statement_is_flagged(Op::Mul);
 }

--- a/ui/wildcard_local_enum.stderr
+++ b/ui/wildcard_local_enum.stderr
@@ -34,5 +34,40 @@ LL -         _ => 0,
 LL +         Entry::Memory | Entry::Irq => 0,
    |
 
-warning: 3 warnings emitted
+warning: this arm absorbs every future variant of `Op` (3 variants today)
+  --> $DIR/wildcard_local_enum.rs:163:9
+   |
+LL |         _ => {
+   |         ^
+   |
+help: list the remaining variants; the compiler then flags every new one added
+   |
+LL -         _ => {
+LL +         Op::Sub | Op::Mul => {
+   |
+
+warning: this arm absorbs every future variant of `Op` (3 variants today)
+  --> $DIR/wildcard_local_enum.rs:208:13
+   |
+LL |             _ => 0,
+   |             ^
+   |
+help: list the remaining variants; the compiler then flags every new one added
+   |
+LL -             _ => 0,
+LL +             Op::Add | Op::Mul => 0,
+   |
+
+warning: this arm absorbs every future variant of `Op` (3 variants today)
+  --> $DIR/wildcard_local_enum.rs:217:9
+   |
+LL |         other => {
+   |         ^^^^^
+   |
+help: list the remaining variants; the compiler then flags every new one added
+   |
+LL |         other @ (Op::Sub | Op::Mul) => {
+   |               +++++++++++++++++++++
+
+warning: 6 warnings emitted
 

--- a/ui_off/flag_cluster.rs
+++ b/ui_off/flag_cluster.rs
@@ -1,0 +1,17 @@
+// The same shape ui/flag_cluster.rs flags; without `flag-cluster-enabled`
+// nothing is reported.
+
+struct Refusals {
+    too_big: bool,
+    exhausted: bool,
+    fragmented: bool,
+}
+
+fn main() {
+    let r = Refusals {
+        too_big: false,
+        exhausted: false,
+        fragmented: true,
+    };
+    println!("{} {} {}", r.too_big, r.exhausted, r.fragmented);
+}

--- a/ui_off/stale_safety_comment.rs
+++ b/ui_off/stale_safety_comment.rs
@@ -1,0 +1,12 @@
+// The same shape ui/stale_safety_comment.rs flags; without
+// `stale-safety-comment-enabled` nothing is reported.
+
+fn stale_name(p: *const u64) -> u64 {
+    // SAFETY: `frames_lock` is held for the duration of this read.
+    unsafe { *p }
+}
+
+fn main() {
+    let x = 7u64;
+    println!("{}", stale_name(&x));
+}

--- a/ui_off/unchecked_input_len.rs
+++ b/ui_off/unchecked_input_len.rs
@@ -1,0 +1,15 @@
+// The shape ui/unchecked_input_len.rs flags first; without
+// `unchecked-input-len-enabled` nothing is reported.
+
+fn use_before_check(len: usize, buf: &[u8]) -> Option<&[u8]> {
+    let (head, _) = buf.split_at(len);
+    if len > buf.len() {
+        return None;
+    }
+    Some(head)
+}
+
+fn main() {
+    let buf = [0u8; 8];
+    let _ = use_before_check(2, &buf);
+}


### PR DESCRIPTION
Two commits. The first pulls the code the lints had each grown their own copy of into mir_flow, hir_shapes, enum_facts and adt_facts; every fixture is byte identical and a run over a large real workspace reports the same findings before and after.

The second adds defaulted_failure, stale_across_reentry and unchecked_input_len, widens bypassed_validator to writes and zeroed values (pub_invariant_fields folds into it), and tightens about ten existing lints where that workspace showed them over-claiming. flag_cluster, stale_safety_comment and unchecked_input_len are now off unless dylint.toml turns them on. asymmetric_arm was tried and dropped.