### PR TITLE
ci: prebuilt dylint binaries, cached target and driver, macOS only on the weekly run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   schedule:
     # Weekly: surface clippy_utils / rustc_private drift within a week even
     # with no commits. Also the only run that includes macOS: the lints are
-    # platform independent, so PRs get the Linux job alone.
+    # platform independent and the mac runners are slower, so PRs get Linux.
     - cron: "0 6 * * 1"
 
 env:
@@ -21,21 +21,18 @@ jobs:
       # rust-toolchain pins the nightly; rustup resolves it on first cargo use.
       - run: rustup show
       # .cargo/config.toml names dylint-link as the linker and the ui tests
-      # need cargo-dylint. dylint publishes both as binaries; installing those
-      # takes seconds where compiling them took a minute and a half.
-      - name: install dylint
-        run: |
-          set -eu
-          base="https://github.com/trailofbits/dylint/releases/download/v$DYLINT_VERSION"
-          for tool in cargo-dylint dylint-link; do
-            name="$tool-x86_64-unknown-linux-gnu-v$DYLINT_VERSION"
-            curl -sSfLO "$base/$name.tar.gz"
-            curl -sSfLO "$base/$name.tar.gz.sha256"
-            sha256sum -c "$name.tar.gz.sha256"
-            tar xzf "$name.tar.gz"
-            install -m 755 "$name/$tool" "$HOME/.cargo/bin/$tool"
-          done
-          cargo dylint --version
+      # need cargo-dylint. Compiling them takes a minute and a half, so the
+      # binaries are cached per dylint version and rebuilt only on a bump;
+      # nothing prebuilt is downloaded.
+      - uses: actions/cache@v4
+        id: dylint
+        with:
+          path: |
+            ~/.cargo/bin/cargo-dylint
+            ~/.cargo/bin/dylint-link
+          key: dylint-${{ runner.os }}-${{ env.DYLINT_VERSION }}
+      - if: steps.dylint.outputs.cache-hit != 'true'
+        run: cargo install cargo-dylint dylint-link --locked --version "$DYLINT_VERSION"
       - uses: Swatinem/rust-cache@v2
       # The ui tests build a rustc driver for the pinned nightly into
       # ~/.dylint_drivers; it only changes when the toolchain or dylint does.
@@ -58,7 +55,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup show
-      - run: cargo install cargo-dylint dylint-link --locked --version "$DYLINT_VERSION"
+      - uses: actions/cache@v4
+        id: dylint
+        with:
+          path: |
+            ~/.cargo/bin/cargo-dylint
+            ~/.cargo/bin/dylint-link
+          key: dylint-${{ runner.os }}-${{ env.DYLINT_VERSION }}
+      - if: steps.dylint.outputs.cache-hit != 'true'
+        run: cargo install cargo-dylint dylint-link --locked --version "$DYLINT_VERSION"
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache@v4
+        with:
+          path: ~/.dylint_drivers
+          key: dylint-driver-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ env.DYLINT_VERSION }}
       - run: cargo test
       - run: cargo dylint --all
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,28 +6,60 @@ on:
   pull_request:
   schedule:
     # Weekly: surface clippy_utils / rustc_private drift within a week even
-    # with no commits.
+    # with no commits. Also the only run that includes macOS: the lints are
+    # platform independent, so PRs get the Linux job alone.
     - cron: "0 6 * * 1"
 
+env:
+  DYLINT_VERSION: 6.0.3
+
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+  linux:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       # rust-toolchain pins the nightly; rustup resolves it on first cargo use.
       - run: rustup show
-      # .cargo/config.toml names dylint-link as the linker, and the ui tests
-      # build a dylint driver, so both binaries have to exist on the runner.
-      - run: cargo install cargo-dylint dylint-link --locked
+      # .cargo/config.toml names dylint-link as the linker and the ui tests
+      # need cargo-dylint. dylint publishes both as binaries; installing those
+      # takes seconds where compiling them took a minute and a half.
+      - name: install dylint
+        run: |
+          set -eu
+          base="https://github.com/trailofbits/dylint/releases/download/v$DYLINT_VERSION"
+          for tool in cargo-dylint dylint-link; do
+            name="$tool-x86_64-unknown-linux-gnu-v$DYLINT_VERSION"
+            curl -sSfLO "$base/$name.tar.gz"
+            curl -sSfLO "$base/$name.tar.gz.sha256"
+            sha256sum -c "$name.tar.gz.sha256"
+            tar xzf "$name.tar.gz"
+            install -m 755 "$name/$tool" "$HOME/.cargo/bin/$tool"
+          done
+          cargo dylint --version
+      - uses: Swatinem/rust-cache@v2
+      # The ui tests build a rustc driver for the pinned nightly into
+      # ~/.dylint_drivers; it only changes when the toolchain or dylint does.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.dylint_drivers
+          key: dylint-driver-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ env.DYLINT_VERSION }}
       - run: cargo fmt --check
-      - run: cargo build
       - run: cargo test
       - run: cargo clippy --all-targets -- -D warnings
       # Mordant lints itself: the workspace metadata points the library at
       # its own source tree.
+      - run: cargo dylint --all
+        env:
+          DYLINT_RUSTFLAGS: -D warnings
+
+  macos:
+    if: github.event_name == 'schedule'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup show
+      - run: cargo install cargo-dylint dylint-link --locked --version "$DYLINT_VERSION"
+      - run: cargo test
       - run: cargo dylint --all
         env:
           DYLINT_RUSTFLAGS: -D warnings


### PR DESCRIPTION
The Linux job spent 98s compiling cargo-dylint and dylint-link and most of cargo test's 87s building the driver. The two binaries are now built once per dylint version and cached (nothing prebuilt is downloaded), target/ and ~/.dylint_drivers are cached, and the cargo build that cargo test repeats is gone. macOS gets the same caches but only runs on the weekly cron; the lints are not platform specific and those runners are slower.

This PR's run pays the one-off cost; the next push shows the cached time. If a branch rule pins the old job name, it is now linux.