### PR TITLE
Tidy the shared machinery so new lints have less to copy

### DIFF
--- a/src/adt_facts.rs
+++ b/src/adt_facts.rs
@@ -110,6 +110,28 @@ pub(crate) fn has_positional_fields(v: &VariantDef) -> bool {
         .any(|f| f.name.as_str().starts_with(|c: char| c.is_ascii_digit()))
 }
 
+/// Whether a configured list names `did`. An entry may be the full def path,
+/// a `::`-suffix of it, the bare item name, or `crate::Name` -- the last for
+/// a re-export whose def path runs through a private module
+/// (`bun_sys::error::Error` configured as `bun_sys::Error`).
+pub(crate) fn matches_config_path<'a>(
+    tcx: TyCtxt<'_>,
+    did: DefId,
+    mut entries: impl Iterator<Item = &'a str>,
+) -> bool {
+    let path = tcx.def_path_str(did);
+    let name = tcx.item_name(did);
+    let krate = tcx.crate_name(did.krate);
+    entries.any(|e| {
+        path == e
+            || path.ends_with(&format!("::{e}"))
+            || match e.rsplit_once("::") {
+                None => name.as_str() == e,
+                Some((k, n)) => !k.contains("::") && krate.as_str() == k && name.as_str() == n,
+            }
+    })
+}
+
 /// `Result<_, E>` -> `E`; anything else, `Option` included, is None.
 pub(crate) fn result_err_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
     let ty::Adt(adt, args) = ty.kind() else {

--- a/src/adt_facts.rs
+++ b/src/adt_facts.rs
@@ -1,13 +1,11 @@
 //! Shared facts about the structs and enums a crate defines: which struct a
-//! type or an impl block is about, what a field's declared type is, what a
-//! struct literal constructs, and the shape questions (explicit `repr`,
-//! positional fields, `Result`'s error type) that several lints ask of the
-//! same definition. Every filter that makes a lint fire or not -- privacy,
-//! `is_struct`, the tail of a literal, a minimum field count -- stays in the
-//! lint, so this module only ever answers, never decides.
+//! type or an impl block is about, what a field's declared type is, and the
+//! shape questions (explicit `repr`, positional fields, `Result`'s error type)
+//! that several lints ask of the same definition. Every filter that makes a
+//! lint fire or not -- privacy, `is_struct`, a minimum field count -- stays in
+//! the lint, so this module only ever answers, never decides.
 
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprField, ExprKind, StructTailExpr};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, AdtDef, FieldDef, Ty, TyCtxt, VariantDef};
 use rustc_span::{Symbol, sym};
@@ -59,36 +57,6 @@ pub(crate) fn impl_self_adt<'tcx>(cx: &LateContext<'tcx>, impl_did: DefId) -> Op
         .instantiate_identity()
         .skip_normalization()
         .ty_adt_def()
-}
-
-/// A `Name { .. }` expression, resolved: the ADT it builds, the variant of it
-/// (the only one, for a struct or union), the fields it spells out, and its
-/// `..base` tail if any.
-pub(crate) struct StructLiteral<'tcx> {
-    pub(crate) adt: AdtDef<'tcx>,
-    pub(crate) variant: &'tcx VariantDef,
-    pub(crate) fields: &'tcx [ExprField<'tcx>],
-    pub(crate) tail: StructTailExpr<'tcx>,
-}
-
-/// Resolve a struct expression; anything else, including a tuple-struct call,
-/// is None. The type comes from typeck rather than the path, so an alias or
-/// `Self` resolves to what it names.
-pub(crate) fn struct_literal<'tcx>(
-    cx: &LateContext<'tcx>,
-    e: &'tcx Expr<'tcx>,
-) -> Option<StructLiteral<'tcx>> {
-    let ExprKind::Struct(qpath, fields, tail) = e.kind else {
-        return None;
-    };
-    let adt = cx.typeck_results().expr_ty(e).ty_adt_def()?;
-    let variant = adt.variant_of_res(cx.qpath_res(qpath, e.hir_id));
-    Some(StructLiteral {
-        adt,
-        variant,
-        fields,
-        tail,
-    })
 }
 
 pub(crate) fn is_option_ty(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {

--- a/src/asymmetric_guard.rs
+++ b/src/asymmetric_guard.rs
@@ -11,7 +11,9 @@ use rustc_span::{Span, Symbol};
 
 use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit;
-use crate::hir_shapes::{Callee, callee_of, ends_in_return, is_self_path, peel_not, self_field};
+use crate::hir_shapes::{
+    Callee, callee_of, ends_in_return, is_self_path, peel_not, self_field, stmt_expr,
+};
 
 rustc_session::declare_lint! {
     /// Flags a guarded call whose guard cannot be sound: `self.can_x()` gates
@@ -250,23 +252,11 @@ impl<'tcx> LateLintPass<'tcx> for AsymmetricGuard {
                 continue;
             }
             if negated && ends_in_return(then) {
-                for later in &block.stmts[i + 1..] {
-                    match later.kind {
-                        StmtKind::Expr(le) | StmtKind::Semi(le) => {
-                            self.collect_actions(cx, le, guard, adt);
-                        }
-                        // The real-world shape binds the result:
-                        // `let connections = self.detach_fds(&victim);`.
-                        StmtKind::Let(l) => {
-                            if let Some(init) = l.init {
-                                self.collect_actions(cx, init, guard, adt);
-                            }
-                        }
-                        StmtKind::Item(_) => {}
-                    }
-                }
-                if let Some(tail) = block.expr {
-                    self.collect_actions(cx, tail, guard, adt);
+                // `let` initializers count: the real-world shape binds the
+                // result, `let connections = self.detach_fds(&victim);`.
+                let later = block.stmts[i + 1..].iter().filter_map(stmt_expr);
+                for e in later.chain(block.expr) {
+                    self.collect_actions(cx, e, guard, adt);
                 }
             } else if !negated {
                 // `if self.can_x() { self.y() }` — the then-branch is gated.

--- a/src/asymmetric_guard.rs
+++ b/src/asymmetric_guard.rs
@@ -69,12 +69,6 @@ pub struct AsymmetricGuard {
 
 rustc_session::impl_lint_pass!(AsymmetricGuard => [ASYMMETRIC_GUARD]);
 
-impl AsymmetricGuard {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// The inherent method a `self.m(..)` call resolves to, with its self type,
 /// when that type is a crate-local ADT.
 fn self_method_call<'tcx>(cx: &LateContext<'tcx>, e: &Expr<'tcx>) -> Option<(DefId, DefId)> {

--- a/src/bypassed_validator.rs
+++ b/src/bypassed_validator.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit_with_note;
 use crate::ctor_flow::{self, FieldCheck};
-use crate::hir_shapes::assigned_adt_field;
+use crate::hir_shapes::{assigned_adt_field, callee_of};
 use clippy_utils::ty::ty_from_hir_ty;
 use rustc_abi::FieldIdx;
-use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
+use rustc_hir::def::{CtorKind, CtorOf, DefKind};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, FnRetTy, HirId, ImplItem, ImplItemKind, ItemKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
@@ -150,33 +150,6 @@ fn is_types_own_code(cx: &LateContext<'_>, at: HirId, struct_did: DefId) -> bool
     false
 }
 
-/// What a call expression, path or method, invokes.
-fn callee(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
-    match expr.kind {
-        ExprKind::Call(f, _) => {
-            let ExprKind::Path(ref qpath) = f.kind else {
-                return None;
-            };
-            cx.qpath_res(qpath, f.hir_id).opt_def_id()
-        }
-        ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
-        _ => None,
-    }
-}
-
-fn is_tuple_ctor_call(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    let ExprKind::Call(f, _) = expr.kind else {
-        return false;
-    };
-    let ExprKind::Path(ref qpath) = f.kind else {
-        return false;
-    };
-    matches!(
-        cx.qpath_res(qpath, f.hir_id),
-        Res::Def(DefKind::Ctor(CtorOf::Struct, CtorKind::Fn), _)
-    )
-}
-
 /// The name a finding gives a callee that produces a value out of nothing.
 fn conjurer(cx: &LateContext<'_>, callee: DefId) -> Option<&'static str> {
     let name = cx.tcx.get_diagnostic_name(callee)?;
@@ -280,12 +253,18 @@ impl<'tcx> LateLintPass<'tcx> for BypassedValidator {
                 let Some(adt) = results.expr_ty(expr).ty_adt_def() else {
                     return;
                 };
+                let Some(def) = callee_of(cx, expr).map(|c| c.def()) else {
+                    return;
+                };
                 // `S(x)` has no callee body: the call is the literal.
-                if is_tuple_ctor_call(cx, expr) {
+                if matches!(
+                    cx.tcx.def_kind(def),
+                    DefKind::Ctor(CtorOf::Struct, CtorKind::Fn)
+                ) {
                     self.note_site(cx, expr, adt, SiteKind::Literal(Literal::All));
                     return;
                 }
-                let Some(what) = callee(cx, expr).and_then(|c| conjurer(cx, c)) else {
+                let Some(what) = conjurer(cx, def) else {
                     return;
                 };
                 // `transmute::<S<'a>, S<'static>>(s)` re-types a value that

--- a/src/bypassed_validator.rs
+++ b/src/bypassed_validator.rs
@@ -3,13 +3,12 @@ use std::collections::HashMap;
 use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit_with_note;
 use crate::ctor_flow::{self, FieldCheck};
+use crate::hir_shapes::assigned_adt_field;
 use clippy_utils::ty::ty_from_hir_ty;
 use rustc_abi::FieldIdx;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{
-    Expr, ExprKind, FnRetTy, HirId, ImplItem, ImplItemKind, ItemKind, StructTailExpr, UnOp,
-};
+use rustc_hir::{Expr, ExprKind, FnRetTy, HirId, ImplItem, ImplItemKind, ItemKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::{Span, Symbol, sym};
@@ -269,19 +268,7 @@ impl<'tcx> LateLintPass<'tcx> for BypassedValidator {
                 self.note_site(cx, expr, adt, SiteKind::Literal(literal));
             }
             ExprKind::Assign(place, ..) | ExprKind::AssignOp(_, place, _) => {
-                // `*s.f = ..` and `(*b).f = ..` both write `f`; the base's
-                // type after auto-deref says whose `f`, so a write through a
-                // `Box` or a guard counts.
-                let mut place = place;
-                while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) =
-                    place.kind
-                {
-                    place = inner;
-                }
-                let ExprKind::Field(base, _) = place.kind else {
-                    return;
-                };
-                let Some(adt) = results.expr_ty_adjusted(base).peel_refs().ty_adt_def() else {
+                let Some((adt, _, place)) = assigned_adt_field(cx, place) else {
                     return;
                 };
                 let Some(field) = results.opt_field_index(place.hir_id) else {

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -7,9 +7,9 @@
 //! for each name.
 
 use std::cell::OnceCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
-use rustc_hir::def_id::{DefId, DefIndex, LocalDefId};
+use rustc_hir::def_id::{DefId, DefIndex};
 use rustc_lint::LateContext;
 use rustc_metadata::creader::CStore;
 use rustc_span::{BytePos, Span};
@@ -135,20 +135,20 @@ pub(crate) fn word_in(haystack: &str, ident: &str) -> bool {
 /// locally never needs it, so it is built on the first lookup that misses
 /// locally.
 pub(crate) struct DefNames {
-    local: HashMap<String, Option<LocalDefId>>,
+    local: HashSet<String>,
     upstream: OnceCell<HashSet<String>>,
 }
 
 impl DefNames {
     pub(crate) fn collect(cx: &LateContext<'_>) -> Self {
         Self {
-            local: crate_def_index(cx),
+            local: crate_def_names(cx),
             upstream: OnceCell::new(),
         }
     }
 
     pub(crate) fn contains(&self, cx: &LateContext<'_>, ident: &str) -> bool {
-        self.local.contains_key(ident)
+        self.local.contains(ident)
             || self
                 .upstream
                 .get_or_init(|| upstream_def_names(cx))
@@ -185,23 +185,12 @@ fn upstream_def_names(cx: &LateContext<'_>) -> HashSet<String> {
 }
 
 /// Every name this crate defines: each item, and every variant and field of
-/// each local ADT, since a claim usually names the field it guards. A name
-/// with exactly one owning item maps to that item; a name several defs share,
-/// and every variant and field, maps to `None`. [`DefNames::contains`] only
-/// asks whether the name is present.
-fn crate_def_index(cx: &LateContext<'_>) -> HashMap<String, Option<LocalDefId>> {
-    let mut index: HashMap<String, Option<LocalDefId>> = HashMap::new();
-    let mut insert = |name: String, def: Option<LocalDefId>| match index.entry(name) {
-        std::collections::hash_map::Entry::Vacant(e) => {
-            e.insert(def);
-        }
-        std::collections::hash_map::Entry::Occupied(mut e) => {
-            e.insert(None);
-        }
-    };
+/// each local ADT, since a claim usually names the field it guards.
+fn crate_def_names(cx: &LateContext<'_>) -> HashSet<String> {
+    let mut names = HashSet::new();
     for def_id in cx.tcx.hir_crate_items(()).definitions() {
         if let Some(name) = cx.tcx.opt_item_name(def_id.to_def_id()) {
-            insert(name.to_string(), Some(def_id));
+            names.insert(name.to_string());
         }
         if let rustc_hir::def::DefKind::Struct
         | rustc_hir::def::DefKind::Enum
@@ -209,12 +198,10 @@ fn crate_def_index(cx: &LateContext<'_>) -> HashMap<String, Option<LocalDefId>> 
         {
             let adt = cx.tcx.adt_def(def_id);
             for v in adt.variants() {
-                insert(v.name.to_string(), None);
-                for f in &v.fields {
-                    insert(f.name.to_string(), None);
-                }
+                names.insert(v.name.to_string());
+                names.extend(v.fields.iter().map(|f| f.name.to_string()));
             }
         }
     }
-    index
+    names
 }

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -51,7 +51,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::{Span, sym};
 
-use crate::adt_facts::result_err_ty;
+use crate::adt_facts::{matches_config_path, result_err_ty};
 use crate::mir_flow::{
     ANY_ELEM, Atom, Exactness, build_cfg, control_deps, direct_control_deps, is_prefix, mir_for,
     operand_place, place_info, post_dominators, switch_operand_atoms,
@@ -228,24 +228,11 @@ fn is_resource_error(tcx: TyCtxt<'_>, ty: Ty<'_>, extra: &[String]) -> bool {
     let ty::Adt(adt, _) = ty.peel_refs().kind() else {
         return false;
     };
-    let path = tcx.def_path_str(adt.did());
-    let name = tcx.item_name(adt.did());
-    let krate = tcx.crate_name(adt.did().krate);
-    RESOURCE_ERRORS
+    let entries = RESOURCE_ERRORS
         .iter()
         .copied()
-        .chain(extra.iter().map(String::as_str))
-        .any(|e| {
-            // Full def path, bare name, or `crate::Name` for a re-export whose
-            // def path runs through a private module (`bun_sys::error::Error`
-            // configured as `bun_sys::Error`).
-            path == e
-                || path.ends_with(&format!("::{e}"))
-                || match e.rsplit_once("::") {
-                    None => name.as_str() == e,
-                    Some((k, n)) => !k.contains("::") && krate.as_str() == k && name.as_str() == n,
-                }
-        })
+        .chain(extra.iter().map(String::as_str));
+    matches_config_path(tcx, adt.did(), entries)
 }
 
 /// Trait methods whose result is the receiver's value seen differently.
@@ -347,20 +334,14 @@ fn gather<'tcx>(
                 | Rvalue::Cast(_, op, _)
                 | Rvalue::UnaryOp(_, op)
                 | Rvalue::WrapUnsafeBinder(op, _) => reads_of_operand(op, false, &mut reads),
-                Rvalue::Ref(_, kind, place) => {
-                    if matches!(kind, BorrowKind::Mut { .. }) && dest.projection.is_empty() {
-                        mut_ref_to.insert(dest.local, place_info(*place).atom);
-                    }
-                    reads_of_place(*place, true, &mut reads);
-                }
-                Rvalue::RawPtr(kind, place) => {
-                    if matches!(kind, RawPtrKind::Mut) && dest.projection.is_empty() {
-                        mut_ref_to.insert(dest.local, place_info(*place).atom);
-                    }
-                    reads_of_place(*place, true, &mut reads);
-                }
-                Rvalue::Reborrow(_, m, place) => {
-                    if m.is_mut() && dest.projection.is_empty() {
+                Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) | Rvalue::Reborrow(_, _, place) => {
+                    let is_mut = matches!(
+                        rvalue,
+                        Rvalue::Ref(_, BorrowKind::Mut { .. }, _)
+                            | Rvalue::RawPtr(RawPtrKind::Mut, _)
+                            | Rvalue::Reborrow(_, Mutability::Mut, _)
+                    );
+                    if is_mut && dest.projection.is_empty() {
                         mut_ref_to.insert(dest.local, place_info(*place).atom);
                     }
                     reads_of_place(*place, true, &mut reads);
@@ -591,43 +572,16 @@ fn closure_over(start: Local, mut succ: impl FnMut(Local) -> Vec<Local>) -> Hash
 /// arithmetically combined) in a root. Returns the slice and the atoms whose
 /// variant payload was consumed on the way (produced, not inspected).
 fn storage_slice(defs: &IndexVec<Local, Vec<Def>>, roots: &[Atom]) -> (Vec<Atom>, Vec<Atom>) {
-    let mut seen: HashSet<Atom> = HashSet::new();
     let mut produced: Vec<Atom> = Vec::new();
-    let mut q: VecDeque<Atom> = roots.iter().cloned().collect();
-    while let Some(at) = q.pop_front() {
-        if !seen.insert(at.clone()) {
-            continue;
+    let slice = walk_slice(defs, roots, |_, r| match r {
+        Read::Derived(a) => Some(a.clone()),
+        Read::Payload(a) => {
+            produced.push(a.clone());
+            None
         }
-        for def in &defs[at.local] {
-            let (below, rem): (bool, &[u32]) = if is_prefix(&def.dest, &at.path) {
-                (true, &at.path[def.dest.len()..])
-            } else if is_prefix(&at.path, &def.dest) {
-                (false, &[])
-            } else {
-                continue;
-            };
-            for r in &def.reads {
-                match r {
-                    Read::Same(a) => q.push_back(if below { a.extended(rem) } else { a.clone() }),
-                    Read::Derived(a) => q.push_back(a.clone()),
-                    Read::AggField(i, a) => {
-                        if !below || rem.is_empty() {
-                            q.push_back(a.clone());
-                        } else if rem[0] == *i {
-                            q.push_back(a.extended(&rem[1..]));
-                        }
-                    }
-                    Read::Payload(a) => produced.push(a.clone()),
-                    Read::Discr(_)
-                    | Read::Index(_)
-                    | Read::CallArg(_)
-                    | Read::CallArgMut
-                    | Read::ViaMut(_) => {}
-                }
-            }
-        }
-    }
-    (seen.into_iter().collect(), produced)
+        _ => None,
+    });
+    (slice, produced)
 }
 
 /// Decision slice from a branch operand. `opaque` holds atoms whose defining
@@ -636,13 +590,27 @@ fn storage_slice(defs: &IndexVec<Local, Vec<Def>>, roots: &[Atom]) -> (Vec<Atom>
 /// method failing on a stored value implicates that value, not everything
 /// its constructor was handed).
 fn decision_slice(defs: &IndexVec<Local, Vec<Def>>, roots: &[Atom], opaque: &[Atom]) -> Vec<Atom> {
+    walk_slice(defs, roots, |at, r| match r {
+        Read::Derived(a) | Read::Payload(a) | Read::Discr(a) | Read::ViaMut(a) => Some(a.clone()),
+        Read::Index(l) => Some(Atom::whole(*l)),
+        Read::CallArg(a) => (!opaque.iter().any(|p| p.overlaps(at))).then(|| a.clone()),
+        Read::Same(_) | Read::AggField(..) | Read::CallArgMut => None,
+    })
+}
+
+/// Worklist closure of `roots` over `defs`. `Same` and `AggField` compose
+/// paths here; any other read is followed to whatever atom `other` names.
+fn walk_slice(
+    defs: &IndexVec<Local, Vec<Def>>,
+    roots: &[Atom],
+    mut other: impl FnMut(&Atom, &Read) -> Option<Atom>,
+) -> Vec<Atom> {
     let mut seen: HashSet<Atom> = HashSet::new();
     let mut q: VecDeque<Atom> = roots.iter().cloned().collect();
     while let Some(at) = q.pop_front() {
         if !seen.insert(at.clone()) {
             continue;
         }
-        let is_produced = opaque.iter().any(|p| p.overlaps(&at));
         for def in &defs[at.local] {
             let (below, rem): (bool, &[u32]) = if is_prefix(&def.dest, &at.path) {
                 (true, &at.path[def.dest.len()..])
@@ -652,26 +620,14 @@ fn decision_slice(defs: &IndexVec<Local, Vec<Def>>, roots: &[Atom], opaque: &[At
                 continue;
             };
             for r in &def.reads {
-                match r {
-                    Read::Same(a) => q.push_back(if below { a.extended(rem) } else { a.clone() }),
-                    Read::AggField(i, a) => {
-                        if !below || rem.is_empty() {
-                            q.push_back(a.clone());
-                        } else if rem[0] == *i {
-                            q.push_back(a.extended(&rem[1..]));
-                        }
+                q.extend(match r {
+                    Read::Same(a) => Some(if below { a.extended(rem) } else { a.clone() }),
+                    Read::AggField(i, a) if below && !rem.is_empty() => {
+                        (rem[0] == *i).then(|| a.extended(&rem[1..]))
                     }
-                    Read::Derived(a) | Read::Payload(a) | Read::Discr(a) | Read::ViaMut(a) => {
-                        q.push_back(a.clone())
-                    }
-                    Read::Index(l) => q.push_back(Atom::whole(*l)),
-                    Read::CallArg(a) => {
-                        if !is_produced {
-                            q.push_back(a.clone());
-                        }
-                    }
-                    Read::CallArgMut => {}
-                }
+                    Read::AggField(_, a) => Some(a.clone()),
+                    _ => other(&at, r),
+                });
             }
         }
     }

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -290,12 +290,10 @@ fn gather<'tcx>(
     let mut payload_alias: IndexVec<Local, Vec<Local>> = IndexVec::from_elem_n(Vec::new(), n);
     let mut mut_ref_to: HashMap<Local, Atom> = HashMap::new();
     let mut local_calls: HashMap<Local, Vec<LocalCall>> = HashMap::new();
-    // Failure exits (Err/None, non-resource) and `Self` payload roots, each
-    // pending on whether their local reaches the return.
-    let mut pending_failures: Vec<(Local, BasicBlock)> = Vec::new();
+    // Failure exits (Err/None with the error type) and `Self` payload roots,
+    // each pending on whether their local reaches the return.
+    let mut pending_failures: Vec<(Local, (BasicBlock, Option<Ty<'tcx>>))> = Vec::new();
     let mut pending_roots: Vec<(Local, Atom)> = Vec::new();
-    let is_resource =
-        |ty: Option<Ty<'tcx>>| ty.is_some_and(|t| is_resource_error(tcx, t, extra_resource_errors));
     let mut closures = Vec::new();
 
     for (bb, data) in body.basic_blocks.iter_enumerated() {
@@ -368,9 +366,8 @@ fn gather<'tcx>(
                             let first = ops.iter().next();
                             let name = tcx.adt_def(*did).variant(*vidx).name;
                             if name == sym::Err || name == sym::None {
-                                if !is_resource(first.map(|o| o.ty(&body.local_decls, tcx))) {
-                                    pending_failures.push((dest.local, bb));
-                                }
+                                let err = first.map(|o| o.ty(&body.local_decls, tcx));
+                                pending_failures.push((dest.local, (bb, err)));
                             } else if let Some(p) = first.and_then(Operand::place) {
                                 pending_roots.push((dest.local, place_info(p).atom));
                             }
@@ -464,9 +461,8 @@ fn gather<'tcx>(
                         .get(1)
                         .and_then(|g| g.as_type())
                         .or_else(|| args.first().map(|a| a.node.ty(&body.local_decls, tcx)));
-                    if !is_resource(residual.and_then(|r| result_err_ty(tcx, r))) {
-                        pending_failures.push((destination.local, bb));
-                    }
+                    let err = residual.and_then(|r| result_err_ty(tcx, r));
+                    pending_failures.push((destination.local, (bb, err)));
                 } else if tcx.is_lang_item(callee, LangItem::TryTraitBranch) {
                     if let Some(Some(r)) = arg_atoms.first()
                         && r.path.is_empty()
@@ -494,7 +490,11 @@ fn gather<'tcx>(
 
     let returned = closure_over(RETURN_PLACE, |l| alias[l].clone());
 
-    let mut failure_blocks = reaching(pending_failures, &returned);
+    let mut failure_blocks: Vec<BasicBlock> = reaching(pending_failures, &returned)
+        .into_iter()
+        .filter(|(_, err)| !err.is_some_and(|t| is_resource_error(tcx, t, extra_resource_errors)))
+        .map(|(bb, _)| bb)
+        .collect();
     let mut self_roots = reaching(pending_roots, &returned);
     // A body returning bare `Self` (a helper, a closure): the return place
     // itself is the self value.

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -39,7 +39,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use rustc_abi::{FieldIdx, VariantIdx};
+use rustc_abi::FieldIdx;
 use rustc_hir::LangItem;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
@@ -198,17 +198,6 @@ struct Def {
 /// A call to a crate-local fn: callee and argument atoms by position.
 type LocalCall = (LocalDefId, Vec<Option<Atom>>);
 
-/// A `Result`/`Option` aggregate assigned to a whole local: which variant,
-/// its first operand, and that operand's type (the error, for `Err`).
-struct WrapperAggregate<'tcx> {
-    dest: Local,
-    adt: DefId,
-    variant: VariantIdx,
-    operand: Option<Atom>,
-    operand_ty: Option<Ty<'tcx>>,
-    block: BasicBlock,
-}
-
 struct Facts {
     defs: IndexVec<Local, Vec<Def>>,
     /// Whole-local moves (`_a = move _b`) and `Try::branch` look-through.
@@ -300,9 +289,13 @@ fn gather<'tcx>(
     let mut alias: IndexVec<Local, Vec<Local>> = IndexVec::from_elem_n(Vec::new(), n);
     let mut payload_alias: IndexVec<Local, Vec<Local>> = IndexVec::from_elem_n(Vec::new(), n);
     let mut mut_ref_to: HashMap<Local, Atom> = HashMap::new();
-    let mut wrappers: Vec<WrapperAggregate<'tcx>> = Vec::new();
     let mut local_calls: HashMap<Local, Vec<LocalCall>> = HashMap::new();
-    let mut residual_calls: Vec<(Local, Option<Ty<'tcx>>, BasicBlock)> = Vec::new();
+    // Failure exits (Err/None, non-resource) and `Self` payload roots, each
+    // pending on whether their local reaches the return.
+    let mut pending_failures: Vec<(Local, BasicBlock)> = Vec::new();
+    let mut pending_roots: Vec<(Local, Atom)> = Vec::new();
+    let is_resource =
+        |ty: Option<Ty<'tcx>>| ty.is_some_and(|t| is_resource_error(tcx, t, extra_resource_errors));
     let mut closures = Vec::new();
 
     for (bb, data) in body.basic_blocks.iter_enumerated() {
@@ -373,14 +366,14 @@ fn gather<'tcx>(
                                     || tcx.is_diagnostic_item(sym::Option, *did)) =>
                         {
                             let first = ops.iter().next();
-                            wrappers.push(WrapperAggregate {
-                                dest: dest.local,
-                                adt: *did,
-                                variant: *vidx,
-                                operand: first.and_then(Operand::place).map(|p| place_info(p).atom),
-                                operand_ty: first.map(|o| o.ty(&body.local_decls, tcx)),
-                                block: bb,
-                            });
+                            let name = tcx.adt_def(*did).variant(*vidx).name;
+                            if name == sym::Err || name == sym::None {
+                                if !is_resource(first.map(|o| o.ty(&body.local_decls, tcx))) {
+                                    pending_failures.push((dest.local, bb));
+                                }
+                            } else if let Some(p) = first.and_then(Operand::place) {
+                                pending_roots.push((dest.local, place_info(p).atom));
+                            }
                         }
                         AggregateKind::Closure(cdid, args) => {
                             let out = args.as_closure().sig().output().skip_binder();
@@ -471,11 +464,9 @@ fn gather<'tcx>(
                         .get(1)
                         .and_then(|g| g.as_type())
                         .or_else(|| args.first().map(|a| a.node.ty(&body.local_decls, tcx)));
-                    residual_calls.push((
-                        destination.local,
-                        residual.and_then(|r| result_err_ty(tcx, r)),
-                        bb,
-                    ));
+                    if !is_resource(residual.and_then(|r| result_err_ty(tcx, r))) {
+                        pending_failures.push((destination.local, bb));
+                    }
                 } else if tcx.is_lang_item(callee, LangItem::TryTraitBranch) {
                     if let Some(Some(r)) = arg_atoms.first()
                         && r.path.is_empty()
@@ -503,31 +494,8 @@ fn gather<'tcx>(
 
     let returned = closure_over(RETURN_PLACE, |l| alias[l].clone());
 
-    let mut failure_blocks = Vec::new();
-    let mut self_roots = Vec::new();
-    for w in &wrappers {
-        if !returned.contains(&w.dest) {
-            continue;
-        }
-        let name = tcx.adt_def(w.adt).variant(w.variant).name;
-        if name == sym::Err || name == sym::None {
-            let resource = name == sym::Err
-                && w.operand_ty
-                    .is_some_and(|t| is_resource_error(tcx, t, extra_resource_errors));
-            if !resource {
-                failure_blocks.push(w.block);
-            }
-        } else if let Some(a) = &w.operand {
-            self_roots.push(a.clone());
-        }
-    }
-    for (dest, err, bb) in &residual_calls {
-        if returned.contains(dest)
-            && !err.is_some_and(|t| is_resource_error(tcx, t, extra_resource_errors))
-        {
-            failure_blocks.push(*bb);
-        }
-    }
+    let mut failure_blocks = reaching(pending_failures, &returned);
+    let mut self_roots = reaching(pending_roots, &returned);
     // A body returning bare `Self` (a helper, a closure): the return place
     // itself is the self value.
     if self_did.is_some_and(|s| is_self_ty(body.local_decls[RETURN_PLACE].ty, s)) {
@@ -545,6 +513,12 @@ fn gather<'tcx>(
         failure_blocks,
         closures,
     }
+}
+
+/// The items whose local reaches the return.
+fn reaching<T>(pending: Vec<(Local, T)>, returned: &HashSet<Local>) -> Vec<T> {
+    let kept = pending.into_iter().filter(|(l, _)| returned.contains(l));
+    kept.map(|(_, t)| t).collect()
 }
 
 fn closure_over(start: Local, mut succ: impl FnMut(Local) -> Vec<Local>) -> HashSet<Local> {

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -575,14 +575,19 @@ fn closure_over(start: Local, mut succ: impl FnMut(Local) -> Vec<Local>) -> Hash
 /// variant payload was consumed on the way (produced, not inspected).
 fn storage_slice(defs: &IndexVec<Local, Vec<Def>>, roots: &[Atom]) -> (Vec<Atom>, Vec<Atom>) {
     let mut produced: Vec<Atom> = Vec::new();
-    let slice = walk_slice(defs, roots, |_, r| match r {
-        Read::Derived(a) => Some(a.clone()),
-        Read::Payload(a) => {
-            produced.push(a.clone());
-            None
-        }
-        _ => None,
-    });
+    let slice = walk_slice(
+        defs,
+        roots,
+        |_| (),
+        |(), r| match r {
+            Read::Derived(a) => Some(a.clone()),
+            Read::Payload(a) => {
+                produced.push(a.clone());
+                None
+            }
+            _ => None,
+        },
+    );
     (slice, produced)
 }
 
@@ -592,20 +597,29 @@ fn storage_slice(defs: &IndexVec<Local, Vec<Def>>, roots: &[Atom]) -> (Vec<Atom>
 /// method failing on a stored value implicates that value, not everything
 /// its constructor was handed).
 fn decision_slice(defs: &IndexVec<Local, Vec<Def>>, roots: &[Atom], opaque: &[Atom]) -> Vec<Atom> {
-    walk_slice(defs, roots, |at, r| match r {
-        Read::Derived(a) | Read::Payload(a) | Read::Discr(a) | Read::ViaMut(a) => Some(a.clone()),
-        Read::Index(l) => Some(Atom::whole(*l)),
-        Read::CallArg(a) => (!opaque.iter().any(|p| p.overlaps(at))).then(|| a.clone()),
-        Read::Same(_) | Read::AggField(..) | Read::CallArgMut => None,
-    })
+    walk_slice(
+        defs,
+        roots,
+        |at| !opaque.iter().any(|p| p.overlaps(at)),
+        |&enter_calls, r| match r {
+            Read::Derived(a) | Read::Payload(a) | Read::Discr(a) | Read::ViaMut(a) => {
+                Some(a.clone())
+            }
+            Read::Index(l) => Some(Atom::whole(*l)),
+            Read::CallArg(a) => enter_calls.then(|| a.clone()),
+            Read::Same(_) | Read::AggField(..) | Read::CallArgMut => None,
+        },
+    )
 }
 
 /// Worklist closure of `roots` over `defs`. `Same` and `AggField` compose
-/// paths here; any other read is followed to whatever atom `other` names.
-fn walk_slice(
+/// paths here; any other read is followed to whatever atom `other` names,
+/// given the per-atom state `enter` computed once when the atom was dequeued.
+fn walk_slice<S>(
     defs: &IndexVec<Local, Vec<Def>>,
     roots: &[Atom],
-    mut other: impl FnMut(&Atom, &Read) -> Option<Atom>,
+    mut enter: impl FnMut(&Atom) -> S,
+    mut other: impl FnMut(&S, &Read) -> Option<Atom>,
 ) -> Vec<Atom> {
     let mut seen: HashSet<Atom> = HashSet::new();
     let mut q: VecDeque<Atom> = roots.iter().cloned().collect();
@@ -613,6 +627,7 @@ fn walk_slice(
         if !seen.insert(at.clone()) {
             continue;
         }
+        let s = enter(&at);
         for def in &defs[at.local] {
             let (below, rem): (bool, &[u32]) = if is_prefix(&def.dest, &at.path) {
                 (true, &at.path[def.dest.len()..])
@@ -628,7 +643,7 @@ fn walk_slice(
                         (rem[0] == *i).then(|| a.extended(&rem[1..]))
                     }
                     Read::AggField(_, a) => Some(a.clone()),
-                    _ => other(&at, r),
+                    _ => other(&s, r),
                 });
             }
         }

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -53,8 +53,8 @@ use rustc_span::{Span, sym};
 
 use crate::adt_facts::{matches_config_path, result_err_ty};
 use crate::mir_flow::{
-    ANY_ELEM, Atom, Exactness, build_cfg, control_deps, direct_control_deps, is_prefix, mir_for,
-    operand_place, place_info, post_dominators, switch_operand_atoms,
+    ANY_ELEM, Atom, Exactness, build_cfg, control_deps, direct_control_deps, mir_for, place_info,
+    post_dominators, switch_operand_atoms,
 };
 
 /// Error types that report the environment refusing, not the value being
@@ -281,7 +281,7 @@ fn reads_of_place(place: Place<'_>, same: bool, out: &mut Vec<Read>) {
 }
 
 fn reads_of_operand(op: &Operand<'_>, same: bool, out: &mut Vec<Read>) {
-    if let Some(p) = operand_place(op) {
+    if let Some(p) = op.place() {
         reads_of_place(p, same, out);
     }
 }
@@ -319,7 +319,7 @@ fn gather<'tcx>(
             match rvalue {
                 Rvalue::Use(op, _) => {
                     if dest.projection.is_empty()
-                        && let Some(p) = operand_place(op)
+                        && let Some(p) = op.place()
                     {
                         let pinfo = place_info(p);
                         if p.projection.is_empty() {
@@ -362,7 +362,7 @@ fn gather<'tcx>(
                 Rvalue::Aggregate(kind, ops) => {
                     let kind = &**kind;
                     for (i, op) in ops.iter().enumerate() {
-                        if let Some(p) = operand_place(op) {
+                        if let Some(p) = op.place() {
                             let info = place_info(p);
                             reads.extend(info.index_locals.iter().map(|l| Read::Index(*l)));
                             match info.exactness {
@@ -387,7 +387,7 @@ fn gather<'tcx>(
                                 dest: dest.local,
                                 adt: *did,
                                 variant: *vidx,
-                                operand: first.and_then(operand_place).map(|p| place_info(p).atom),
+                                operand: first.and_then(Operand::place).map(|p| place_info(p).atom),
                                 operand_ty: first.map(|o| o.ty(&body.local_decls, tcx)),
                                 block: bb,
                             });
@@ -423,7 +423,7 @@ fn gather<'tcx>(
         {
             let arg_atoms: Vec<Option<Atom>> = args
                 .iter()
-                .map(|a| operand_place(&a.node).map(|p| place_info(p).atom))
+                .map(|a| a.node.place().map(|p| place_info(p).atom))
                 .collect();
             // A call handed a `&mut` is an operation on that argument (insert,
             // write, advance); its other arguments are the data operated
@@ -629,9 +629,9 @@ fn walk_slice<S>(
         }
         let s = enter(&at);
         for def in &defs[at.local] {
-            let (below, rem): (bool, &[u32]) = if is_prefix(&def.dest, &at.path) {
+            let (below, rem): (bool, &[u32]) = if at.path.starts_with(&def.dest) {
                 (true, &at.path[def.dest.len()..])
-            } else if is_prefix(&at.path, &def.dest) {
+            } else if def.dest.starts_with(&at.path) {
                 (false, &[])
             } else {
                 continue;
@@ -678,7 +678,7 @@ fn decides_on_resource<'tcx>(
     let TerminatorKind::SwitchInt { discr, .. } = &body.basic_blocks[bb].terminator().kind else {
         return false;
     };
-    let Some(p) = operand_place(discr) else {
+    let Some(p) = discr.place() else {
         return false;
     };
     // `_d = discriminant(_r); switchInt(move _d)`: look one def back.

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -607,7 +607,13 @@ fn walk_slice<S>(
                         (rem[0] == *i).then(|| a.extended(&rem[1..]))
                     }
                     Read::AggField(_, a) => Some(a.clone()),
-                    _ => other(&s, r),
+                    Read::Derived(_)
+                    | Read::Payload(_)
+                    | Read::Discr(_)
+                    | Read::Index(_)
+                    | Read::CallArg(_)
+                    | Read::CallArgMut
+                    | Read::ViaMut(_) => other(&s, r),
                 });
             }
         }

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -45,8 +45,8 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
 use rustc_lint::LateContext;
 use rustc_middle::mir::{
-    AggregateKind, BasicBlock, Body, BorrowKind, Local, Operand, Place, RETURN_PLACE, RawPtrKind,
-    Rvalue, StatementKind, TerminatorKind,
+    AggregateKind, BasicBlock, Body, BorrowKind, Local, Mutability, Operand, Place, RETURN_PLACE,
+    RawPtrKind, Rvalue, StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::{Span, sym};
@@ -334,7 +334,9 @@ fn gather<'tcx>(
                 | Rvalue::Cast(_, op, _)
                 | Rvalue::UnaryOp(_, op)
                 | Rvalue::WrapUnsafeBinder(op, _) => reads_of_operand(op, false, &mut reads),
-                Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) | Rvalue::Reborrow(_, _, place) => {
+                Rvalue::Ref(_, _, place)
+                | Rvalue::RawPtr(_, place)
+                | Rvalue::Reborrow(_, _, place) => {
                     let is_mut = matches!(
                         rvalue,
                         Rvalue::Ref(_, BorrowKind::Mut { .. }, _)

--- a/src/ctor_flow.rs
+++ b/src/ctor_flow.rs
@@ -269,20 +269,20 @@ fn mentions_self(ty: Ty<'_>, self_did: DefId) -> bool {
         .any(|arg| arg.as_type().is_some_and(|t| is_self_ty(t, self_did)))
 }
 
-/// Reads of one operand/place in value position.
-fn reads_of_place(place: Place<'_>, same: bool, out: &mut Vec<Read>) {
+/// Reads of one operand/place in value position; `exact` tags the Exact case.
+fn reads_of_place(place: Place<'_>, exact: impl FnOnce(Atom) -> Read, out: &mut Vec<Read>) {
     let info = place_info(place);
     out.extend(info.index_locals.iter().map(|l| Read::Index(*l)));
-    match info.exactness {
-        Exactness::VariantPayload => out.push(Read::Payload(info.atom)),
-        Exactness::Exact if same => out.push(Read::Same(info.atom)),
-        Exactness::Exact | Exactness::Inexact => out.push(Read::Derived(info.atom)),
-    }
+    out.push(match info.exactness {
+        Exactness::VariantPayload => Read::Payload(info.atom),
+        Exactness::Exact => exact(info.atom),
+        Exactness::Inexact => Read::Derived(info.atom),
+    });
 }
 
-fn reads_of_operand(op: &Operand<'_>, same: bool, out: &mut Vec<Read>) {
+fn reads_of_operand(op: &Operand<'_>, exact: impl FnOnce(Atom) -> Read, out: &mut Vec<Read>) {
     if let Some(p) = op.place() {
-        reads_of_place(p, same, out);
+        reads_of_place(p, exact, out);
     }
 }
 
@@ -328,12 +328,14 @@ fn gather<'tcx>(
                             payload_alias[dest.local].push(p.local);
                         }
                     }
-                    reads_of_operand(op, true, &mut reads);
+                    reads_of_operand(op, Read::Same, &mut reads);
                 }
                 Rvalue::Repeat(op, _)
                 | Rvalue::Cast(_, op, _)
                 | Rvalue::UnaryOp(_, op)
-                | Rvalue::WrapUnsafeBinder(op, _) => reads_of_operand(op, false, &mut reads),
+                | Rvalue::WrapUnsafeBinder(op, _) => {
+                    reads_of_operand(op, Read::Derived, &mut reads)
+                }
                 Rvalue::Ref(_, _, place)
                 | Rvalue::RawPtr(_, place)
                 | Rvalue::Reborrow(_, _, place) => {
@@ -346,13 +348,13 @@ fn gather<'tcx>(
                     if is_mut && dest.projection.is_empty() {
                         mut_ref_to.insert(dest.local, place_info(*place).atom);
                     }
-                    reads_of_place(*place, true, &mut reads);
+                    reads_of_place(*place, Read::Same, &mut reads);
                 }
-                Rvalue::CopyForDeref(place) => reads_of_place(*place, true, &mut reads),
+                Rvalue::CopyForDeref(place) => reads_of_place(*place, Read::Same, &mut reads),
                 Rvalue::BinaryOp(_, ops) => {
                     let (a, b) = &**ops;
-                    reads_of_operand(a, false, &mut reads);
-                    reads_of_operand(b, false, &mut reads);
+                    reads_of_operand(a, Read::Derived, &mut reads);
+                    reads_of_operand(b, Read::Derived, &mut reads);
                 }
                 Rvalue::Discriminant(place) => {
                     let info = place_info(*place);
@@ -362,19 +364,7 @@ fn gather<'tcx>(
                 Rvalue::Aggregate(kind, ops) => {
                     let kind = &**kind;
                     for (i, op) in ops.iter().enumerate() {
-                        if let Some(p) = op.place() {
-                            let info = place_info(p);
-                            reads.extend(info.index_locals.iter().map(|l| Read::Index(*l)));
-                            match info.exactness {
-                                Exactness::VariantPayload => {
-                                    reads.push(Read::Payload(info.atom));
-                                }
-                                Exactness::Exact => {
-                                    reads.push(Read::AggField(i as u32, info.atom));
-                                }
-                                Exactness::Inexact => reads.push(Read::Derived(info.atom)),
-                            }
-                        }
+                        reads_of_operand(op, |a| Read::AggField(i as u32, a), &mut reads);
                     }
                     match kind {
                         AggregateKind::Adt(did, vidx, _, _, None)
@@ -738,6 +728,15 @@ fn helper_summary<'tcx>(
     Some(out)
 }
 
+fn root_fields(roots: &mut HashMap<FieldIdx, Vec<Atom>>, base: &Atom, nfields: usize) {
+    for f in 0..nfields {
+        roots
+            .entry(FieldIdx::from_usize(f))
+            .or_default()
+            .push(base.extended(&[f as u32]));
+    }
+}
+
 /// field -> root atoms: `carrier.f` for every `Self`-typed local the returned
 /// value passes through, plus helper-call arguments the helper stores in `f`.
 fn field_roots<'tcx>(
@@ -760,25 +759,12 @@ fn field_roots<'tcx>(
             }));
         } else {
             // `Ok(pair.1)`-style: the self value is a sub-place; root there.
-            for f in 0..nfields {
-                roots
-                    .entry(FieldIdx::from_usize(f))
-                    .or_default()
-                    .push(r.extended(&[f as u32]));
-            }
+            root_fields(&mut roots, r, nfields);
         }
     }
     for &c in &carriers {
         if is_self_ty(body.local_decls[c].ty, self_did) {
-            for f in 0..nfields {
-                roots
-                    .entry(FieldIdx::from_usize(f))
-                    .or_default()
-                    .push(Atom {
-                        local: c,
-                        path: vec![f as u32],
-                    });
-            }
+            root_fields(&mut roots, &Atom::whole(c), nfields);
         }
         if let Some(calls) = facts.local_calls.get(&c) {
             for (callee, args) in calls {

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -7,7 +7,7 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::{Span, sym};
 
-use crate::adt_facts::result_err_ty;
+use crate::adt_facts::{matches_config_path, result_err_ty};
 use crate::baseline::{emit, emit_with_note};
 use crate::enum_facts::{arm_variant, ctor_literal_variant};
 use crate::hir_shapes::{Callee, callee_of};
@@ -76,22 +76,8 @@ impl DefaultedFailure {
     }
 
     fn is_listed(&self, cx: &LateContext<'_>, callee: DefId) -> bool {
-        if self.listed.is_empty() {
-            return false;
-        }
-        let path = cx.tcx.def_path_str(callee);
-        let name = cx.tcx.item_name(callee);
-        let krate = cx.tcx.crate_name(callee.krate);
-        // Same spellings as `validator-resource-errors`: a full path, a bare
-        // name, or `crate::name`.
-        self.listed.iter().any(|e| {
-            path == *e
-                || path.ends_with(&format!("::{e}"))
-                || match e.rsplit_once("::") {
-                    None => name.as_str() == e,
-                    Some((k, n)) => !k.contains("::") && krate.as_str() == k && name.as_str() == n,
-                }
-        })
+        !self.listed.is_empty()
+            && matches_config_path(cx.tcx, callee, self.listed.iter().map(String::as_str))
     }
 
     /// `call` produces the `Result`/`Option` whose failure the caller

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -154,12 +154,22 @@ fn fallible_call<'tcx>(cx: &LateContext<'tcx>, call: &Expr<'tcx>) -> Option<Fall
         .then_some(FallibleCall { callee, wrapper })
 }
 
-fn peel<'h>(e: &'h Expr<'h>) -> &'h Expr<'h> {
-    let e = clippy_utils::peel_blocks(e);
-    if let ExprKind::DropTemps(inner) = e.kind {
-        peel(inner)
-    } else {
-        e
+/// Unlike `clippy_utils::peel_blocks`, sees through `unsafe { .. }` too:
+/// `unsafe { f(x) }.unwrap_or(0)` is an ordinary receiver here.
+fn peel<'h>(mut e: &'h Expr<'h>) -> &'h Expr<'h> {
+    loop {
+        match e.kind {
+            ExprKind::DropTemps(inner) => e = inner,
+            ExprKind::Block(
+                Block {
+                    stmts: [],
+                    expr: Some(tail),
+                    ..
+                },
+                None,
+            ) => e = tail,
+            _ => return e,
+        }
     }
 }
 

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -170,7 +170,7 @@ fn through_ok<'h>(cx: &LateContext<'_>, recv: &'h Expr<'h>) -> &'h Expr<'h> {
 /// unit value, `T::default()` / `T::new()`, or those assembled into a tuple,
 /// array or struct. A fallback computed from the surroundings is a decision
 /// this lint cannot judge.
-fn is_fixed_value(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+fn is_fixed_value<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>) -> bool {
     let e = peel_blocks_unsafe(e);
     match e.kind {
         ExprKind::Lit(_) => true,
@@ -181,17 +181,14 @@ fn is_fixed_value(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
             items.iter().all(|i| is_fixed_value(cx, i))
         }
         ExprKind::Path(ref qpath) => is_constant_res(cx.qpath_res(qpath, e.hir_id)),
-        ExprKind::Call(callee, args) => {
-            let ExprKind::Path(qpath) = &callee.kind else {
-                return false;
-            };
-            match cx.qpath_res(qpath, callee.hir_id) {
-                Res::Def(DefKind::Fn | DefKind::AssocFn, def) => {
-                    args.is_empty() && is_nullary_ctor_name(cx, def)
+        ExprKind::Call(_, args) => {
+            callee_of(cx, e).is_some_and(|c| match cx.tcx.def_kind(c.def()) {
+                DefKind::Fn | DefKind::AssocFn => {
+                    args.is_empty() && is_nullary_ctor_name(cx, c.def())
                 }
-                Res::Def(DefKind::Ctor(..), _) => args.iter().all(|a| is_fixed_value(cx, a)),
+                DefKind::Ctor(..) => args.iter().all(|a| is_fixed_value(cx, a)),
                 _ => false,
-            }
+            })
         }
         ExprKind::Struct(_, fields, tail) => {
             fields.iter().all(|f| is_fixed_value(cx, f.expr))
@@ -305,7 +302,11 @@ fn else_reports_success(cx: &LateContext<'_>, els: &Block<'_>) -> bool {
 /// tell" into "no", which is the answer's own vocabulary rather than a value
 /// smuggled past a check. `unwrap_or(true)` is not this: it answers "yes"
 /// unasked.
-fn folds_to_no(cx: &LateContext<'_>, unwrapped: &Expr<'_>, fallback: &Fallback<'_>) -> bool {
+fn folds_to_no<'tcx>(
+    cx: &LateContext<'tcx>,
+    unwrapped: &Expr<'_>,
+    fallback: &Fallback<'tcx>,
+) -> bool {
     if !cx.typeck_results().expr_ty(unwrapped).is_bool() {
         return false;
     }
@@ -315,16 +316,10 @@ fn folds_to_no(cx: &LateContext<'_>, unwrapped: &Expr<'_>, fallback: &Fallback<'
     };
     match value.kind {
         ExprKind::Lit(lit) => lit.node == rustc_ast::LitKind::Bool(false),
-        ExprKind::Call(callee, []) => {
-            let ExprKind::Path(qpath) = &callee.kind else {
-                return false;
-            };
-            matches!(
-                cx.qpath_res(qpath, callee.hir_id),
-                Res::Def(DefKind::Fn | DefKind::AssocFn, def)
-                    if cx.tcx.item_name(def).as_str() == "default"
-            )
-        }
+        ExprKind::Call(_, []) => callee_of(cx, value).is_some_and(|c| {
+            matches!(cx.tcx.def_kind(c.def()), DefKind::Fn | DefKind::AssocFn)
+                && cx.tcx.item_name(c.def()).as_str() == "default"
+        }),
         _ => false,
     }
 }

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -10,7 +10,7 @@ use rustc_span::{Span, sym};
 use crate::adt_facts::{matches_config_path, result_err_ty};
 use crate::baseline::{emit, emit_with_note};
 use crate::enum_facts::{arm_variant, ctor_literal_variant};
-use crate::hir_shapes::{callee_of, peel_blocks_unsafe as peel};
+use crate::hir_shapes::{callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
     /// Flags a call whose failure is replaced by a fixed value and never
@@ -156,12 +156,12 @@ fn fallible_call<'tcx>(cx: &LateContext<'tcx>, call: &Expr<'tcx>) -> Option<Fall
 
 /// `recv`, or the `Result` under a value-position `.ok()` on it.
 fn through_ok<'h>(cx: &LateContext<'_>, recv: &'h Expr<'h>) -> &'h Expr<'h> {
-    let recv = peel(recv);
+    let recv = peel_blocks_unsafe(recv);
     if let ExprKind::MethodCall(seg, inner, [], _) = recv.kind
         && seg.ident.as_str() == "ok"
         && result_err_ty(cx.tcx, cx.typeck_results().expr_ty_adjusted(inner)).is_some()
     {
-        return peel(inner);
+        return peel_blocks_unsafe(inner);
     }
     recv
 }
@@ -171,7 +171,7 @@ fn through_ok<'h>(cx: &LateContext<'_>, recv: &'h Expr<'h>) -> &'h Expr<'h> {
 /// array or struct. A fallback computed from the surroundings is a decision
 /// this lint cannot judge.
 fn is_fixed_value(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
-    let e = peel(e);
+    let e = peel_blocks_unsafe(e);
     match e.kind {
         ExprKind::Lit(_) => true,
         ExprKind::Unary(UnOp::Neg, inner)
@@ -242,7 +242,7 @@ fn fixed_fallback<'tcx>(
         ("unwrap_or_default", []) => Some(Fallback::Default),
         ("unwrap_or", [value]) => is_fixed_value(cx, value).then_some(Fallback::Value(value)),
         ("unwrap_or_else", [thunk]) => {
-            let thunk = peel(thunk);
+            let thunk = peel_blocks_unsafe(thunk);
             match thunk.kind {
                 ExprKind::Closure(c) => {
                     let value = cx.tcx.hir_body(c.body).value;
@@ -279,19 +279,19 @@ fn else_reports_success(cx: &LateContext<'_>, els: &Block<'_>) -> bool {
         ) => e,
         _ => return false,
     };
-    let ExprKind::Ret(value) = peel(only).kind else {
+    let ExprKind::Ret(value) = peel_blocks_unsafe(only).kind else {
         return false;
     };
     match value {
         None => true,
         Some(v) => {
-            let v = peel(v);
+            let v = peel_blocks_unsafe(v);
             match v.kind {
                 ExprKind::Tup([]) => true,
                 ExprKind::Call(_, [payload]) => {
                     ctor_literal_variant(cx, v)
                         .is_some_and(|variant| cx.tcx.item_name(variant) == sym::Ok)
-                        && matches!(peel(payload).kind, ExprKind::Tup([]))
+                        && matches!(peel_blocks_unsafe(payload).kind, ExprKind::Tup([]))
                 }
                 _ => false,
             }
@@ -311,7 +311,7 @@ fn folds_to_no(cx: &LateContext<'_>, unwrapped: &Expr<'_>, fallback: &Fallback<'
     }
     let value = match fallback {
         Fallback::Default => return true,
-        Fallback::Value(value) => peel(value),
+        Fallback::Value(value) => peel_blocks_unsafe(value),
     };
     match value.kind {
         ExprKind::Lit(lit) => lit.node == rustc_ast::LitKind::Bool(false),
@@ -383,7 +383,7 @@ impl<'tcx> LateLintPass<'tcx> for DefaultedFailure {
         if span.from_expansion() {
             return;
         }
-        let init = peel(init);
+        let init = peel_blocks_unsafe(init);
         let call = through_ok(cx, init);
         let head_is_failure_of_call = arm_variant(cx, pat).is_some_and(|variant| {
             let head = cx.tcx.item_name(variant);

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -10,7 +10,7 @@ use rustc_span::{Span, sym};
 use crate::adt_facts::{matches_config_path, result_err_ty};
 use crate::baseline::{emit, emit_with_note};
 use crate::enum_facts::{arm_variant, ctor_literal_variant};
-use crate::hir_shapes::callee_of;
+use crate::hir_shapes::{callee_of, peel_blocks_unsafe as peel};
 
 rustc_session::declare_lint! {
     /// Flags a call whose failure is replaced by a fixed value and never
@@ -152,25 +152,6 @@ fn fallible_call<'tcx>(cx: &LateContext<'tcx>, call: &Expr<'tcx>) -> Option<Fall
     let callee = callee_of(cx, call)?.def();
     matches!(cx.tcx.def_kind(callee), DefKind::Fn | DefKind::AssocFn)
         .then_some(FallibleCall { callee, wrapper })
-}
-
-/// Unlike `clippy_utils::peel_blocks`, sees through `unsafe { .. }` too:
-/// `unsafe { f(x) }.unwrap_or(0)` is an ordinary receiver here.
-fn peel<'h>(mut e: &'h Expr<'h>) -> &'h Expr<'h> {
-    loop {
-        match e.kind {
-            ExprKind::DropTemps(inner) => e = inner,
-            ExprKind::Block(
-                Block {
-                    stmts: [],
-                    expr: Some(tail),
-                    ..
-                },
-                None,
-            ) => e = tail,
-            _ => return e,
-        }
-    }
 }
 
 /// `recv`, or the `Result` under a value-position `.ok()` on it.

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -10,7 +10,7 @@ use rustc_span::{Span, sym};
 use crate::adt_facts::{matches_config_path, result_err_ty};
 use crate::baseline::{emit, emit_with_note};
 use crate::enum_facts::{arm_variant, ctor_literal_variant};
-use crate::hir_shapes::{Callee, callee_of};
+use crate::hir_shapes::callee_of;
 
 rustc_session::declare_lint! {
     /// Flags a call whose failure is replaced by a fixed value and never
@@ -149,9 +149,7 @@ fn fallible_call<'tcx>(cx: &LateContext<'tcx>, call: &Expr<'tcx>) -> Option<Fall
     } else {
         return None;
     };
-    let callee = match callee_of(cx, call)? {
-        Callee::Path { def, .. } | Callee::Method { def, .. } => def,
-    };
+    let callee = callee_of(cx, call)?.def();
     matches!(cx.tcx.def_kind(callee), DefKind::Fn | DefKind::AssocFn)
         .then_some(FallibleCall { callee, wrapper })
 }

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -154,20 +154,12 @@ fn fallible_call<'tcx>(cx: &LateContext<'tcx>, call: &Expr<'tcx>) -> Option<Fall
         .then_some(FallibleCall { callee, wrapper })
 }
 
-fn peel<'h>(mut e: &'h Expr<'h>) -> &'h Expr<'h> {
-    loop {
-        match e.kind {
-            ExprKind::DropTemps(inner) => e = inner,
-            ExprKind::Block(
-                Block {
-                    stmts: [],
-                    expr: Some(tail),
-                    ..
-                },
-                None,
-            ) => e = tail,
-            _ => return e,
-        }
+fn peel<'h>(e: &'h Expr<'h>) -> &'h Expr<'h> {
+    let e = clippy_utils::peel_blocks(e);
+    if let ExprKind::DropTemps(inner) = e.kind {
+        peel(inner)
+    } else {
+        e
     }
 }
 

--- a/src/enum_facts.rs
+++ b/src/enum_facts.rs
@@ -91,13 +91,7 @@ pub(crate) fn is_panic_arm(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
     if !cx.typeck_results().expr_ty(body).is_never() {
         return false;
     }
-    let mut inner = body;
-    while let ExprKind::Block(b, _) = inner.kind {
-        match (b.stmts.len(), b.expr) {
-            (0, Some(tail)) => inner = tail,
-            _ => break,
-        }
-    }
+    let inner = clippy_utils::peel_blocks(body);
     clippy_utils::macros::macro_backtrace(inner.span).any(|mac| {
         matches!(
             cx.tcx.item_name(mac.def_id).as_str(),

--- a/src/enum_facts.rs
+++ b/src/enum_facts.rs
@@ -9,6 +9,8 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, Pat, PatExpr, PatExprKind, PatKind, QPath};
 use rustc_lint::LateContext;
 
+use crate::hir_shapes::peel_blocks_unsafe;
+
 /// The variant `res` names, whether spelled as the variant itself (unit and
 /// struct variants) or as its constructor (tuple variants).
 pub(crate) fn variant_of_res(cx: &LateContext<'_>, res: Res) -> Option<DefId> {
@@ -91,15 +93,7 @@ pub(crate) fn is_panic_arm(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
     if !cx.typeck_results().expr_ty(body).is_never() {
         return false;
     }
-    // Not `clippy_utils::peel_blocks`: `_ => unsafe { unreachable!() }` is
-    // still a panic arm.
-    let mut inner = body;
-    while let ExprKind::Block(b, _) = inner.kind
-        && b.stmts.is_empty()
-        && let Some(tail) = b.expr
-    {
-        inner = tail;
-    }
+    let inner = peel_blocks_unsafe(body);
     clippy_utils::macros::macro_backtrace(inner.span).any(|mac| {
         matches!(
             cx.tcx.item_name(mac.def_id).as_str(),

--- a/src/enum_facts.rs
+++ b/src/enum_facts.rs
@@ -91,7 +91,15 @@ pub(crate) fn is_panic_arm(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
     if !cx.typeck_results().expr_ty(body).is_never() {
         return false;
     }
-    let inner = clippy_utils::peel_blocks(body);
+    // Not `clippy_utils::peel_blocks`: `_ => unsafe { unreachable!() }` is
+    // still a panic arm.
+    let mut inner = body;
+    while let ExprKind::Block(b, _) = inner.kind
+        && b.stmts.is_empty()
+        && let Some(tail) = b.expr
+    {
+        inner = tail;
+    }
     clippy_utils::macros::macro_backtrace(inner.span).any(|mac| {
         matches!(
             cx.tcx.item_name(mac.def_id).as_str(),

--- a/src/exclusive_options.rs
+++ b/src/exclusive_options.rs
@@ -2,11 +2,12 @@ use std::collections::HashMap;
 
 use crate::adt_facts::{field_ty, is_option_ty, private_local_struct};
 use crate::baseline::emit;
+use crate::hir_shapes::assigned_field;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind, StructTailExpr, UnOp};
+use rustc_hir::{Expr, ExprKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
-use rustc_span::{Ident, Symbol};
+use rustc_span::Symbol;
 
 use crate::MordantConfig;
 
@@ -69,19 +70,6 @@ fn relevant_adt<'tcx>(
     (opts.len() >= min_fields).then_some((adt, opts))
 }
 
-/// The `base.field` an assignment writes, through any number of derefs; the
-/// caller reads the ADJUSTED type of `base`, so a write through a `Box`, a
-/// guard or any other `Deref` container reaches the struct behind it.
-fn assigned_field<'h>(mut place: &'h Expr<'h>) -> Option<(&'h Expr<'h>, Ident)> {
-    while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) = place.kind {
-        place = inner;
-    }
-    match place.kind {
-        ExprKind::Field(base, ident) => Some((base, ident)),
-        _ => None,
-    }
-}
-
 enum Init {
     Some,
     None,
@@ -130,7 +118,7 @@ impl<'tcx> LateLintPass<'tcx> for ExclusiveOptions {
             // A later `s.field = ...` write re-opens every combination; the
             // construction sites alone no longer prove anything.
             ExprKind::Assign(place, _, _) | ExprKind::AssignOp(_, place, _) => {
-                let Some((base, ident)) = assigned_field(place) else {
+                let Some((base, ident, _)) = assigned_field(place) else {
                     return;
                 };
                 let ty = cx.typeck_results().expr_ty_adjusted(base);

--- a/src/exclusive_options.rs
+++ b/src/exclusive_options.rs
@@ -70,22 +70,6 @@ fn relevant_adt<'tcx>(
     (opts.len() >= min_fields).then_some((adt, opts))
 }
 
-enum Init {
-    Some,
-    None,
-    Unknown,
-}
-
-fn option_init(cx: &LateContext<'_>, expr: &Expr<'_>) -> Init {
-    if clippy_utils::as_some_expr(cx, expr).is_some() {
-        Init::Some
-    } else if clippy_utils::is_none_expr(cx, expr) {
-        Init::None
-    } else {
-        Init::Unknown
-    }
-}
-
 impl<'tcx> LateLintPass<'tcx> for ExclusiveOptions {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         match expr.kind {
@@ -104,13 +88,11 @@ impl<'tcx> LateLintPass<'tcx> for ExclusiveOptions {
                     if !opts.contains(&field.ident.name) {
                         continue;
                     }
-                    match option_init(cx, field.expr) {
-                        Init::Some => somes.push(field.ident.name),
-                        Init::None => {}
-                        Init::Unknown => {
-                            facts.unprovable = true;
-                            return;
-                        }
+                    if clippy_utils::as_some_expr(cx, field.expr).is_some() {
+                        somes.push(field.ident.name);
+                    } else if !clippy_utils::is_none_expr(cx, field.expr) {
+                        facts.unprovable = true;
+                        return;
                     }
                 }
                 facts.sites.push(somes);

--- a/src/flag_cluster.rs
+++ b/src/flag_cluster.rs
@@ -24,18 +24,10 @@ rustc_session::declare_lint! {
 }
 
 pub struct FlagCluster {
-    min_bools: usize,
+    pub config: &'static MordantConfig,
 }
 
 rustc_session::impl_lint_pass!(FlagCluster => [FLAG_CLUSTER]);
-
-impl FlagCluster {
-    pub fn new(config: &MordantConfig) -> Self {
-        Self {
-            min_bools: config.flag_cluster_min_bools,
-        }
-    }
-}
 
 impl<'tcx> LateLintPass<'tcx> for FlagCluster {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
@@ -57,7 +49,7 @@ impl<'tcx> LateLintPass<'tcx> for FlagCluster {
             .filter(|f| field_ty(cx, f).is_bool())
             .map(|f| f.name)
             .collect();
-        if bools.len() < self.min_bools {
+        if bools.len() < self.config.flag_cluster_min_bools {
             return;
         }
         let names: Vec<String> = bools.iter().map(|s| format!("`{s}`")).collect();

--- a/src/forbidden_reach.rs
+++ b/src/forbidden_reach.rs
@@ -38,6 +38,7 @@ rustc_session::declare_lint! {
 /// never = ["core::panicking", "std::vec::Vec::push"]
 /// ```
 #[derive(Clone, Default, serde::Deserialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 #[serde(rename_all = "kebab-case", default)]
 pub struct ReachRule {
     pub from: String,

--- a/src/forbidden_reach.rs
+++ b/src/forbidden_reach.rs
@@ -10,7 +10,7 @@ use rustc_span::def_id::LocalDefId;
 
 use crate::MordantConfig;
 use crate::baseline::emit;
-use crate::hir_shapes::{Callee, callee_of, def_path_names};
+use crate::hir_shapes::{callee_of, def_path_names};
 
 rustc_session::declare_lint! {
     /// Config-declared reachability bans: "from `scheduler::pick`, no call
@@ -87,8 +87,8 @@ impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
         let caller = def_id.to_def_id();
         let mut edges = Vec::new();
         for_each_expr(cx, body.value, |e: &Expr<'tcx>| {
-            if let Some(Callee::Path { def, .. } | Callee::Method { def, .. }) = callee_of(cx, e) {
-                edges.push((def, e.span));
+            if let Some(callee) = callee_of(cx, e) {
+                edges.push((callee.def(), e.span));
             }
             std::ops::ControlFlow::<()>::Continue(())
         });

--- a/src/forbidden_reach.rs
+++ b/src/forbidden_reach.rs
@@ -10,7 +10,7 @@ use rustc_span::def_id::LocalDefId;
 
 use crate::MordantConfig;
 use crate::baseline::emit;
-use crate::hir_shapes::{Callee, callee_of};
+use crate::hir_shapes::{Callee, callee_of, def_path_names};
 
 rustc_session::declare_lint! {
     /// Config-declared reachability bans: "from `scheduler::pick`, no call
@@ -64,38 +64,11 @@ impl ForbiddenReach {
         }
     }
 
-    fn names_of(&self, cx: &LateContext<'_>, def: DefId) -> [String; 2] {
-        let path = strip_generic_segments(&cx.tcx.def_path_str(def));
-        let with_crate = format!("{}::{}", cx.tcx.crate_name(def.krate), path);
-        [path, with_crate]
-    }
-
     /// Path-suffix match on `::`-separated segments, so "Vec::push" matches
     /// `std::vec::Vec::push` but a bare substring never matches by accident.
     fn matches_pattern(name: &str, pattern: &str) -> bool {
         name == pattern || name.ends_with(&format!("::{pattern}"))
     }
-}
-
-/// `std::vec::Vec::<T>::push` -> `std::vec::Vec::push`: generic-argument
-/// segments would defeat suffix matching, and no ban is per-instantiation.
-fn strip_generic_segments(path: &str) -> String {
-    let mut out = String::with_capacity(path.len());
-    let mut depth = 0usize;
-    let mut chars = path.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '<' => depth += 1,
-            '>' => depth = depth.saturating_sub(1),
-            _ if depth > 0 => {}
-            ':' if chars.peek() == Some(&':') && out.ends_with("::") => {
-                // Collapse the `::` that wrapped a stripped `::<..>`.
-                chars.next();
-            }
-            _ => out.push(c),
-        }
-    }
-    out
 }
 
 impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
@@ -121,12 +94,9 @@ impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
         });
         self.calls.insert(caller, edges);
 
+        let names = def_path_names(cx, caller);
         for (i, rule) in self.rules.iter().enumerate() {
-            if self
-                .names_of(cx, caller)
-                .iter()
-                .any(|n| Self::matches_pattern(n, &rule.from))
-            {
+            if names.iter().any(|n| Self::matches_pattern(n, &rule.from)) {
                 self.roots.push((i, caller, span));
             }
         }
@@ -152,8 +122,7 @@ impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
                     continue;
                 };
                 for &(callee, at) in edges {
-                    let banned = self
-                        .names_of(cx, callee)
+                    let banned = def_path_names(cx, callee)
                         .iter()
                         .any(|n| rule.never.iter().any(|p| Self::matches_pattern(n, p)));
                     if banned {

--- a/src/guard_flag.rs
+++ b/src/guard_flag.rs
@@ -2,10 +2,10 @@ use std::collections::{HashMap, HashSet};
 
 use crate::adt_facts::{field_ty, struct_field};
 use crate::baseline::emit;
-use crate::hir_shapes::{ends_in_return, peel_not, self_field};
+use crate::hir_shapes::{assigned_adt_field, ends_in_return, peel_not, self_field};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Body, Expr, ExprKind, FnDecl, Mutability, Stmt, StmtKind, UnOp};
+use rustc_hir::{Body, Expr, ExprKind, FnDecl, Mutability, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::def_id::LocalDefId;
@@ -62,18 +62,7 @@ fn self_bool_field<'tcx>(
 /// The struct field a written place denotes, for any receiver: `x.flag`,
 /// `(*this).flag`, `self.inner.flag`.
 fn written_field<'tcx>(cx: &LateContext<'tcx>, place: &'tcx Expr<'tcx>) -> Option<(DefId, Symbol)> {
-    let mut place = place;
-    while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) = place.kind {
-        place = inner;
-    }
-    let ExprKind::Field(base, ident) = place.kind else {
-        return None;
-    };
-    let adt = cx
-        .typeck_results()
-        .expr_ty_adjusted(base)
-        .peel_refs()
-        .ty_adt_def()?;
+    let (adt, ident, _) = assigned_adt_field(cx, place)?;
     (adt.is_struct() && adt.did().is_local()).then(|| (adt.did(), ident.name))
 }
 

--- a/src/guard_flag.rs
+++ b/src/guard_flag.rs
@@ -37,12 +37,6 @@ pub struct GuardFlag {
 
 rustc_session::impl_lint_pass!(GuardFlag => [GUARD_FLAG]);
 
-impl GuardFlag {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// `self.field` where `self` is the literal receiver.
 fn self_bool_field<'tcx>(
     cx: &LateContext<'tcx>,

--- a/src/hir_shapes.rs
+++ b/src/hir_shapes.rs
@@ -7,6 +7,7 @@
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, QPath, Stmt, StmtKind, UnOp};
 use rustc_lint::LateContext;
+use rustc_middle::ty::AdtDef;
 use rustc_span::Ident;
 use rustc_span::symbol::kw;
 
@@ -22,6 +23,37 @@ pub(crate) fn self_field<'h>(e: &Expr<'h>) -> Option<(&'h Expr<'h>, Ident)> {
         ExprKind::Field(base, ident) if is_self_path(base) => Some((base, ident)),
         _ => None,
     }
+}
+
+/// The `base.field` an assignment target writes, through any number of
+/// explicit derefs: `x.f`, `(*this).f`, `*s.f`. Returned as `base`, the
+/// field name, and the `Field` expression itself.
+pub(crate) fn assigned_field<'h>(
+    mut place: &'h Expr<'h>,
+) -> Option<(&'h Expr<'h>, Ident, &'h Expr<'h>)> {
+    while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) = place.kind {
+        place = inner;
+    }
+    match place.kind {
+        ExprKind::Field(base, ident) => Some((base, ident, place)),
+        _ => None,
+    }
+}
+
+/// `assigned_field` with `base` resolved to the ADT behind its ADJUSTED
+/// type, so a write through a `Box`, a guard or any other `Deref` container
+/// reaches the type it holds.
+pub(crate) fn assigned_adt_field<'tcx>(
+    cx: &LateContext<'tcx>,
+    place: &'tcx Expr<'tcx>,
+) -> Option<(AdtDef<'tcx>, Ident, &'tcx Expr<'tcx>)> {
+    let (base, ident, field) = assigned_field(place)?;
+    let adt = cx
+        .typeck_results()
+        .expr_ty_adjusted(base)
+        .peel_refs()
+        .ty_adt_def()?;
+    Some((adt, ident, field))
 }
 
 /// `e` with every `!` and HIR condition wrapper stripped, in any
@@ -92,4 +124,33 @@ pub(crate) fn callee_of<'tcx>(cx: &LateContext<'tcx>, e: &Expr<'tcx>) -> Option<
         }
         _ => None,
     }
+}
+
+/// A definition's path with generic segments stripped, bare and prefixed
+/// with its crate name: the two spellings a config pattern may name it by.
+pub(crate) fn def_path_names(cx: &LateContext<'_>, def: DefId) -> [String; 2] {
+    let path = strip_generic_segments(&cx.tcx.def_path_str(def));
+    let with_crate = format!("{}::{}", cx.tcx.crate_name(def.krate), path);
+    [path, with_crate]
+}
+
+/// `std::vec::Vec::<T>::push` -> `std::vec::Vec::push`: generic-argument
+/// segments would defeat suffix matching, and no pattern is per-instantiation.
+pub(crate) fn strip_generic_segments(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    let mut depth = 0usize;
+    let mut chars = path.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            _ if depth > 0 => {}
+            ':' if chars.peek() == Some(&':') && out.ends_with("::") => {
+                // Collapse the `::` that wrapped a stripped `::<..>`.
+                chars.next();
+            }
+            _ => out.push(c),
+        }
+    }
+    out
 }

--- a/src/hir_shapes.rs
+++ b/src/hir_shapes.rs
@@ -105,6 +105,14 @@ pub(crate) enum Callee<'h> {
     },
 }
 
+impl Callee<'_> {
+    pub(crate) fn def(&self) -> DefId {
+        match *self {
+            Callee::Path { def, .. } | Callee::Method { def, .. } => def,
+        }
+    }
+}
+
 /// Resolves a call or method call. `def` is unfiltered — constructors and
 /// foreign definitions come back too — because each caller wants a different
 /// subset. A call through anything but a path (a closure value, a field

--- a/src/hir_shapes.rs
+++ b/src/hir_shapes.rs
@@ -5,7 +5,7 @@
 //! spelled identically.
 
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind, QPath, Stmt, StmtKind, UnOp};
+use rustc_hir::{Block, Expr, ExprKind, QPath, Stmt, StmtKind, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty::AdtDef;
 use rustc_span::symbol::kw;
@@ -104,6 +104,24 @@ pub(crate) fn peel_not<'h>(mut e: &'h Expr<'h>) -> (&'h Expr<'h>, bool) {
             _ => return (e, negated),
         }
     }
+}
+
+/// `e` under any nesting of `{ tail }` / `unsafe { tail }` (no statements)
+/// and HIR temporaries. `clippy_utils::peel_blocks` stops at `unsafe`.
+pub(crate) fn peel_blocks_unsafe<'h>(mut e: &'h Expr<'h>) -> &'h Expr<'h> {
+    while let ExprKind::DropTemps(inner)
+    | ExprKind::Block(
+        &Block {
+            stmts: [],
+            expr: Some(inner),
+            ..
+        },
+        None,
+    ) = e.kind
+    {
+        e = inner;
+    }
+    e
 }
 
 /// The statement's expression, for `let` its initializer.

--- a/src/hir_shapes.rs
+++ b/src/hir_shapes.rs
@@ -8,8 +8,8 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, QPath, Stmt, StmtKind, UnOp};
 use rustc_lint::LateContext;
 use rustc_middle::ty::AdtDef;
-use rustc_span::Ident;
 use rustc_span::symbol::kw;
+use rustc_span::{Ident, Symbol};
 
 /// The bare `self` path.
 pub(crate) fn is_self_path(e: &Expr<'_>) -> bool {
@@ -38,6 +38,38 @@ pub(crate) fn assigned_field<'h>(
         ExprKind::Field(base, ident) => Some((base, ident, place)),
         _ => None,
     }
+}
+
+/// `root.a.b` as `root` and `[a, b]`, read through `&`, `*` and HIR
+/// temporaries at any level, which all name the same place.
+pub(crate) fn field_chain<'h>(mut e: &'h Expr<'h>) -> (&'h Expr<'h>, Vec<Symbol>) {
+    let mut fields = Vec::new();
+    loop {
+        match e.kind {
+            ExprKind::Field(inner, ident) => {
+                fields.push(ident.name);
+                e = inner;
+            }
+            ExprKind::AddrOf(_, _, inner)
+            | ExprKind::Unary(UnOp::Deref, inner)
+            | ExprKind::DropTemps(inner) => e = inner,
+            _ => {
+                fields.reverse();
+                return (e, fields);
+            }
+        }
+    }
+}
+
+/// `head.a.b`; from an empty `head`, `a.b`.
+pub(crate) fn dotted(mut head: String, fields: &[Symbol]) -> String {
+    for f in fields {
+        if !head.is_empty() {
+            head.push('.');
+        }
+        head.push_str(f.as_str());
+    }
+    head
 }
 
 /// `assigned_field` with `base` resolved to the ADT behind its ADJUSTED

--- a/src/hir_shapes.rs
+++ b/src/hir_shapes.rs
@@ -74,6 +74,15 @@ pub(crate) fn peel_not<'h>(mut e: &'h Expr<'h>) -> (&'h Expr<'h>, bool) {
     }
 }
 
+/// The statement's expression, for `let` its initializer.
+pub(crate) fn stmt_expr<'tcx>(stmt: &'tcx Stmt<'tcx>) -> Option<&'tcx Expr<'tcx>> {
+    match stmt.kind {
+        StmtKind::Expr(e) | StmtKind::Semi(e) => Some(e),
+        StmtKind::Let(l) => l.init,
+        StmtKind::Item(_) => None,
+    }
+}
+
 /// The expression's final action is a `return`.
 pub(crate) fn ends_in_return(e: &Expr<'_>) -> bool {
     match e.kind {

--- a/src/insert_then_unwrap.rs
+++ b/src/insert_then_unwrap.rs
@@ -1,12 +1,11 @@
 use clippy_utils::visitors::for_each_expr;
-use rustc_hir::{Block, Expr, ExprKind, Pat, QPath, StmtKind, UnOp};
+use rustc_hir::{Block, Expr, ExprKind, Pat, QPath, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::sym;
-use rustc_span::symbol::kw;
 
 use crate::baseline::emit;
-use crate::hir_shapes::stmt_expr;
+use crate::hir_shapes::{dotted, field_chain, stmt_expr};
 
 rustc_session::declare_lint! {
     /// Flags `map.get(&k).unwrap()` when the presence it bets on was proved a
@@ -29,20 +28,15 @@ rustc_session::declare_lint_pass!(InsertThenUnwrap => [INSERT_THEN_UNWRAP]);
 /// (which name the same value); `-k` and `!k` are different values from `k`.
 /// Anything else is `None`, and untrackable means unprovable means silent.
 fn identity(e: &Expr<'_>) -> Option<String> {
-    match &e.kind {
-        ExprKind::Field(base, ident) => Some(format!("{}.{}", identity(base)?, ident.name)),
+    let (root, fields) = field_chain(e);
+    let head = match &root.kind {
         ExprKind::Path(QPath::Resolved(None, p)) if p.segments.len() == 1 => {
-            let seg = p.segments[0].ident;
-            if seg.name == kw::SelfLower {
-                Some("self".to_string())
-            } else {
-                Some(seg.name.to_string())
-            }
+            p.segments[0].ident.name.to_string()
         }
-        ExprKind::Lit(lit) => Some(format!("lit:{:?}", lit.node)),
-        ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) => identity(inner),
-        _ => None,
-    }
+        ExprKind::Lit(lit) => format!("lit:{:?}", lit.node),
+        _ => return None,
+    };
+    Some(dotted(head, &fields))
 }
 
 /// The local an identity is rooted at: `k` for `k` and `k.id`, `None` for

--- a/src/insert_then_unwrap.rs
+++ b/src/insert_then_unwrap.rs
@@ -6,6 +6,7 @@ use rustc_span::sym;
 use rustc_span::symbol::kw;
 
 use crate::baseline::emit;
+use crate::hir_shapes::stmt_expr;
 
 rustc_session::declare_lint! {
     /// Flags `map.get(&k).unwrap()` when the presence it bets on was proved a
@@ -141,13 +142,7 @@ impl<'tcx> LateLintPass<'tcx> for InsertThenUnwrap {
                 .filter_map(|id| root_local(id))
                 .collect();
             for later in &block.stmts[i + 1..] {
-                let (le, pat) = match later.kind {
-                    StmtKind::Expr(le) | StmtKind::Semi(le) => (Some(le), None),
-                    // The initializer still sees the names as the insert did;
-                    // the pattern takes effect for the statements after it.
-                    StmtKind::Let(l) => (l.init, Some(l.pat)),
-                    StmtKind::Item(_) => (None, None),
-                };
+                let le = stmt_expr(later);
                 // The lookup must be the statement's own top-level shape (or
                 // the let initializer); a lookup buried under other calls is
                 // checked as a disturbance instead.
@@ -168,7 +163,11 @@ impl<'tcx> LateLintPass<'tcx> for InsertThenUnwrap {
                     );
                     return;
                 }
-                if pat.is_some_and(|p| rebinds(p, &roots)) {
+                // The initializer still saw the names as the insert did; the
+                // pattern takes effect for the statements after it.
+                if let StmtKind::Let(l) = later.kind
+                    && rebinds(l.pat, &roots)
+                {
                     break;
                 }
                 if le.is_some_and(|le| may_disturb(cx, le)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_private)]
+#![feature(default_field_values)]
 #![warn(unused_extern_crates)]
 
 extern crate rustc_abi;
@@ -60,7 +61,11 @@ mod wildcard_local_enum;
 /// gate reads these field names out of the pinned source to decide which keys
 /// it may set — so grouping them into sub-structs would rename user-visible
 /// keys to satisfy a lint about internal invariants.
-#[derive(serde::Deserialize)]
+///
+/// `dylint_linting::config_or_default` returns `Default` when the linted
+/// workspace has no `dylint.toml`; the container-level `serde(default)`
+/// fills any omitted key from it too.
+#[derive(Default, serde::Deserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[serde(rename_all = "kebab-case", default)]
 #[cfg_attr(dylint_lib = "mordant", allow(flag_cluster))]
@@ -87,14 +92,14 @@ pub struct MordantConfig {
     /// with one of these is never treated as validating a field.
     pub validator_resource_errors: Vec<String>,
     /// Minimum Option fields for `exclusive_options` to consider a struct.
-    pub exclusive_options_min_fields: usize,
+    pub exclusive_options_min_fields: usize = 2,
     /// `wildcard_local_enum` stays silent above this many variants.
-    pub wildcard_local_enum_max_variants: usize,
+    pub wildcard_local_enum_max_variants: usize = 12,
     /// Bool fields at which `flag_cluster` fires.
-    pub flag_cluster_min_bools: usize,
+    pub flag_cluster_min_bools: usize = 3,
     /// Construction sites at which `stored_projection` will read a
     /// correspondence between two fields.
-    pub stored_projection_min_sites: usize,
+    pub stored_projection_min_sites: usize = 2,
     /// Ratchet file name, resolved upward from each crate's manifest dir. Runs
     /// suppress up to the recorded count per (lint, file) and surface only new
     /// findings. Regenerate with `MORDANT_BASELINE_WRITE=1`.
@@ -136,35 +141,6 @@ pub struct MordantConfig {
     /// which nothing inside the function tells from a missed check; run it
     /// once over parsing code and read the list.
     pub unchecked_input_len_enabled: bool,
-}
-
-/// `dylint_linting::config_or_default` returns this when the linted
-/// workspace has no `dylint.toml`; the container-level `serde(default)`
-/// fills any omitted key from it too.
-impl Default for MordantConfig {
-    fn default() -> Self {
-        Self {
-            nonidentity_key_types: Vec::new(),
-            nonidentity_key_forms: Vec::new(),
-            stringly_error_include_box_dyn: false,
-            nonidentity_key_methods: Vec::new(),
-            nonidentity_key_composite: false,
-            nonidentity_key_fixes: Vec::new(),
-            validator_resource_errors: Vec::new(),
-            exclusive_options_min_fields: 2,
-            wildcard_local_enum_max_variants: 12,
-            flag_cluster_min_bools: 3,
-            stored_projection_min_sites: 2,
-            baseline: None,
-            forbidden_reach: Vec::new(),
-            stale_across_reentry_callees: Vec::new(),
-            defaulted_failure_callees: Vec::new(),
-            flag_cluster_enabled: false,
-            stale_safety_comment_enabled: false,
-            defaulted_failure_ignored_errors: Vec::new(),
-            unchecked_input_len_enabled: false,
-        }
-    }
 }
 
 #[expect(clippy::no_mangle_with_rust_abi)]
@@ -291,7 +267,7 @@ fn ui_opt_in_lints_are_off_without_their_key() {
 }
 
 /// `config_or_default` returns `Default` when the linted workspace has no
-/// `dylint.toml`. A derived `Default` yields 0 for every `usize`, which
+/// `dylint.toml`. A threshold that lost its `= N` would default to 0, which
 /// turns `wildcard_local_enum` off (`n > 0` for every enum) and makes
 /// `exclusive_options` consider every struct.
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ mod wildcard_local_enum;
 /// it may set — so grouping them into sub-structs would rename user-visible
 /// keys to satisfy a lint about internal invariants.
 #[derive(serde::Deserialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 #[serde(rename_all = "kebab-case", default)]
 #[cfg_attr(dylint_lib = "mordant", allow(flag_cluster))]
 pub struct MordantConfig {
@@ -309,29 +310,7 @@ fn config_default_thresholds_match_docs() {
 #[test]
 fn config_omitted_toml_keys_use_the_same_thresholds() {
     let parsed: MordantConfig = toml::from_str("").expect("empty document is an empty table");
-    let d = MordantConfig::default();
-    assert_eq!(
-        parsed.exclusive_options_min_fields,
-        d.exclusive_options_min_fields
-    );
-    assert_eq!(
-        parsed.wildcard_local_enum_max_variants,
-        d.wildcard_local_enum_max_variants
-    );
-    assert_eq!(parsed.flag_cluster_min_bools, d.flag_cluster_min_bools);
-    assert_eq!(
-        parsed.stored_projection_min_sites,
-        d.stored_projection_min_sites
-    );
-    assert_eq!(parsed.flag_cluster_enabled, d.flag_cluster_enabled);
-    assert_eq!(
-        parsed.stale_safety_comment_enabled,
-        d.stale_safety_comment_enabled
-    );
-    assert_eq!(
-        parsed.unchecked_input_len_enabled,
-        d.unchecked_input_len_enabled
-    );
+    assert_eq!(parsed, MordantConfig::default());
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,17 +86,13 @@ pub struct MordantConfig {
     /// with one of these is never treated as validating a field.
     pub validator_resource_errors: Vec<String>,
     /// Minimum Option fields for `exclusive_options` to consider a struct.
-    #[serde(default = "default_min_fields")]
     pub exclusive_options_min_fields: usize,
     /// `wildcard_local_enum` stays silent above this many variants.
-    #[serde(default = "default_max_variants")]
     pub wildcard_local_enum_max_variants: usize,
     /// Bool fields at which `flag_cluster` fires.
-    #[serde(default = "default_min_bools")]
     pub flag_cluster_min_bools: usize,
     /// Construction sites at which `stored_projection` will read a
     /// correspondence between two fields.
-    #[serde(default = "default_min_sites")]
     pub stored_projection_min_sites: usize,
     /// Ratchet file name, resolved upward from each crate's manifest dir. Runs
     /// suppress up to the recorded count per (lint, file) and surface only new
@@ -141,26 +137,9 @@ pub struct MordantConfig {
     pub unchecked_input_len_enabled: bool,
 }
 
-fn default_min_fields() -> usize {
-    2
-}
-
-fn default_max_variants() -> usize {
-    12
-}
-
-fn default_min_bools() -> usize {
-    3
-}
-
-fn default_min_sites() -> usize {
-    2
-}
-
 /// `dylint_linting::config_or_default` returns this when the linted
-/// workspace has no `dylint.toml`. Field-level `serde(default = ...)` covers
-/// a present file that omits a key; both paths call the same fns, so the
-/// two cannot disagree.
+/// workspace has no `dylint.toml`; the container-level `serde(default)`
+/// fills any omitted key from it too.
 impl Default for MordantConfig {
     fn default() -> Self {
         Self {
@@ -171,10 +150,10 @@ impl Default for MordantConfig {
             nonidentity_key_composite: false,
             nonidentity_key_fixes: Vec::new(),
             validator_resource_errors: Vec::new(),
-            exclusive_options_min_fields: default_min_fields(),
-            wildcard_local_enum_max_variants: default_max_variants(),
-            flag_cluster_min_bools: default_min_bools(),
-            stored_projection_min_sites: default_min_sites(),
+            exclusive_options_min_fields: 2,
+            wildcard_local_enum_max_variants: 12,
+            flag_cluster_min_bools: 3,
+            stored_projection_min_sites: 2,
             baseline: None,
             forbidden_reach: Vec::new(),
             stale_across_reentry_callees: Vec::new(),
@@ -326,8 +305,7 @@ fn config_default_thresholds_match_docs() {
 }
 
 /// An empty table (file present, keys omitted) must not drift from
-/// `Default`. Field-level `serde(default = ...)` and this impl share the
-/// same fns.
+/// `Default`.
 #[test]
 fn config_omitted_toml_keys_use_the_same_thresholds() {
     let parsed: MordantConfig = toml::from_str("").expect("empty document is an empty table");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ extern crate rustc_span;
 
 dylint_linting::dylint_library!();
 
+use rustc_data_structures::sync;
+
 mod adt_facts;
 mod asymmetric_guard;
 mod baseline;
@@ -145,81 +147,72 @@ pub struct MordantConfig {
 
 #[expect(clippy::no_mangle_with_rust_abi)]
 #[unsafe(no_mangle)]
-pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint::LintStore) {
+pub fn register_lints(sess: &rustc_session::Session, s: &mut rustc_lint::LintStore) {
+    use {
+        asymmetric_guard::AsymmetricGuard, baseline::BaselineWriter,
+        bypassed_validator::BypassedValidator, defaulted_failure::DefaultedFailure,
+        discarded_error::DiscardedError, exclusive_options::ExclusiveOptions,
+        flag_cluster::FlagCluster, forbidden_reach::ForbiddenReach, guard_flag::GuardFlag,
+        insert_then_unwrap::InsertThenUnwrap, lock_order::LockOrder,
+        narrowed_return::NarrowedReturn, nonidentity_key::NonidentityKey,
+        overwide_parameter::OverwideParameter, parallel_bools::ParallelBools,
+        stale_across_reentry::StaleAcrossReentry, stale_panic_message::StalePanicMessage,
+        stale_safety_comment::StaleSafetyComment, stored_projection::StoredProjection,
+        stringified_error::StringifiedError, stringly_error::StringlyError,
+        unchecked_input_len::UncheckedInputLen, unit_mismatch::UnitMismatch,
+        unread_error_variant::UnreadErrorVariant, unread_none::UnreadNone,
+        wildcard_local_enum::WildcardLocalEnum,
+    };
     dylint_linting::init_config(sess);
     let config: MordantConfig = dylint_linting::config_or_default(env!("CARGO_PKG_NAME"));
     let config: &'static MordantConfig = Box::leak(Box::new(config));
     baseline::setup(&config.baseline);
-    lint_store.register_lints(&[
-        stringly_error::STRINGLY_ERROR,
-        nonidentity_key::NONIDENTITY_KEY,
-        stringified_error::STRINGIFIED_ERROR,
-        exclusive_options::EXCLUSIVE_OPTIONS,
-        parallel_bools::PARALLEL_BOOLS,
-        flag_cluster::FLAG_CLUSTER,
-        bypassed_validator::BYPASSED_VALIDATOR,
-        unread_error_variant::UNREAD_ERROR_VARIANT,
-        asymmetric_guard::ASYMMETRIC_GUARD,
-        stale_safety_comment::STALE_SAFETY_COMMENT,
-        unit_mismatch::UNIT_MISMATCH,
-        stale_panic_message::STALE_PANIC_MESSAGE,
-        lock_order::LOCK_ORDER,
-        forbidden_reach::FORBIDDEN_REACH,
-        guard_flag::GUARD_FLAG,
-        unread_none::UNREAD_NONE,
-        insert_then_unwrap::INSERT_THEN_UNWRAP,
-        overwide_parameter::OVERWIDE_PARAMETER,
-        narrowed_return::NARROWED_RETURN,
-        wildcard_local_enum::WILDCARD_LOCAL_ENUM,
-        discarded_error::DISCARDED_ERROR,
-        stored_projection::STORED_PROJECTION,
-        stale_across_reentry::STALE_ACROSS_REENTRY,
-        defaulted_failure::DEFAULTED_FAILURE,
-        unchecked_input_len::UNCHECKED_INPUT_LEN,
-    ]);
-    lint_store.register_late_pass(move |_| Box::new(stringly_error::StringlyError { config }));
-    lint_store.register_late_pass(move |_| Box::new(nonidentity_key::NonidentityKey::new(config)));
-    lint_store.register_late_pass(|_| Box::new(stringified_error::StringifiedError));
-    lint_store
-        .register_late_pass(move |_| Box::new(exclusive_options::ExclusiveOptions::new(config)));
-    lint_store.register_late_pass(|_| Box::new(parallel_bools::ParallelBools::default()));
-    // The opt-in lints stay registered above so `allow(..)` / `-A` of them
-    // still resolve; only their passes are skipped.
-    if config.flag_cluster_enabled {
-        lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster { config }));
-    }
-    lint_store
-        .register_late_pass(move |_| Box::new(bypassed_validator::BypassedValidator::new(config)));
-    lint_store
-        .register_late_pass(|_| Box::new(unread_error_variant::UnreadErrorVariant::default()));
-    lint_store.register_late_pass(|_| Box::new(asymmetric_guard::AsymmetricGuard::default()));
-    if config.stale_safety_comment_enabled {
-        lint_store
-            .register_late_pass(|_| Box::new(stale_safety_comment::StaleSafetyComment::default()));
-    }
-    lint_store.register_late_pass(|_| Box::new(unit_mismatch::UnitMismatch));
-    lint_store.register_late_pass(|_| Box::new(stale_panic_message::StalePanicMessage::default()));
-    lint_store.register_late_pass(|_| Box::new(lock_order::LockOrder::default()));
-    lint_store.register_late_pass(move |_| Box::new(forbidden_reach::ForbiddenReach::new(config)));
-    lint_store.register_late_pass(|_| Box::new(guard_flag::GuardFlag::default()));
-    lint_store.register_late_pass(|_| Box::new(unread_none::UnreadNone::default()));
-    lint_store.register_late_pass(|_| Box::new(insert_then_unwrap::InsertThenUnwrap));
-    lint_store.register_late_pass(|_| Box::new(overwide_parameter::OverwideParameter::default()));
-    lint_store.register_late_pass(|_| Box::new(narrowed_return::NarrowedReturn::default()));
-    lint_store
-        .register_late_pass(move |_| Box::new(wildcard_local_enum::WildcardLocalEnum { config }));
-    lint_store.register_late_pass(|_| Box::new(discarded_error::DiscardedError));
-    lint_store
-        .register_late_pass(move |_| Box::new(stored_projection::StoredProjection::new(config)));
-    lint_store
-        .register_late_pass(move |_| Box::new(stale_across_reentry::StaleAcrossReentry { config }));
-    lint_store
-        .register_late_pass(move |_| Box::new(defaulted_failure::DefaultedFailure::new(config)));
-    if config.unchecked_input_len_enabled {
-        lint_store.register_late_pass(|_| Box::new(unchecked_input_len::UncheckedInputLen));
-    }
+    add(s, true, move || StringlyError { config });
+    add(s, true, move || NonidentityKey::new(config));
+    add(s, true, || StringifiedError);
+    add(s, true, move || ExclusiveOptions::new(config));
+    add(s, true, ParallelBools::default);
+    add(s, config.flag_cluster_enabled, move || FlagCluster {
+        config,
+    });
+    add(s, true, move || BypassedValidator::new(config));
+    add(s, true, UnreadErrorVariant::default);
+    add(s, true, AsymmetricGuard::default);
+    add(
+        s,
+        config.stale_safety_comment_enabled,
+        StaleSafetyComment::default,
+    );
+    add(s, true, || UnitMismatch);
+    add(s, true, StalePanicMessage::default);
+    add(s, true, LockOrder::default);
+    add(s, true, move || ForbiddenReach::new(config));
+    add(s, true, GuardFlag::default);
+    add(s, true, UnreadNone::default);
+    add(s, true, || InsertThenUnwrap);
+    add(s, true, OverwideParameter::default);
+    add(s, true, NarrowedReturn::default);
+    add(s, true, move || WildcardLocalEnum { config });
+    add(s, true, || DiscardedError);
+    add(s, true, move || StoredProjection::new(config));
+    add(s, true, move || StaleAcrossReentry { config });
+    add(s, true, move || DefaultedFailure::new(config));
+    add(s, config.unchecked_input_len_enabled, || UncheckedInputLen);
     // Last, so its check_crate_post flushes after every lint has recorded.
-    lint_store.register_late_pass(|_| Box::new(baseline::BaselineWriter));
+    add(s, true, || BaselineWriter);
+}
+
+/// Registers the pass's lints unconditionally, so `allow(..)` / `-A` of an
+/// opt-in lint still resolves when only its pass is skipped.
+fn add<T: for<'tcx> rustc_lint::LateLintPass<'tcx> + 'static>(
+    s: &mut rustc_lint::LintStore,
+    enabled: bool,
+    make: impl Fn() -> T + sync::DynSend + sync::DynSync + 'static,
+) {
+    s.register_lints(&make().get_lints());
+    if enabled {
+        s.register_late_pass(move |_| Box::new(make()));
+    }
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
         defaulted_failure::DEFAULTED_FAILURE,
         unchecked_input_len::UNCHECKED_INPUT_LEN,
     ]);
-    lint_store.register_late_pass(move |_| Box::new(stringly_error::StringlyError::new(config)));
+    lint_store.register_late_pass(move |_| Box::new(stringly_error::StringlyError { config }));
     lint_store.register_late_pass(move |_| Box::new(nonidentity_key::NonidentityKey::new(config)));
     lint_store.register_late_pass(|_| Box::new(stringified_error::StringifiedError));
     lint_store
@@ -186,7 +186,7 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     // The opt-in lints stay registered above so `allow(..)` / `-A` of them
     // still resolve; only their passes are skipped.
     if config.flag_cluster_enabled {
-        lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster::new(config)));
+        lint_store.register_late_pass(move |_| Box::new(flag_cluster::FlagCluster { config }));
     }
     lint_store
         .register_late_pass(move |_| Box::new(bypassed_validator::BypassedValidator::new(config)));
@@ -207,13 +207,12 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     lint_store.register_late_pass(|_| Box::new(overwide_parameter::OverwideParameter::default()));
     lint_store.register_late_pass(|_| Box::new(narrowed_return::NarrowedReturn::default()));
     lint_store
-        .register_late_pass(move |_| Box::new(wildcard_local_enum::WildcardLocalEnum::new(config)));
+        .register_late_pass(move |_| Box::new(wildcard_local_enum::WildcardLocalEnum { config }));
     lint_store.register_late_pass(|_| Box::new(discarded_error::DiscardedError));
     lint_store
         .register_late_pass(move |_| Box::new(stored_projection::StoredProjection::new(config)));
-    lint_store.register_late_pass(move |_| {
-        Box::new(stale_across_reentry::StaleAcrossReentry::new(config))
-    });
+    lint_store
+        .register_late_pass(move |_| Box::new(stale_across_reentry::StaleAcrossReentry { config }));
     lint_store
         .register_late_pass(move |_| Box::new(defaulted_failure::DefaultedFailure::new(config)));
     if config.unchecked_input_len_enabled {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     lint_store.register_late_pass(|_| Box::new(stringified_error::StringifiedError));
     lint_store
         .register_late_pass(move |_| Box::new(exclusive_options::ExclusiveOptions::new(config)));
-    lint_store.register_late_pass(|_| Box::new(parallel_bools::ParallelBools::new()));
+    lint_store.register_late_pass(|_| Box::new(parallel_bools::ParallelBools::default()));
     // The opt-in lints stay registered above so `allow(..)` / `-A` of them
     // still resolve; only their passes are skipped.
     if config.flag_cluster_enabled {
@@ -214,21 +214,22 @@ pub fn register_lints(sess: &rustc_session::Session, lint_store: &mut rustc_lint
     }
     lint_store
         .register_late_pass(move |_| Box::new(bypassed_validator::BypassedValidator::new(config)));
-    lint_store.register_late_pass(|_| Box::new(unread_error_variant::UnreadErrorVariant::new()));
-    lint_store.register_late_pass(|_| Box::new(asymmetric_guard::AsymmetricGuard::new()));
+    lint_store
+        .register_late_pass(|_| Box::new(unread_error_variant::UnreadErrorVariant::default()));
+    lint_store.register_late_pass(|_| Box::new(asymmetric_guard::AsymmetricGuard::default()));
     if config.stale_safety_comment_enabled {
         lint_store
-            .register_late_pass(|_| Box::new(stale_safety_comment::StaleSafetyComment::new()));
+            .register_late_pass(|_| Box::new(stale_safety_comment::StaleSafetyComment::default()));
     }
     lint_store.register_late_pass(|_| Box::new(unit_mismatch::UnitMismatch));
-    lint_store.register_late_pass(|_| Box::new(stale_panic_message::StalePanicMessage::new()));
-    lint_store.register_late_pass(|_| Box::new(lock_order::LockOrder::new()));
+    lint_store.register_late_pass(|_| Box::new(stale_panic_message::StalePanicMessage::default()));
+    lint_store.register_late_pass(|_| Box::new(lock_order::LockOrder::default()));
     lint_store.register_late_pass(move |_| Box::new(forbidden_reach::ForbiddenReach::new(config)));
-    lint_store.register_late_pass(|_| Box::new(guard_flag::GuardFlag::new()));
-    lint_store.register_late_pass(|_| Box::new(unread_none::UnreadNone::new()));
+    lint_store.register_late_pass(|_| Box::new(guard_flag::GuardFlag::default()));
+    lint_store.register_late_pass(|_| Box::new(unread_none::UnreadNone::default()));
     lint_store.register_late_pass(|_| Box::new(insert_then_unwrap::InsertThenUnwrap));
-    lint_store.register_late_pass(|_| Box::new(overwide_parameter::OverwideParameter::new()));
-    lint_store.register_late_pass(|_| Box::new(narrowed_return::NarrowedReturn::new()));
+    lint_store.register_late_pass(|_| Box::new(overwide_parameter::OverwideParameter::default()));
+    lint_store.register_late_pass(|_| Box::new(narrowed_return::NarrowedReturn::default()));
     lint_store
         .register_late_pass(move |_| Box::new(wildcard_local_enum::WildcardLocalEnum::new(config)));
     lint_store.register_late_pass(|_| Box::new(discarded_error::DiscardedError));

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -10,7 +10,7 @@ use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
 use crate::baseline::emit;
-use crate::hir_shapes::is_self_path;
+use crate::hir_shapes::{is_self_path, stmt_expr};
 
 rustc_session::declare_lint! {
     /// Flags two lock acquisitions the crate performs in both orders: one
@@ -159,36 +159,27 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
                     let Some((first, guard_name)) = stmt_lock_binding(cx, stmt) else {
                         continue;
                     };
-                    'later: for later in &block.stmts[i + 1..] {
-                        let exprs: Vec<&Expr<'_>> = match later.kind {
-                            StmtKind::Expr(le) | StmtKind::Semi(le) => vec![le],
-                            StmtKind::Let(l) => l.init.into_iter().collect(),
-                            StmtKind::Item(_) => vec![],
-                        };
-                        for le in exprs {
-                            if is_drop_of(le, guard_name) {
-                                break 'later;
+                    for le in block.stmts[i + 1..].iter().filter_map(stmt_expr) {
+                        if is_drop_of(le, guard_name) {
+                            break;
+                        }
+                        let mut second: Option<(Lock, Span)> = None;
+                        for_each_expr(cx, le, |inner: &Expr<'_>| {
+                            // A closure built here runs whenever its holder
+                            // decides, possibly after the guard is gone; what
+                            // it locks is not locked now.
+                            if matches!(inner.kind, ExprKind::Closure(..)) {
+                                return std::ops::ControlFlow::<(), Descend>::Continue(Descend::No);
                             }
-                            let mut second: Option<(Lock, Span)> = None;
-                            for_each_expr(cx, le, |inner: &Expr<'_>| {
-                                // A closure built here runs whenever its
-                                // holder decides, possibly after the guard is
-                                // gone; what it locks is not locked now.
-                                if matches!(inner.kind, ExprKind::Closure(..)) {
-                                    return std::ops::ControlFlow::<(), Descend>::Continue(
-                                        Descend::No,
-                                    );
-                                }
-                                if let Some(l) = lock_acquisition(cx, inner)
-                                    && l != first
-                                {
-                                    second = Some((l, inner.span));
-                                }
-                                std::ops::ControlFlow::<(), Descend>::Continue(Descend::Yes)
-                            });
-                            if let Some((second, at)) = second {
-                                self.pairs.entry((first.clone(), second)).or_insert(at);
+                            if let Some(l) = lock_acquisition(cx, inner)
+                                && l != first
+                            {
+                                second = Some((l, inner.span));
                             }
+                            std::ops::ControlFlow::<(), Descend>::Continue(Descend::Yes)
+                        });
+                        if let Some((second, at)) = second {
+                            self.pairs.entry((first.clone(), second)).or_insert(at);
                         }
                     }
                 }

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -48,12 +48,6 @@ pub struct LockOrder {
 
 rustc_session::impl_lint_pass!(LockOrder => [LOCK_ORDER]);
 
-impl LockOrder {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// `self.a.b.lock()` (or `.read()` / `.write()`) on a `Mutex`/`RwLock`
 /// receiver: the lock's identity is the field path and the type of `self`.
 fn lock_acquisition(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<Lock> {

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -2,12 +2,10 @@ use std::collections::HashMap;
 
 use clippy_utils::visitors::{Descend, for_each_expr};
 use rustc_hir::def_id::DefId;
-use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Body, Expr, ExprKind, FnDecl, PatKind, QPath, Stmt, StmtKind};
+use rustc_hir::{Block, Expr, ExprKind, PatKind, QPath, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
-use rustc_span::def_id::LocalDefId;
 
 use crate::baseline::emit;
 use crate::hir_shapes::{dotted, field_chain, is_self_path, stmt_expr};
@@ -122,53 +120,37 @@ fn is_drop_of(e: &Expr<'_>, name: rustc_span::Symbol) -> bool {
 }
 
 impl<'tcx> LateLintPass<'tcx> for LockOrder {
-    fn check_fn(
-        &mut self,
-        cx: &LateContext<'tcx>,
-        kind: FnKind<'tcx>,
-        _decl: &'tcx FnDecl<'tcx>,
-        body: &'tcx Body<'tcx>,
-        _span: Span,
-        _def_id: LocalDefId,
-    ) {
-        if matches!(kind, FnKind::Closure) {
-            return;
-        }
-        // Walk every block: a `let guard = <lock>` makes later statements of
-        // the same block "while holding", until a `drop(guard)`.
-        for_each_expr(cx, body.value, |e: &Expr<'tcx>| {
-            if let ExprKind::Block(block, _) = e.kind {
-                for (i, stmt) in block.stmts.iter().enumerate() {
-                    let Some((first, guard_name)) = stmt_lock_binding(cx, stmt) else {
-                        continue;
-                    };
-                    for le in block.stmts[i + 1..].iter().filter_map(stmt_expr) {
-                        if is_drop_of(le, guard_name) {
-                            break;
-                        }
-                        let mut second: Option<(Lock, Span)> = None;
-                        for_each_expr(cx, le, |inner: &Expr<'_>| {
-                            // A closure built here runs whenever its holder
-                            // decides, possibly after the guard is gone; what
-                            // it locks is not locked now.
-                            if matches!(inner.kind, ExprKind::Closure(..)) {
-                                return std::ops::ControlFlow::<(), Descend>::Continue(Descend::No);
-                            }
-                            if let Some(l) = lock_acquisition(cx, inner)
-                                && l != first
-                            {
-                                second = Some((l, inner.span));
-                            }
-                            std::ops::ControlFlow::<(), Descend>::Continue(Descend::Yes)
-                        });
-                        if let Some((second, at)) = second {
-                            self.pairs.entry((first.clone(), second)).or_insert(at);
-                        }
+    // A `let guard = <lock>` makes later statements of the same block "while
+    // holding", until a `drop(guard)`.
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        for (i, stmt) in block.stmts.iter().enumerate() {
+            let Some((first, guard_name)) = stmt_lock_binding(cx, stmt) else {
+                continue;
+            };
+            for le in block.stmts[i + 1..].iter().filter_map(stmt_expr) {
+                if is_drop_of(le, guard_name) {
+                    break;
+                }
+                let mut second: Option<(Lock, Span)> = None;
+                for_each_expr(cx, le, |inner: &Expr<'_>| {
+                    // A closure built here runs whenever its holder decides,
+                    // possibly after the guard is gone; what it locks is not
+                    // locked now.
+                    if matches!(inner.kind, ExprKind::Closure(..)) {
+                        return std::ops::ControlFlow::<(), Descend>::Continue(Descend::No);
                     }
+                    if let Some(l) = lock_acquisition(cx, inner)
+                        && l != first
+                    {
+                        second = Some((l, inner.span));
+                    }
+                    std::ops::ControlFlow::<(), Descend>::Continue(Descend::Yes)
+                });
+                if let Some((second, at)) = second {
+                    self.pairs.entry((first.clone(), second)).or_insert(at);
                 }
             }
-            std::ops::ControlFlow::<()>::Continue(())
-        });
+        }
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -121,7 +121,9 @@ fn is_drop_of(e: &Expr<'_>, name: rustc_span::Symbol) -> bool {
 
 impl<'tcx> LateLintPass<'tcx> for LockOrder {
     // A `let guard = <lock>` makes later statements of the same block "while
-    // holding", until a `drop(guard)`.
+    // holding", until a `drop(guard)`. Every HIR block is a scope of its own
+    // here, bare `loop {}` bodies and const/static initializers included, not
+    // only blocks that appear as an `ExprKind::Block` inside a fn body.
     fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
         for (i, stmt) in block.stmts.iter().enumerate() {
             let Some((first, guard_name)) = stmt_lock_binding(cx, stmt) else {
@@ -155,6 +157,7 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
         let sm = cx.tcx.sess.source_map();
+        let mut findings: Vec<(Span, String)> = Vec::new();
         for ((a, b), span) in &self.pairs {
             // Report each conflicting pair once, from the lexically smaller
             // side, so the two orders produce one finding, not two.
@@ -163,17 +166,25 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
             }
             if let Some(rev_span) = self.pairs.get(&(b.clone(), a.clone())) {
                 let (a, b) = (&a.path, &b.path);
-                emit(
-                    cx,
-                    LOCK_ORDER,
+                findings.push((
                     *span,
                     format!(
                         "`{a}` is locked before `{b}` here, but `{b}` before `{a}` at {}",
                         sm.span_to_diagnostic_string(*rev_span),
                     ),
-                    "both orders existing is the shape of a deadlock; pick one order and hold to it everywhere",
-                );
+                ));
             }
+        }
+        // `pairs` is a HashMap; report in source order.
+        findings.sort_by_key(|(span, _)| span.lo());
+        for (span, msg) in findings {
+            emit(
+                cx,
+                LOCK_ORDER,
+                span,
+                msg,
+                "both orders existing is the shape of a deadlock; pick one order and hold to it everywhere",
+            );
         }
     }
 }

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -10,7 +10,7 @@ use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
 use crate::baseline::emit;
-use crate::hir_shapes::{is_self_path, stmt_expr};
+use crate::hir_shapes::{dotted, field_chain, is_self_path, stmt_expr};
 
 rustc_session::declare_lint! {
     /// Flags two lock acquisitions the crate performs in both orders: one
@@ -87,19 +87,8 @@ fn lock_acquisition(cx: &LateContext<'_>, e: &Expr<'_>) -> Option<Lock> {
 /// anything that is not a plain field chain off `self`, since only those
 /// have a stable identity.
 fn field_path<'h>(e: &'h Expr<'h>) -> Option<(&'h Expr<'h>, String)> {
-    match &e.kind {
-        ExprKind::Field(base, ident) => {
-            let (root, prefix) = field_path(base)?;
-            if prefix.is_empty() {
-                Some((root, ident.name.to_string()))
-            } else {
-                Some((root, format!("{prefix}.{}", ident.name)))
-            }
-        }
-        ExprKind::Path(_) if is_self_path(e) => Some((e, String::new())),
-        ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(_, inner) => field_path(inner),
-        _ => None,
-    }
+    let (root, fields) = field_chain(e);
+    is_self_path(root).then(|| (root, dotted(String::new(), &fields)))
 }
 
 /// The lock acquired by this statement's `let` initializer, with the bound

--- a/src/mir_flow.rs
+++ b/src/mir_flow.rs
@@ -20,8 +20,11 @@
 use std::collections::{HashSet, VecDeque};
 
 use rustc_hir::def_id::LocalDefId;
+use rustc_index::IndexVec;
 use rustc_index::bit_set::DenseBitSet;
-use rustc_middle::mir::{BasicBlock, Body, Local, Place, ProjectionElem, TerminatorKind};
+use rustc_middle::mir::{
+    BasicBlock, BasicBlockData, Body, Local, Place, ProjectionElem, TerminatorKind,
+};
 use rustc_middle::ty::TyCtxt;
 
 // ── MIR access ───────────────────────────────────────────────────────────────
@@ -177,13 +180,14 @@ pub(crate) fn place_info(place: Place<'_>) -> PlaceInfo {
 /// "does not happen" here, otherwise everything after `assert!(x)` would be
 /// control-dependent on `x`.
 pub(crate) struct Cfg {
-    succs: Vec<Vec<usize>>,
-    /// Index of the virtual exit node.
-    exit: usize,
+    succs: IndexVec<BasicBlock, Vec<BasicBlock>>,
+    /// The virtual exit node, one past the last block.
+    exit: BasicBlock,
 }
 
-fn raw_successors(body: &Body<'_>, bb: BasicBlock) -> Vec<BasicBlock> {
-    let Some(term) = &body.basic_blocks[bb].terminator else {
+/// Normal (non-unwind) successors of a non-cleanup block; none otherwise.
+fn raw_successors(body: &Body<'_>, data: &BasicBlockData<'_>) -> Vec<BasicBlock> {
+    let Some(term) = data.terminator.as_ref().filter(|_| !data.is_cleanup) else {
         return Vec::new();
     };
     // Unwind targets are always cleanup blocks, so this leaves the normal edges.
@@ -197,27 +201,18 @@ fn raw_successors(body: &Body<'_>, bb: BasicBlock) -> Vec<BasicBlock> {
 }
 
 pub(crate) fn build_cfg(body: &Body<'_>) -> Cfg {
-    let n = body.basic_blocks.len();
-    let raw: Vec<Vec<usize>> = (0..n)
-        .map(|i| {
-            let bb = BasicBlock::from_usize(i);
-            if body.basic_blocks[bb].is_cleanup {
-                Vec::new()
-            } else {
-                raw_successors(body, bb)
-                    .into_iter()
-                    .map(|b| b.as_usize())
-                    .collect()
-            }
-        })
+    let exit = BasicBlock::from_usize(body.basic_blocks.len());
+    let raw: IndexVec<BasicBlock, Vec<BasicBlock>> = body
+        .basic_blocks
+        .iter()
+        .map(|data| raw_successors(body, data))
         .collect();
-    let mut can_return: Vec<bool> = (0..n)
-        .map(|i| {
+    let mut can_return: IndexVec<BasicBlock, bool> = body
+        .basic_blocks
+        .iter()
+        .map(|data| {
             matches!(
-                body.basic_blocks[BasicBlock::from_usize(i)]
-                    .terminator
-                    .as_ref()
-                    .map(|t| &t.kind),
+                data.terminator.as_ref().map(|t| &t.kind),
                 Some(TerminatorKind::Return | TerminatorKind::TailCall { .. })
             )
         })
@@ -225,36 +220,38 @@ pub(crate) fn build_cfg(body: &Body<'_>) -> Cfg {
     let mut changed = true;
     while changed {
         changed = false;
-        for b in 0..n {
+        for b in raw.indices() {
             if !can_return[b] && raw[b].iter().any(|s| can_return[*s]) {
                 can_return[b] = true;
                 changed = true;
             }
         }
     }
-    let succs = (0..n)
-        .map(|b| {
-            let live: Vec<usize> = raw[b].iter().copied().filter(|s| can_return[*s]).collect();
-            if live.is_empty() { vec![n] } else { live }
+    let succs = raw
+        .iter()
+        .map(|r| {
+            let live: Vec<BasicBlock> = r.iter().copied().filter(|s| can_return[*s]).collect();
+            if live.is_empty() { vec![exit] } else { live }
         })
         .collect();
-    Cfg { succs, exit: n }
+    Cfg { succs, exit }
 }
 
-pub(crate) type Bits = DenseBitSet<usize>;
-
+type Bits = DenseBitSet<BasicBlock>;
 /// Post-dominator sets over blocks plus the virtual exit.
-pub(crate) fn post_dominators(cfg: &Cfg) -> Vec<Bits> {
-    let n = cfg.exit;
-    let mut pdom: Vec<Bits> = (0..=n).map(|_| Bits::new_filled(n + 1)).collect();
-    pdom[n] = Bits::new_empty(n + 1);
-    pdom[n].insert(n);
+pub(crate) type Pdoms = IndexVec<BasicBlock, Bits>;
+
+pub(crate) fn post_dominators(cfg: &Cfg) -> Pdoms {
+    let size = cfg.exit.as_usize() + 1;
+    let mut pdom = IndexVec::from_elem_n(Bits::new_filled(size), size);
+    pdom[cfg.exit] = Bits::new_empty(size);
+    pdom[cfg.exit].insert(cfg.exit);
     let mut changed = true;
     while changed {
         changed = false;
-        for b in 0..n {
-            let mut acc = Bits::new_filled(n + 1);
-            for &s in &cfg.succs[b] {
+        for (b, succs) in cfg.succs.iter_enumerated() {
+            let mut acc = Bits::new_filled(size);
+            for &s in succs {
                 acc.intersect(&pdom[s]);
             }
             acc.insert(b);
@@ -267,40 +264,33 @@ pub(crate) fn post_dominators(cfg: &Cfg) -> Vec<Bits> {
     pdom
 }
 
-/// Branches (`t` not post-dominating them, but post-dominating one of their
-/// successors) whose outcome decides whether `t` runs, in block order.
-fn direct_deps(cfg: &Cfg, pdom: &[Bits], t: usize) -> Vec<usize> {
-    (0..cfg.exit)
-        .filter(|a| {
+/// Branch blocks that `t` is directly control-dependent on, in block order:
+/// `t` does not post-dominate them but does post-dominate one of their
+/// successors, so their outcome sends control to `t` or away from it. A
+/// branch that only decides whether one of those is reached (an early
+/// `return Ok` guard in front of it) is not among them; `control_deps` has
+/// those too.
+pub(crate) fn direct_control_deps(cfg: &Cfg, pdom: &Pdoms, t: BasicBlock) -> Vec<BasicBlock> {
+    cfg.succs
+        .iter_enumerated()
+        .filter(|(a, succs)| {
             let strictly = pdom[*a].contains(t) && *a != t;
-            cfg.succs[*a].len() >= 2
-                && !strictly
-                && cfg.succs[*a].iter().any(|s| pdom[*s].contains(t))
+            succs.len() >= 2 && !strictly && succs.iter().any(|s| pdom[*s].contains(t))
         })
-        .collect()
-}
-
-/// Branch blocks that `target` is directly control-dependent on: the ones
-/// whose outcome sends control to `target` or away from it. A branch that
-/// only decides whether one of those is reached (an early `return Ok` guard
-/// in front of it) is not among them; `control_deps` has those too.
-pub(crate) fn direct_control_deps(cfg: &Cfg, pdom: &[Bits], target: BasicBlock) -> Vec<BasicBlock> {
-    direct_deps(cfg, pdom, target.as_usize())
-        .into_iter()
-        .map(BasicBlock::from_usize)
+        .map(|(a, _)| a)
         .collect()
 }
 
 /// Branch blocks that `target` is transitively control-dependent on,
 /// innermost first.
-pub(crate) fn control_deps(cfg: &Cfg, pdom: &[Bits], target: BasicBlock) -> Vec<BasicBlock> {
+pub(crate) fn control_deps(cfg: &Cfg, pdom: &Pdoms, target: BasicBlock) -> Vec<BasicBlock> {
     let mut seen = HashSet::new();
-    let mut q = VecDeque::from([target.as_usize()]);
+    let mut q = VecDeque::from([target]);
     let mut deps = Vec::new();
     while let Some(t) = q.pop_front() {
-        for a in direct_deps(cfg, pdom, t) {
+        for a in direct_control_deps(cfg, pdom, t) {
             if seen.insert(a) {
-                deps.push(BasicBlock::from_usize(a));
+                deps.push(a);
                 q.push_back(a);
             }
         }

--- a/src/mir_flow.rs
+++ b/src/mir_flow.rs
@@ -200,27 +200,11 @@ fn raw_successors(body: &Body<'_>, bb: BasicBlock) -> Vec<BasicBlock> {
     let Some(term) = &body.basic_blocks[bb].terminator else {
         return Vec::new();
     };
-    let mut v = match &term.kind {
-        TerminatorKind::Goto { target } => vec![*target],
-        TerminatorKind::SwitchInt { targets, .. } => targets.all_targets().to_vec(),
-        TerminatorKind::Drop { target, .. } | TerminatorKind::Assert { target, .. } => {
-            vec![*target]
-        }
-        TerminatorKind::Call { target, .. } => target.iter().copied().collect(),
-        TerminatorKind::Yield { resume, .. } => vec![*resume],
-        TerminatorKind::FalseEdge { real_target, .. }
-        | TerminatorKind::FalseUnwind { real_target, .. } => {
-            vec![*real_target]
-        }
-        TerminatorKind::InlineAsm { targets, .. } => targets.to_vec(),
-        TerminatorKind::Return
-        | TerminatorKind::Unreachable
-        | TerminatorKind::UnwindResume
-        | TerminatorKind::UnwindTerminate(_)
-        | TerminatorKind::CoroutineDrop
-        | TerminatorKind::TailCall { .. } => Vec::new(),
-    };
-    v.retain(|b| !body.basic_blocks[*b].is_cleanup);
+    // Unwind targets are always cleanup blocks, so this leaves the normal edges.
+    let mut v: Vec<_> = term
+        .successors()
+        .filter(|b| !body.basic_blocks[*b].is_cleanup)
+        .collect();
     v.sort();
     v.dedup();
     v

--- a/src/mir_flow.rs
+++ b/src/mir_flow.rs
@@ -24,6 +24,7 @@
 use std::collections::{HashSet, VecDeque};
 
 use rustc_hir::def_id::LocalDefId;
+use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::{BasicBlock, Body, Local, Operand, Place, ProjectionElem, TerminatorKind};
 use rustc_middle::ty::TyCtxt;
 
@@ -255,47 +256,24 @@ pub(crate) fn build_cfg(body: &Body<'_>) -> Cfg {
     Cfg { succs, exit: n }
 }
 
-pub(crate) struct Bits(Vec<u64>);
-impl Bits {
-    fn full(n: usize) -> Self {
-        let mut v = vec![!0u64; n.div_ceil(64)];
-        if !n.is_multiple_of(64) {
-            *v.last_mut().unwrap() = (1u64 << (n % 64)) - 1;
-        }
-        Bits(v)
-    }
-    fn empty(n: usize) -> Self {
-        Bits(vec![0; n.div_ceil(64)])
-    }
-    fn set(&mut self, i: usize) {
-        self.0[i / 64] |= 1 << (i % 64);
-    }
-    fn has(&self, i: usize) -> bool {
-        self.0[i / 64] & (1 << (i % 64)) != 0
-    }
-    fn and_assign(&mut self, o: &Bits) {
-        for (a, b) in self.0.iter_mut().zip(&o.0) {
-            *a &= *b;
-        }
-    }
-}
+pub(crate) type Bits = DenseBitSet<usize>;
 
 /// Post-dominator sets over blocks plus the virtual exit.
 pub(crate) fn post_dominators(cfg: &Cfg) -> Vec<Bits> {
     let n = cfg.exit;
-    let mut pdom: Vec<Bits> = (0..=n).map(|_| Bits::full(n + 1)).collect();
-    pdom[n] = Bits::empty(n + 1);
-    pdom[n].set(n);
+    let mut pdom: Vec<Bits> = (0..=n).map(|_| Bits::new_filled(n + 1)).collect();
+    pdom[n] = Bits::new_empty(n + 1);
+    pdom[n].insert(n);
     let mut changed = true;
     while changed {
         changed = false;
         for b in 0..n {
-            let mut acc = Bits::full(n + 1);
+            let mut acc = Bits::new_filled(n + 1);
             for &s in &cfg.succs[b] {
-                acc.and_assign(&pdom[s]);
+                acc.intersect(&pdom[s]);
             }
-            acc.set(b);
-            if acc.0 != pdom[b].0 {
+            acc.insert(b);
+            if acc != pdom[b] {
                 pdom[b] = acc;
                 changed = true;
             }
@@ -309,8 +287,10 @@ pub(crate) fn post_dominators(cfg: &Cfg) -> Vec<Bits> {
 fn direct_deps(cfg: &Cfg, pdom: &[Bits], t: usize) -> Vec<usize> {
     (0..cfg.exit)
         .filter(|a| {
-            let strictly = pdom[*a].has(t) && *a != t;
-            cfg.succs[*a].len() >= 2 && !strictly && cfg.succs[*a].iter().any(|s| pdom[*s].has(t))
+            let strictly = pdom[*a].contains(t) && *a != t;
+            cfg.succs[*a].len() >= 2
+                && !strictly
+                && cfg.succs[*a].iter().any(|s| pdom[*s].contains(t))
         })
         .collect()
 }

--- a/src/mir_flow.rs
+++ b/src/mir_flow.rs
@@ -1,7 +1,7 @@
 //! MIR machinery shared by the body-level analyses, with no opinion about
 //! what any of it means for a lint.
 //!
-//! It answers five questions about a body:
+//! It answers four questions about a body:
 //!
 //! * which MIR to read at all (`mir_for`: the pre-optimization body, so `?`
 //!   is still a `Try::branch` call and every aggregate is intact);
@@ -11,21 +11,17 @@
 //!   `post_dominators`, `control_deps`), over a CFG in which blocks that
 //!   cannot reach a `return` do not exist, so nothing is "decided" by an
 //!   `assert!`;
-//! * whether every path to a block passes through another (`dominates`).
-//!   This is a different relation from control dependence: a clamp's branch
-//!   dominates the use after it without deciding whether the use runs;
 //! * what a branch switches on (`switch_operand_atoms`).
 //!
 //! What the answers mean is the caller's business: `ctor_flow` combines them
 //! into "does a failure exit depend on a stored field", `unchecked_input_len`
-//! asks whether a comparison dominates a use, `variant_flow` uses only
-//! `mir_for` and traces returned variants its own way.
+//! and `variant_flow` use only `mir_for` and trace the body their own way.
 
 use std::collections::{HashSet, VecDeque};
 
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::bit_set::DenseBitSet;
-use rustc_middle::mir::{BasicBlock, Body, Local, Operand, Place, ProjectionElem, TerminatorKind};
+use rustc_middle::mir::{BasicBlock, Body, Local, Place, ProjectionElem, TerminatorKind};
 use rustc_middle::ty::TyCtxt;
 
 // ── MIR access ───────────────────────────────────────────────────────────────
@@ -102,7 +98,7 @@ impl Atom {
     /// a decision on the whole of something only part of which is stored
     /// (`lexer.next()?` then `log: lexer.log`), is not evidence about the part.
     pub(crate) fn inspects(&self, stored: &Atom) -> bool {
-        self.local == stored.local && is_prefix(&stored.path, &self.path)
+        self.local == stored.local && self.path.starts_with(&stored.path)
     }
 }
 
@@ -172,17 +168,6 @@ pub(crate) fn place_info(place: Place<'_>) -> PlaceInfo {
         exactness,
         index_locals,
     }
-}
-
-pub(crate) fn operand_place<'tcx>(op: &Operand<'tcx>) -> Option<Place<'tcx>> {
-    match op {
-        Operand::Copy(p) | Operand::Move(p) => Some(*p),
-        Operand::Constant(_) | Operand::RuntimeChecks(_) => None,
-    }
-}
-
-pub(crate) fn is_prefix(a: &[u32], b: &[u32]) -> bool {
-    a.len() <= b.len() && a.iter().zip(b).all(|(x, y)| x == y)
 }
 
 // ── control dependence ───────────────────────────────────────────────────────
@@ -325,7 +310,8 @@ pub(crate) fn control_deps(cfg: &Cfg, pdom: &[Bits], target: BasicBlock) -> Vec<
 
 pub(crate) fn switch_operand_atoms(body: &Body<'_>, bb: BasicBlock) -> Vec<Atom> {
     match &body.basic_blocks[bb].terminator().kind {
-        TerminatorKind::SwitchInt { discr, .. } => operand_place(discr)
+        TerminatorKind::SwitchInt { discr, .. } => discr
+            .place()
             .map(|p| {
                 let info = place_info(p);
                 let mut v: Vec<Atom> = info.index_locals.into_iter().map(Atom::whole).collect();
@@ -335,13 +321,4 @@ pub(crate) fn switch_operand_atoms(body: &Body<'_>, bb: BasicBlock) -> Vec<Atom>
             .unwrap_or_default(),
         _ => Vec::new(),
     }
-}
-
-// ── dominance ────────────────────────────────────────────────────────────────
-
-/// Every path from the entry to `at` passes through `check` (rustc's forward
-/// dominators over the full CFG). Reflexive; false when `at` is unreachable.
-pub(crate) fn dominates(body: &Body<'_>, check: BasicBlock, at: BasicBlock) -> bool {
-    let d = body.basic_blocks.dominators();
-    d.is_reachable(at) && d.dominates(check, at)
 }

--- a/src/narrowed_return.rs
+++ b/src/narrowed_return.rs
@@ -41,12 +41,6 @@ pub struct NarrowedReturn {
 
 rustc_session::impl_lint_pass!(NarrowedReturn => [NARROWED_RETURN]);
 
-impl NarrowedReturn {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl<'tcx> LateLintPass<'tcx> for NarrowedReturn {
     fn check_fn(
         &mut self,

--- a/src/nonidentity_key.rs
+++ b/src/nonidentity_key.rs
@@ -39,10 +39,7 @@ impl KeyForm {
 }
 
 pub struct NonidentityKey {
-    deny_types: Vec<String>,
-    deny_methods: Vec<String>,
-    fix_types: Vec<String>,
-    composite: bool,
+    config: &'static MordantConfig,
     /// The opted-in forms. Membership, not one flag per form: a form the
     /// project did not name is absent rather than false.
     forms: Vec<KeyForm>,
@@ -62,12 +59,9 @@ const KEY_METHODS: &[&str] = &[
 ];
 
 impl NonidentityKey {
-    pub fn new(config: &MordantConfig) -> Self {
+    pub fn new(config: &'static MordantConfig) -> Self {
         Self {
-            deny_types: config.nonidentity_key_types.clone(),
-            deny_methods: config.nonidentity_key_methods.clone(),
-            fix_types: config.nonidentity_key_fixes.clone(),
-            composite: config.nonidentity_key_composite,
+            config,
             forms: config
                 .nonidentity_key_forms
                 .iter()
@@ -77,13 +71,17 @@ impl NonidentityKey {
     }
 
     fn is_denied<'tcx>(&self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<String> {
-        configured(cx, ty.peel_refs().ty_adt_def()?.did(), &self.deny_types)
+        configured(
+            cx,
+            ty.peel_refs().ty_adt_def()?.did(),
+            &self.config.nonidentity_key_types,
+        )
     }
 
     fn is_fixing<'tcx>(&self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-        ty.peel_refs()
-            .ty_adt_def()
-            .is_some_and(|adt| configured(cx, adt.did(), &self.fix_types).is_some())
+        ty.peel_refs().ty_adt_def().is_some_and(|adt| {
+            configured(cx, adt.did(), &self.config.nonidentity_key_fixes).is_some()
+        })
     }
 
     /// A direct hit, or (opt-in) a denied type inside a tuple or one level of
@@ -92,7 +90,7 @@ impl NonidentityKey {
         if let Some(path) = self.is_denied(cx, key_ty) {
             return Some(path);
         }
-        if !self.composite {
+        if !self.config.nonidentity_key_composite {
             return None;
         }
         let components: Vec<Ty<'_>> = match key_ty.peel_refs().kind() {
@@ -213,10 +211,11 @@ impl<'tcx> LateLintPass<'tcx> for NonidentityKey {
         }
         // Project-declared methods whose result is not an identity (e.g. a
         // NaN-boxing `Value::to_bits`, where boxed values yield pointer bits).
-        if !self.deny_methods.is_empty()
+        let deny_methods = &self.config.nonidentity_key_methods;
+        if !deny_methods.is_empty()
             && let ExprKind::MethodCall(kseg, _, _, _) = key_expr.kind
             && let Some(mdid) = cx.typeck_results().type_dependent_def_id(key_expr.hir_id)
-            && configured(cx, mdid, &self.deny_methods).is_some()
+            && configured(cx, mdid, deny_methods).is_some()
         {
             emit(
                 cx,

--- a/src/nonidentity_key.rs
+++ b/src/nonidentity_key.rs
@@ -1,5 +1,5 @@
 use crate::baseline::emit;
-use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
@@ -77,34 +77,13 @@ impl NonidentityKey {
     }
 
     fn is_denied<'tcx>(&self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<String> {
-        let ty::Adt(adt, _) = ty.peel_refs().kind() else {
-            return None;
-        };
-        let path = cx.tcx.def_path_str(adt.did());
-        let with_crate = if adt.did().is_local() {
-            format!("{}::{}", cx.tcx.crate_name(LOCAL_CRATE), path)
-        } else {
-            path.clone()
-        };
-        self.deny_types
-            .iter()
-            .find(|d| **d == path || **d == with_crate)
-            .map(|_| path)
+        configured(cx, ty.peel_refs().ty_adt_def()?.did(), &self.deny_types)
     }
 
     fn is_fixing<'tcx>(&self, cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-        let ty::Adt(adt, _) = ty.peel_refs().kind() else {
-            return false;
-        };
-        let path = cx.tcx.def_path_str(adt.did());
-        let with_crate = if adt.did().is_local() {
-            format!("{}::{}", cx.tcx.crate_name(LOCAL_CRATE), path)
-        } else {
-            path.clone()
-        };
-        self.fix_types
-            .iter()
-            .any(|d| *d == path || *d == with_crate)
+        ty.peel_refs()
+            .ty_adt_def()
+            .is_some_and(|adt| configured(cx, adt.did(), &self.fix_types).is_some())
     }
 
     /// A direct hit, or (opt-in) a denied type inside a tuple or one level of
@@ -133,6 +112,18 @@ impl NonidentityKey {
         // Renders as: map keyed on `(Span, u32)` carrying `Span`, ...
         Some(format!("{key_ty}` carrying `{hit}"))
     }
+}
+
+/// `did`'s def path when `list` names it, either as that path or with the
+/// local crate's name in front.
+fn configured(cx: &LateContext<'_>, did: DefId, list: &[String]) -> Option<String> {
+    let path = cx.tcx.def_path_str(did);
+    let with_crate = did
+        .is_local()
+        .then(|| format!("{}::{path}", cx.tcx.crate_name(LOCAL_CRATE)));
+    list.iter()
+        .any(|d| *d == path || Some(d) == with_crate.as_ref())
+        .then_some(path)
 }
 
 /// The key type of a keyed std/indexmap collection, or None.
@@ -225,29 +216,18 @@ impl<'tcx> LateLintPass<'tcx> for NonidentityKey {
         if !self.deny_methods.is_empty()
             && let ExprKind::MethodCall(kseg, _, _, _) = key_expr.kind
             && let Some(mdid) = cx.typeck_results().type_dependent_def_id(key_expr.hir_id)
+            && configured(cx, mdid, &self.deny_methods).is_some()
         {
-            let path = cx.tcx.def_path_str(mdid);
-            let with_crate = if mdid.is_local() {
-                format!("{}::{}", cx.tcx.crate_name(LOCAL_CRATE), path)
-            } else {
-                path.clone()
-            };
-            if self
-                .deny_methods
-                .iter()
-                .any(|d| *d == path || *d == with_crate)
-            {
-                emit(
-                    cx,
-                    NONIDENTITY_KEY,
-                    key_expr.span,
-                    format!(
-                        "map keyed on `{}()`, which this project declares is not an identity",
-                        kseg.ident
-                    ),
-                    "key on the canonical identity of the thing this names",
-                );
-            }
+            emit(
+                cx,
+                NONIDENTITY_KEY,
+                key_expr.span,
+                format!(
+                    "map keyed on `{}()`, which this project declares is not an identity",
+                    kseg.ident
+                ),
+                "key on the canonical identity of the thing this names",
+            );
         }
         if self.forms.contains(&KeyForm::PtrCast) && is_ptr_to_int_cast(cx, key_expr) {
             emit(

--- a/src/overwide_parameter.rs
+++ b/src/overwide_parameter.rs
@@ -1,10 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
+use clippy_utils::res::MaybeResPath;
 use clippy_utils::visitors::for_each_expr;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Body, Expr, ExprKind, FnDecl, HirId, PatKind, QPath};
+use rustc_hir::{Body, Expr, ExprKind, FnDecl, HirId, PatKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
@@ -106,8 +107,7 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
         let fn_def = def_id.to_def_id();
         for_each_expr(cx, body.value, |e: &Expr<'tcx>| {
             if let ExprKind::Match(scrut, arms, _) = e.kind
-                && let ExprKind::Path(QPath::Resolved(None, path)) = &scrut.kind
-                && let Res::Local(scrut_local) = path.res
+                && let Some(scrut_local) = scrut.res_local_id()
                 && let Some(idx) = params.iter().position(|p| *p == Some(scrut_local))
             {
                 for arm in arms {

--- a/src/overwide_parameter.rs
+++ b/src/overwide_parameter.rs
@@ -28,11 +28,6 @@ rustc_session::declare_lint! {
     "panicking arm for a variant no existing call site passes"
 }
 
-struct EnumParam {
-    /// Variants with a diverging panic arm in this fn's body.
-    panicking: Vec<(DefId, Span)>,
-}
-
 #[derive(Default)]
 struct CallFacts {
     passed: HashSet<DefId>,
@@ -42,8 +37,8 @@ struct CallFacts {
 
 #[derive(Default)]
 pub struct OverwideParameter {
-    /// fn -> per-param enum facts (None for params this lint ignores).
-    fns: HashMap<DefId, Vec<Option<EnumParam>>>,
+    /// (fn, param idx) -> variants with a diverging panic arm in the fn body.
+    panicking: HashMap<(DefId, usize), Vec<(DefId, Span)>>,
     calls: HashMap<(DefId, usize), CallFacts>,
     /// Functions referenced other than by direct call: indirect callers are
     /// invisible, so their call-site sets are unknowable.
@@ -96,58 +91,43 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
             return;
         }
         // Param locals whose type is a crate-local enum.
-        let mut params: Vec<Option<(HirId, DefId)>> = Vec::new();
-        for param in body.params {
-            let PatKind::Binding(_, hir_id, _, None) = param.pat.kind else {
-                params.push(None);
-                continue;
-            };
-            let pty = cx.typeck_results().pat_ty(param.pat).peel_refs();
-            match pty.kind() {
-                ty::Adt(adt, _) if adt.is_enum() && adt.did().is_local() => {
-                    params.push(Some((hir_id, adt.did())));
-                }
-                _ => params.push(None),
-            }
-        }
+        let params: Vec<Option<HirId>> = body
+            .params
+            .iter()
+            .map(|param| {
+                let PatKind::Binding(_, hir_id, _, None) = param.pat.kind else {
+                    return None;
+                };
+                let pty = cx.typeck_results().pat_ty(param.pat).peel_refs();
+                matches!(pty.kind(), ty::Adt(adt, _) if adt.is_enum() && adt.did().is_local())
+                    .then_some(hir_id)
+            })
+            .collect();
         if params.iter().all(Option::is_none) {
             return;
         }
         // Panicking arms in matches whose scrutinee is exactly the param.
-        let mut facts: Vec<Option<EnumParam>> = params
-            .iter()
-            .map(|p| {
-                p.map(|_| EnumParam {
-                    panicking: Vec::new(),
-                })
-            })
-            .collect();
+        let fn_def = def_id.to_def_id();
         for_each_expr(cx, body.value, |e: &Expr<'tcx>| {
             if let ExprKind::Match(scrut, arms, _) = e.kind
                 && let ExprKind::Path(QPath::Resolved(None, path)) = &scrut.kind
                 && let Res::Local(scrut_local) = path.res
+                && let Some(idx) = params.iter().position(|p| *p == Some(scrut_local))
             {
-                for (idx, p) in params.iter().enumerate() {
-                    let Some((param_hir, _)) = p else { continue };
-                    if *param_hir != scrut_local {
-                        continue;
-                    }
-                    for arm in arms {
-                        if arm.guard.is_some() {
-                            continue;
-                        }
-                        if let Some(variant) = crate::enum_facts::arm_variant(cx, arm.pat)
-                            && crate::enum_facts::is_panic_arm(cx, arm.body)
-                            && let Some(f) = &mut facts[idx]
-                        {
-                            f.panicking.push((variant, arm.span));
-                        }
+                for arm in arms {
+                    if arm.guard.is_none()
+                        && let Some(variant) = crate::enum_facts::arm_variant(cx, arm.pat)
+                        && crate::enum_facts::is_panic_arm(cx, arm.body)
+                    {
+                        self.panicking
+                            .entry((fn_def, idx))
+                            .or_default()
+                            .push((variant, arm.span));
                     }
                 }
             }
             std::ops::ControlFlow::<()>::Continue(())
         });
-        self.fns.insert(def_id.to_def_id(), facts);
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
@@ -209,43 +189,40 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
         let mut findings: Vec<(Span, String)> = Vec::new();
-        for (fn_def, params) in &self.fns {
+        for (key @ (fn_def, _), arms) in &self.panicking {
             if self.poisoned.contains(fn_def) {
                 continue;
             }
-            for (idx, facts) in params.iter().enumerate() {
-                let Some(facts) = facts else { continue };
-                let Some(calls) = self.calls.get(&(*fn_def, idx)) else {
-                    // Never called: nothing provable about its domain.
-                    continue;
-                };
-                if calls.unknown || calls.sites == 0 {
+            let Some(calls) = self.calls.get(key) else {
+                // Never called: nothing provable about its domain.
+                continue;
+            };
+            if calls.unknown || calls.sites == 0 {
+                continue;
+            }
+            for (variant, span) in arms {
+                if calls.passed.contains(variant) {
                     continue;
                 }
-                for (variant, span) in &facts.panicking {
-                    if calls.passed.contains(variant) {
-                        continue;
-                    }
-                    let mut passed: Vec<String> = calls
-                        .passed
-                        .iter()
-                        .map(|v| format!("`{}`", cx.tcx.item_name(*v)))
-                        .collect();
-                    passed.sort();
-                    findings.push((
-                        *span,
-                        format!(
-                            "all {} call sites of `{}` pass {}; this arm panics on `{}`, which no existing caller sends",
-                            calls.sites,
-                            cx.tcx.item_name(*fn_def),
-                            passed.join(", "),
-                            cx.tcx.item_name(*variant),
-                        ),
-                    ));
-                }
+                let mut passed: Vec<String> = calls
+                    .passed
+                    .iter()
+                    .map(|v| format!("`{}`", cx.tcx.item_name(*v)))
+                    .collect();
+                passed.sort();
+                findings.push((
+                    *span,
+                    format!(
+                        "all {} call sites of `{}` pass {}; this arm panics on `{}`, which no existing caller sends",
+                        calls.sites,
+                        cx.tcx.item_name(*fn_def),
+                        passed.join(", "),
+                        cx.tcx.item_name(*variant),
+                    ),
+                ));
             }
         }
-        // `fns` is a HashMap; report in source order.
+        // `panicking` is a HashMap; report in source order.
         findings.sort_by_key(|(span, _)| span.lo());
         for (span, msg) in findings {
             emit(

--- a/src/overwide_parameter.rs
+++ b/src/overwide_parameter.rs
@@ -48,10 +48,6 @@ pub struct OverwideParameter {
 rustc_session::impl_lint_pass!(OverwideParameter => [OVERWIDE_PARAMETER]);
 
 impl OverwideParameter {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// One call of `def`, with the value sent to each body param index.
     fn record_call<'tcx>(
         &mut self,

--- a/src/overwide_parameter.rs
+++ b/src/overwide_parameter.rs
@@ -157,20 +157,10 @@ impl<'tcx> LateLintPass<'tcx> for OverwideParameter {
                 let ExprKind::Path(qpath) = &expr.kind else {
                     return;
                 };
-                let is_direct_callee =
-                    cx.tcx
-                        .hir_parent_iter(expr.hir_id)
-                        .next()
-                        .is_some_and(|(_, node)| {
-                            matches!(
-                                node,
-                                rustc_hir::Node::Expr(Expr {
-                                    kind: ExprKind::Call(callee, _),
-                                    ..
-                                }) if callee.hir_id == expr.hir_id
-                            )
-                        });
-                if is_direct_callee {
+                if matches!(
+                    clippy_utils::get_parent_expr(cx, expr),
+                    Some(Expr { kind: ExprKind::Call(callee, _), .. }) if callee.hir_id == expr.hir_id
+                ) {
                     return;
                 }
                 if let Res::Def(DefKind::Fn | DefKind::AssocFn, def) =

--- a/src/parallel_bools.rs
+++ b/src/parallel_bools.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 
 use crate::adt_facts::{field_ty, private_local_struct, struct_field};
 use crate::baseline::emit;
+use crate::hir_shapes::assigned_field;
 use clippy_utils::get_enclosing_block;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Expr, ExprKind, HirId, UnOp};
+use rustc_hir::{Expr, ExprKind, HirId};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Symbol;
@@ -52,14 +53,10 @@ fn relevant_struct<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>) -> Option<ty:
 
 impl<'tcx> LateLintPass<'tcx> for ParallelBools {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        let (ExprKind::Assign(mut place, _, _) | ExprKind::AssignOp(_, mut place, _)) = expr.kind
-        else {
+        let (ExprKind::Assign(place, _, _) | ExprKind::AssignOp(_, place, _)) = expr.kind else {
             return;
         };
-        while let ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) = place.kind {
-            place = inner;
-        }
-        let ExprKind::Field(base, ident) = place.kind else {
+        let Some((base, ident, _)) = assigned_field(place) else {
             return;
         };
         // The adjusted type: a write through a `Box`, a guard or any other

--- a/src/parallel_bools.rs
+++ b/src/parallel_bools.rs
@@ -33,12 +33,6 @@ pub struct ParallelBools {
 
 rustc_session::impl_lint_pass!(ParallelBools => [PARALLEL_BOOLS]);
 
-impl ParallelBools {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// The crate-private local struct behind `ty`, if it has 2+ bool fields.
 fn relevant_struct<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>) -> Option<ty::AdtDef<'tcx>> {
     let adt = private_local_struct(cx, ty)?;

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -14,7 +14,7 @@ use rustc_span::symbol::{Symbol, kw, sym};
 use crate::MordantConfig;
 use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit_with_note;
-use crate::hir_shapes::{def_path_names, strip_generic_segments};
+use crate::hir_shapes::{def_path_names, stmt_expr, strip_generic_segments};
 
 rustc_session::declare_lint! {
     /// A fact read off a field of `self` (`let n = self.items.len()`, `let p =
@@ -485,15 +485,6 @@ fn mentions<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>, binding: HirId) -
         }
     })
     .is_some()
-}
-
-/// The statement's expression, for `let` its initializer.
-fn stmt_expr<'tcx>(stmt: &'tcx Stmt<'tcx>) -> Option<&'tcx Expr<'tcx>> {
-    match stmt.kind {
-        StmtKind::Expr(e) | StmtKind::Semi(e) => Some(e),
-        StmtKind::Let(l) => l.init,
-        StmtKind::Item(_) => None,
-    }
 }
 
 /// How an expression gives control away.

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -1,10 +1,10 @@
-use clippy_utils::visitors::{for_each_expr, for_each_expr_without_closures};
-use rustc_hir::def::Res;
+use clippy_utils::res::MaybeResPath;
+use clippy_utils::visitors::{for_each_expr, for_each_expr_without_closures, is_local_used};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{Visitor, walk_expr};
 use rustc_hir::{
     BinOpKind, Block, Expr, ExprKind, HirId, ImplicitSelfKind, MatchSource, Mutability, PatKind,
-    QPath, Stmt, StmtKind, UnOp,
+    Stmt, StmtKind, UnOp,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
@@ -442,21 +442,6 @@ fn hands_out<'tcx>(cx: &LateContext<'tcx>, arg: &'tcx Expr<'tcx>, t: &Tracked) -
     }
 }
 
-fn is_binding(e: &Expr<'_>, binding: HirId) -> bool {
-    matches!(&e.kind, ExprKind::Path(QPath::Resolved(None, p)) if p.res == Res::Local(binding))
-}
-
-fn mentions<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>, binding: HirId) -> bool {
-    for_each_expr(cx, e, |inner: &Expr<'tcx>| {
-        if is_binding(inner, binding) {
-            std::ops::ControlFlow::Break(())
-        } else {
-            std::ops::ControlFlow::Continue(())
-        }
-    })
-    .is_some()
-}
-
 /// How an expression gives control away.
 enum Exit<'tcx> {
     /// A configured callee: the project says it re-enters, and re-entry
@@ -626,7 +611,7 @@ fn refreshes<'tcx>(
                 self_place(recv).is_some_and(|p| p == t.place)
             }
             ExprKind::Assign(lhs, _, _) | ExprKind::AssignOp(_, lhs, _) => {
-                is_binding(lhs, t.binding)
+                lhs.res_local_id() == Some(t.binding)
                     || self_place(lhs).is_some_and(|p| t.place.starts_with(&p))
             }
             _ => false,
@@ -650,7 +635,10 @@ struct Reuse<'a, 'tcx> {
 
 impl<'a, 'tcx> Reuse<'a, 'tcx> {
     fn depends(&self, args: &'tcx [Expr<'tcx>]) -> bool {
-        self.gated > 0 || args.iter().any(|a| mentions(self.cx, a, self.t.binding))
+        self.gated > 0
+            || args
+                .iter()
+                .any(|a| is_local_used(self.cx, a, self.t.binding))
     }
 
     fn access(&self, e: &'tcx Expr<'tcx>) -> bool {
@@ -689,7 +677,7 @@ impl<'tcx> Visitor<'tcx> for Reuse<'_, 'tcx> {
             return;
         }
         if self.t.fact == Fact::Pointer {
-            if is_binding(e, self.t.binding) {
+            if e.res_local_id() == Some(self.t.binding) {
                 self.found = Some(e.span);
             } else {
                 walk_expr(self, e);
@@ -704,7 +692,7 @@ impl<'tcx> Visitor<'tcx> for Reuse<'_, 'tcx> {
         // (`if self.items[n] > 0`, `match self.items.remove(n)`); if it does
         // not, the branches under it are gated on the number.
         match &e.kind {
-            ExprKind::If(cond, then, els) if mentions(self.cx, cond, self.t.binding) => {
+            ExprKind::If(cond, then, els) if is_local_used(self.cx, *cond, self.t.binding) => {
                 self.visit_expr(cond);
                 self.gated += 1;
                 self.visit_expr(then);
@@ -713,7 +701,7 @@ impl<'tcx> Visitor<'tcx> for Reuse<'_, 'tcx> {
                 }
                 self.gated -= 1;
             }
-            ExprKind::Match(scrut, arms, _) if mentions(self.cx, scrut, self.t.binding) => {
+            ExprKind::Match(scrut, arms, _) if is_local_used(self.cx, *scrut, self.t.binding) => {
                 self.visit_expr(scrut);
                 self.gated += 1;
                 for arm in *arms {

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -61,18 +61,12 @@ rustc_session::declare_lint! {
 }
 
 pub struct StaleAcrossReentry {
-    callees: Vec<String>,
+    pub config: &'static MordantConfig,
 }
 
 rustc_session::impl_lint_pass!(StaleAcrossReentry => [STALE_ACROSS_REENTRY]);
 
 impl StaleAcrossReentry {
-    pub fn new(config: &MordantConfig) -> Self {
-        Self {
-            callees: config.stale_across_reentry_callees.clone(),
-        }
-    }
-
     /// Whether the call to `def` with `args` is one the config names, under
     /// any spelling of either the item typeck resolved or the impl item the
     /// receiver type sends it to.
@@ -82,14 +76,15 @@ impl StaleAcrossReentry {
         def: DefId,
         args: ty::GenericArgsRef<'tcx>,
     ) -> bool {
-        if self.callees.is_empty() {
+        let callees = &self.config.stale_across_reentry_callees;
+        if callees.is_empty() {
             return false;
         }
         std::iter::once(def)
             .chain(impl_item_of(cx, def, args))
             .flat_map(|def| callee_names(cx, def))
             .any(|[name, with_crate]| {
-                self.callees
+                callees
                     .iter()
                     .any(|p| matches_pattern(&name, p) || matches_pattern(&with_crate, p))
             })

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -9,12 +9,14 @@ use rustc_hir::{
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
-use rustc_span::symbol::{Symbol, kw, sym};
+use rustc_span::symbol::{Symbol, sym};
 
 use crate::MordantConfig;
 use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit_with_note;
-use crate::hir_shapes::{def_path_names, stmt_expr, strip_generic_segments};
+use crate::hir_shapes::{
+    def_path_names, dotted, field_chain, is_self_path, stmt_expr, strip_generic_segments,
+};
 
 rustc_session::declare_lint! {
     /// A fact read off a field of `self` (`let n = self.items.len()`, `let p =
@@ -245,35 +247,8 @@ const ADAPTERS: &[&str] = &[
 /// `self.a.b` as `[a, b]`; anything not rooted at `self` through fields
 /// alone has no identity a re-entrant callee shares with this function.
 fn self_place(e: &Expr<'_>) -> Option<Vec<Symbol>> {
-    fn go(e: &Expr<'_>, out: &mut Vec<Symbol>) -> bool {
-        match &e.kind {
-            ExprKind::Field(base, ident) => {
-                if !go(base, out) {
-                    return false;
-                }
-                out.push(ident.name);
-                true
-            }
-            ExprKind::Path(QPath::Resolved(None, p)) => {
-                p.segments.len() == 1 && p.segments[0].ident.name == kw::SelfLower
-            }
-            ExprKind::AddrOf(_, _, inner)
-            | ExprKind::Unary(UnOp::Deref, inner)
-            | ExprKind::DropTemps(inner) => go(inner, out),
-            _ => false,
-        }
-    }
-    let mut out = Vec::new();
-    (go(e, &mut out) && !out.is_empty()).then_some(out)
-}
-
-fn render(place: &[Symbol]) -> String {
-    let mut s = String::from("self");
-    for f in place {
-        s.push('.');
-        s.push_str(f.as_str());
-    }
-    s
+    let (root, fields) = field_chain(e);
+    (is_self_path(root) && !fields.is_empty()).then_some(fields)
 }
 
 /// What the fact's field is, which decides who could change it underneath
@@ -462,12 +437,7 @@ fn hands_out<'tcx>(cx: &LateContext<'tcx>, arg: &'tcx Expr<'tcx>, t: &Tracked) -
                 e = inner;
             }
             ExprKind::Unary(UnOp::Deref, inner) | ExprKind::DropTemps(inner) => e = inner,
-            ExprKind::Path(QPath::Resolved(None, p)) => {
-                return p.segments.len() == 1
-                    && p.segments[0].ident.name == kw::SelfLower
-                    && counts(shared);
-            }
-            _ => return false,
+            _ => return is_self_path(e) && counts(shared),
         }
     }
 }
@@ -795,7 +765,7 @@ impl<'tcx> LateLintPass<'tcx> for StaleAcrossReentry {
                             break;
                         }
                         if let Some(at) = reuse_in(cx, e, &t) {
-                            let place = render(&t.place);
+                            let place = dotted(String::from("self"), &t.place);
                             let name = t.name;
                             let msg = match t.fact {
                                 Fact::Count | Fact::Flag => format!(

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -14,6 +14,7 @@ use rustc_span::symbol::{Symbol, kw, sym};
 use crate::MordantConfig;
 use crate::adt_facts::impl_self_adt;
 use crate::baseline::emit_with_note;
+use crate::hir_shapes::{def_path_names, strip_generic_segments};
 
 rustc_session::declare_lint! {
     /// A fact read off a field of `self` (`let n = self.items.len()`, `let p =
@@ -85,7 +86,7 @@ impl StaleAcrossReentry {
         std::iter::once(def)
             .chain(impl_item_of(cx, def, args))
             .flat_map(|def| callee_names(cx, def))
-            .any(|(name, with_crate)| {
+            .any(|[name, with_crate]| {
                 self.callees
                     .iter()
                     .any(|p| matches_pattern(&name, p) || matches_pattern(&with_crate, p))
@@ -119,29 +120,26 @@ fn impl_item_of<'tcx>(
 /// (`Vm::run_callback`) and trait items (`Runner::run_job`); an impl's item
 /// renders as `<Worker as Runner>::run_job`, which no `Type::method` pattern
 /// matches, so it is spelled `Worker::run_job` and `Runner::run_job` instead.
-fn callee_names(cx: &LateContext<'_>, def: DefId) -> Vec<(String, String)> {
-    let path_of = |did: DefId| strip_generic_segments(&cx.tcx.def_path_str(did));
-    let mut names = vec![path_of(def)];
+fn callee_names(cx: &LateContext<'_>, def: DefId) -> Vec<[String; 2]> {
+    let mut names = vec![def_path_names(cx, def)];
     if let Some(impl_did) = cx.tcx.impl_of_assoc(def)
         && let Some(trait_ref) = cx.tcx.impl_opt_trait_ref(impl_did)
     {
-        let item = cx.tcx.item_name(def);
-        if let Some(adt) = impl_self_adt(cx, impl_did) {
-            names.push(format!("{}::{item}", path_of(adt.did())));
-        }
-        names.push(format!(
-            "{}::{item}",
-            path_of(trait_ref.skip_binder().def_id)
-        ));
-    }
-    let krate = cx.tcx.crate_name(def.krate);
-    names
-        .into_iter()
-        .map(|name| {
+        let (krate, item) = (cx.tcx.crate_name(def.krate), cx.tcx.item_name(def));
+        let owners = impl_self_adt(cx, impl_did)
+            .map(|adt| adt.did())
+            .into_iter()
+            .chain([trait_ref.skip_binder().def_id]);
+        names.extend(owners.map(|owner| {
+            let name = format!(
+                "{}::{item}",
+                strip_generic_segments(&cx.tcx.def_path_str(owner))
+            );
             let with_crate = format!("{krate}::{name}");
-            (name, with_crate)
-        })
-        .collect()
+            [name, with_crate]
+        }));
+    }
+    names
 }
 
 /// Segment-wise suffix match: `run_callback` and `Vm::run_callback` both
@@ -158,26 +156,6 @@ fn matches_pattern(name: &str, pattern: &str) -> bool {
         None => have_last == want_last,
     };
     last_matches && want.all(|w| have.next() == Some(w))
-}
-
-/// `Vec::<T>::push` -> `Vec::push`, so patterns are written the way the
-/// source spells the call.
-fn strip_generic_segments(path: &str) -> String {
-    let mut out = String::with_capacity(path.len());
-    let mut depth = 0usize;
-    let mut chars = path.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '<' => depth += 1,
-            '>' => depth = depth.saturating_sub(1),
-            _ if depth > 0 => {}
-            ':' if chars.peek() == Some(&':') && out.ends_with("::") => {
-                chars.next();
-            }
-            _ => out.push(c),
-        }
-    }
-    out
 }
 
 /// What kind of fact a binding holds about its place, which decides what

--- a/src/stale_panic_message.rs
+++ b/src/stale_panic_message.rs
@@ -23,12 +23,6 @@ pub struct StalePanicMessage {
 
 rustc_session::impl_lint_pass!(StalePanicMessage => [STALE_PANIC_MESSAGE]);
 
-impl StalePanicMessage {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 const PANIC_MACROS: &[&str] = &[
     "panic",
     "unreachable",

--- a/src/stale_safety_comment.rs
+++ b/src/stale_safety_comment.rs
@@ -28,12 +28,6 @@ pub struct StaleSafetyComment {
 
 rustc_session::impl_lint_pass!(StaleSafetyComment => [STALE_SAFETY_COMMENT]);
 
-impl StaleSafetyComment {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// The `//` run directly above `span`, when it mentions SAFETY.
 fn safety_comment_above(
     cx: &LateContext<'_>,

--- a/src/stored_projection.rs
+++ b/src/stored_projection.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
@@ -9,6 +9,7 @@ use rustc_span::Symbol;
 use crate::MordantConfig;
 use crate::adt_facts::{has_fixed_repr, has_positional_fields};
 use crate::baseline::emit;
+use crate::enum_facts::ctor_literal_variant;
 use crate::hir_shapes::assigned_adt_field;
 
 rustc_session::declare_lint! {
@@ -132,28 +133,15 @@ fn peel<'tcx>(e: &'tcx Expr<'tcx>) -> &'tcx Expr<'tcx> {
 
 fn classify<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>) -> Option<Val> {
     let e = peel(e);
+    // `Some(x)`, `Wide(n)` — the variant is the fact, the payload is not.
+    if let Some(v) = ctor_literal_variant(cx, e) {
+        return Some(as_variant(v));
+    }
     match e.kind {
         ExprKind::Path(ref qpath) => match cx.qpath_res(qpath, e.hir_id) {
-            Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Const), did) => {
-                Some(as_variant(cx.tcx.parent(did)))
-            }
             Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did) => {
                 Some(as_named_const(did))
             }
-            _ => None,
-        },
-        // `Some(x)`, `Wide(n)` — the variant is the fact, the payload is not.
-        ExprKind::Call(f, _) => match f.kind {
-            ExprKind::Path(ref qpath) => match cx.qpath_res(qpath, f.hir_id) {
-                Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Fn), did) => {
-                    Some(as_variant(cx.tcx.parent(did)))
-                }
-                _ => None,
-            },
-            _ => None,
-        },
-        ExprKind::Struct(qpath, ..) => match cx.qpath_res(qpath, e.hir_id) {
-            Res::Def(DefKind::Variant, did) => Some(as_variant(did)),
             _ => None,
         },
         ExprKind::Lit(lit) => Some(Val::Lit(format!("{:?}", lit.node))),

--- a/src/stored_projection.rs
+++ b/src/stored_projection.rs
@@ -9,6 +9,7 @@ use rustc_span::Symbol;
 use crate::MordantConfig;
 use crate::adt_facts::{has_fixed_repr, has_positional_fields, struct_literal};
 use crate::baseline::emit;
+use crate::hir_shapes::assigned_adt_field;
 
 rustc_session::declare_lint! {
     /// Flags two fields of one type whose constant values agree one-for-one
@@ -164,21 +165,7 @@ impl StoredProjection {
     /// `s.f = …`, through any number of derefs and autoderefs: `f` of `s`'s
     /// struct is decided by more than its literals.
     fn note_assignment<'tcx>(&mut self, cx: &LateContext<'tcx>, place: &'tcx Expr<'tcx>) {
-        let mut place = place;
-        while let ExprKind::Unary(rustc_hir::UnOp::Deref, inner) | ExprKind::DropTemps(inner) =
-            place.kind
-        {
-            place = inner;
-        }
-        let ExprKind::Field(base, field) = place.kind else {
-            return;
-        };
-        let Some(adt) = cx
-            .typeck_results()
-            .expr_ty_adjusted(base)
-            .peel_refs()
-            .ty_adt_def()
-        else {
+        let Some((adt, field, _)) = assigned_adt_field(cx, place) else {
             return;
         };
         if !adt.is_struct() || !adt.did().is_local() {

--- a/src/stored_projection.rs
+++ b/src/stored_projection.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
@@ -66,30 +66,11 @@ struct Site {
 /// A `Variant` records *which* variant and never its payload: `Some(n)` and
 /// `Some(m)` are the same fact here, which is what makes an `Option` beside an
 /// enum legible as one correspondence rather than as many.
-///
-/// A definition is held as its `(krate, index)` pair because `DefId` is not
-/// `Ord` and the comparisons below need a total order. `local` travels beside
-/// it rather than being read back off `krate == 0`, which is an encoding
-/// detail.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 enum Val {
-    Variant { at: (u32, u32), local: bool },
-    NamedConst { at: (u32, u32), local: bool },
+    Variant(DefId),
+    NamedConst(DefId),
     Lit(String),
-}
-
-fn as_variant(d: DefId) -> Val {
-    Val::Variant {
-        at: (d.krate.as_u32(), d.index.as_u32()),
-        local: d.is_local(),
-    }
-}
-
-fn as_named_const(d: DefId) -> Val {
-    Val::NamedConst {
-        at: (d.krate.as_u32(), d.index.as_u32()),
-        local: d.is_local(),
-    }
 }
 
 impl Val {
@@ -117,8 +98,8 @@ impl Val {
     /// names a closed set of states, a sibling restates one of them, and the
     /// repair is a method on the enum — `Ceiling::limit()`, or folding the
     /// field into the variant as `Wide { remaining }`.
-    const fn decides(&self) -> bool {
-        matches!(self, Val::Variant { local: true, .. })
+    fn decides(&self) -> bool {
+        matches!(self, Val::Variant(d) if d.is_local())
     }
 }
 
@@ -135,12 +116,12 @@ fn classify<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'tcx>) -> Option<Val> {
     let e = peel(e);
     // `Some(x)`, `Wide(n)` — the variant is the fact, the payload is not.
     if let Some(v) = ctor_literal_variant(cx, e) {
-        return Some(as_variant(v));
+        return Some(Val::Variant(v));
     }
     match e.kind {
         ExprKind::Path(ref qpath) => match cx.qpath_res(qpath, e.hir_id) {
             Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, did) => {
-                Some(as_named_const(did))
+                Some(Val::NamedConst(did))
             }
             _ => None,
         },
@@ -232,8 +213,8 @@ impl<'tcx> LateLintPass<'tcx> for StoredProjection {
                     if !(va.iter().all(|v| v.decides()) || vb.iter().all(|v| v.decides())) {
                         continue;
                     }
-                    let da: BTreeSet<&&Val> = va.iter().collect();
-                    let db: BTreeSet<&&Val> = vb.iter().collect();
+                    let da: HashSet<&&Val> = va.iter().collect();
+                    let db: HashSet<&&Val> = vb.iter().collect();
                     // One distinct value on either side is a constant, not a
                     // correspondence.
                     if da.len() < 2 || db.len() < 2 {
@@ -266,8 +247,8 @@ impl<'tcx> LateLintPass<'tcx> for StoredProjection {
 /// Do `a` and `b` agree one-for-one — each value of one always beside the same
 /// value of the other, in both directions?
 fn bijective(a: &[&Val], b: &[&Val]) -> bool {
-    let mut fwd: BTreeMap<&Val, &Val> = BTreeMap::new();
-    let mut rev: BTreeMap<&Val, &Val> = BTreeMap::new();
+    let mut fwd: HashMap<&Val, &Val> = HashMap::new();
+    let mut rev: HashMap<&Val, &Val> = HashMap::new();
     for (x, y) in a.iter().zip(b.iter()) {
         if *fwd.entry(x).or_insert(y) != *y {
             return false;
@@ -281,10 +262,19 @@ fn bijective(a: &[&Val], b: &[&Val]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use rustc_hir::def_id::{CrateNum, DefId, DefIndex};
+
     use super::{Val, bijective};
 
     fn lit(s: &str) -> Val {
         Val::Lit(s.to_string())
+    }
+
+    fn def(krate: u32, index: u32) -> DefId {
+        DefId {
+            krate: CrateNum::from_u32(krate),
+            index: DefIndex::from_u32(index),
+        }
     }
 
     #[test]
@@ -322,30 +312,18 @@ mod tests {
     /// positive this lint was measured emitting before `decides` narrowed.
     #[test]
     fn a_named_constant_decides_nothing() {
-        let c = Val::NamedConst {
-            at: (0, 7),
-            local: true,
-        };
-        assert!(!c.decides());
+        assert!(!Val::NamedConst(def(0, 7)).decides());
     }
 
     /// A foreign variant is `Some`/`None`, which is `exclusive_options`' shape
     /// rather than this one.
     #[test]
     fn a_foreign_variant_decides_nothing() {
-        let v = Val::Variant {
-            at: (2, 7),
-            local: false,
-        };
-        assert!(!v.decides());
+        assert!(!Val::Variant(def(2, 7)).decides());
     }
 
     #[test]
     fn a_local_enum_variant_decides() {
-        let v = Val::Variant {
-            at: (0, 7),
-            local: true,
-        };
-        assert!(v.decides());
+        assert!(Val::Variant(def(0, 7)).decides());
     }
 }

--- a/src/stored_projection.rs
+++ b/src/stored_projection.rs
@@ -7,7 +7,7 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Symbol;
 
 use crate::MordantConfig;
-use crate::adt_facts::{has_fixed_repr, has_positional_fields, struct_literal};
+use crate::adt_facts::{has_fixed_repr, has_positional_fields};
 use crate::baseline::emit;
 use crate::hir_shapes::assigned_adt_field;
 
@@ -184,29 +184,31 @@ impl<'tcx> LateLintPass<'tcx> for StoredProjection {
             self.note_assignment(cx, place);
             return;
         }
-        let Some(lit) = struct_literal(cx, expr) else {
-            return;
-        };
         // A `..base` literal overrides part of a value that already exists, so
         // the fields written are the ones deliberately being made to differ.
-        if !matches!(lit.tail, StructTailExpr::None) {
+        let ExprKind::Struct(qpath, fields, StructTailExpr::None) = expr.kind else {
+            return;
+        };
+        // Typeck rather than the path, so an alias or `Self` resolves.
+        let Some(adt) = cx.typeck_results().expr_ty(expr).ty_adt_def() else {
+            return;
+        };
+        if !adt.did().is_local() {
             return;
         }
-        if !lit.adt.did().is_local() {
-            return;
-        }
+        let variant = adt.variant_of_res(cx.qpath_res(qpath, expr.hir_id));
         // A wire record legitimately restates what a sibling implies.
-        if has_fixed_repr(lit.adt) || has_positional_fields(lit.variant) {
+        if has_fixed_repr(adt) || has_positional_fields(variant) {
             return;
         }
         let mut vals = BTreeMap::new();
-        for f in lit.fields {
+        for f in fields {
             if let Some(v) = classify(cx, f.expr) {
                 vals.insert(f.ident.name, v);
             }
         }
         self.seen
-            .entry(lit.variant.def_id)
+            .entry(variant.def_id)
             .or_default()
             .push(Site { fields: vals });
     }

--- a/src/stored_projection.rs
+++ b/src/stored_projection.rs
@@ -10,7 +10,7 @@ use crate::MordantConfig;
 use crate::adt_facts::{has_fixed_repr, has_positional_fields};
 use crate::baseline::emit;
 use crate::enum_facts::ctor_literal_variant;
-use crate::hir_shapes::assigned_adt_field;
+use crate::hir_shapes::{assigned_adt_field, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
     /// Flags two fields of one type whose constant values agree one-for-one
@@ -124,9 +124,9 @@ impl Val {
 
 /// Strip the wrappers that do not change which value an expression names.
 fn peel<'tcx>(e: &'tcx Expr<'tcx>) -> &'tcx Expr<'tcx> {
+    let e = peel_blocks_unsafe(e);
     match e.kind {
-        ExprKind::AddrOf(_, _, inner) | ExprKind::DropTemps(inner) => peel(inner),
-        ExprKind::Block(b, None) if b.stmts.is_empty() => b.expr.map_or(e, peel),
+        ExprKind::AddrOf(_, _, inner) => peel(inner),
         _ => e,
     }
 }

--- a/src/stringified_error.rs
+++ b/src/stringified_error.rs
@@ -1,5 +1,6 @@
 use crate::adt_facts::result_err_ty;
 use crate::baseline::emit;
+use crate::hir_shapes::callee_of;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
@@ -69,7 +70,7 @@ impl<'tcx> LateLintPass<'tcx> for StringifiedError {
 
 /// The closure body is exactly `param.to_string()`, `String::from(param)`, or a
 /// `format!` invocation — a stringification and nothing else.
-fn closure_body_stringifies(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
+fn closure_body_stringifies<'tcx>(cx: &LateContext<'tcx>, body: &Expr<'tcx>) -> bool {
     // A `format!` body expands to a call, so the macro check runs first.
     let from_format = clippy_utils::macros::macro_backtrace(body.span)
         .next()
@@ -81,16 +82,9 @@ fn closure_body_stringifies(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
         ExprKind::MethodCall(seg, recv, [], _) => {
             seg.ident.as_str() == "to_string" && is_param(recv)
         }
-        ExprKind::Call(callee, [inner]) => {
-            let ExprKind::Path(qpath) = &callee.kind else {
-                return false;
-            };
-            let res = cx.typeck_results().qpath_res(qpath, callee.hir_id);
-            let Some(def_id) = res.opt_def_id() else {
-                return false;
-            };
-            cx.tcx.def_path_str(def_id) == "std::string::String::from" && is_param(inner)
-        }
+        ExprKind::Call(_, [inner]) => callee_of(cx, body).is_some_and(|c| {
+            cx.tcx.def_path_str(c.def()) == "std::string::String::from" && is_param(inner)
+        }),
         _ => false,
     }
 }

--- a/src/stringly_error.rs
+++ b/src/stringly_error.rs
@@ -20,18 +20,12 @@ rustc_session::declare_lint! {
 }
 
 pub struct StringlyError {
-    include_box_dyn: bool,
+    pub config: &'static MordantConfig,
 }
 
 rustc_session::impl_lint_pass!(StringlyError => [STRINGLY_ERROR]);
 
 impl StringlyError {
-    pub fn new(config: &MordantConfig) -> Self {
-        Self {
-            include_box_dyn: config.stringly_error_include_box_dyn,
-        }
-    }
-
     fn check_sig<'tcx>(&self, cx: &LateContext<'tcx>, def_id: LocalDefId, decl: &FnDecl<'tcx>) {
         if !cx.effective_visibilities.is_exported(def_id) {
             return;
@@ -62,7 +56,9 @@ impl StringlyError {
                 } else if cx.tcx.is_diagnostic_item(sym::Cow, adt.did()) && args.type_at(1).is_str()
                 {
                     Some("Cow<str>")
-                } else if self.include_box_dyn && adt.is_box() && is_dyn_error(cx, args.type_at(0))
+                } else if self.config.stringly_error_include_box_dyn
+                    && adt.is_box()
+                    && is_dyn_error(cx, args.type_at(0))
                 {
                     Some("Box<dyn Error>")
                 } else {

--- a/src/unchecked_input_len.rs
+++ b/src/unchecked_input_len.rs
@@ -251,37 +251,36 @@ fn mutably_lent<'tcx>(rvalue: &Rvalue<'tcx>) -> Option<Place<'tcx>> {
 
 impl<'a, 'tcx> Analysis<'a, 'tcx> {
     fn new(tcx: TyCtxt<'tcx>, body: &'a Body<'tcx>, range_patterns: Vec<Span>) -> Self {
-        // Every write to a local's own storage (the whole of it or a field),
-        // including lending it out mutably; a write through it (`(*q).len =
+        // Every place the body writes or lends out mutably.
+        let mut targets: Vec<Place<'tcx>> = Vec::new();
+        for data in body.basic_blocks.iter() {
+            for stmt in &data.statements {
+                match &stmt.kind {
+                    StatementKind::Assign(a) => {
+                        let (dest, rvalue) = &**a;
+                        targets.push(*dest);
+                        targets.extend(mutably_lent(rvalue));
+                    }
+                    StatementKind::SetDiscriminant { place, .. } => targets.push(**place),
+                    _ => {}
+                }
+            }
+            match &data.terminator().kind {
+                TerminatorKind::Call { destination, .. } => targets.push(*destination),
+                TerminatorKind::Yield { resume_arg, .. } => targets.push(*resume_arg),
+                _ => {}
+            }
+        }
+        // Writes to a local's own storage; a write through it (`(*q).len =
         // ..`) is a write to what it points at, which `collect_kills` charges
         // to the resolved place. Arguments carry one implicit write.
         let mut writes: IndexVec<Local, u32> = IndexVec::from_elem_n(0, body.local_decls.len());
         for l in body.args_iter() {
             writes[l] += 1;
         }
-        let mut written = |p: Place<'tcx>| {
+        for p in &targets {
             if !p.is_indirect() {
                 writes[p.local] += 1;
-            }
-        };
-        for data in body.basic_blocks.iter() {
-            for stmt in &data.statements {
-                match &stmt.kind {
-                    StatementKind::Assign(a) => {
-                        let (dest, rvalue) = &**a;
-                        written(*dest);
-                        if let Some(p) = mutably_lent(rvalue) {
-                            written(p);
-                        }
-                    }
-                    StatementKind::SetDiscriminant { place, .. } => written(**place),
-                    _ => {}
-                }
-            }
-            match &data.terminator().kind {
-                TerminatorKind::Call { destination, .. } => written(*destination),
-                TerminatorKind::Yield { resume_arg, .. } => written(*resume_arg),
-                _ => {}
             }
         }
 
@@ -327,40 +326,22 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
             seed_ids: HashMap::new(),
             taint: HashMap::new(),
         };
-        this.collect_kills();
+        this.collect_kills(targets);
         this
     }
 
     /// Writes and mutable borrows whose target, once aliases are resolved,
     /// lies under a parameter; plus the receiver itself.
-    fn collect_kills(&mut self) {
-        let mut targets: Vec<Place<'tcx>> = Vec::new();
-        for info in &self.body.var_debug_info {
-            if info.name == kw::SelfLower
-                && let VarDebugInfoContents::Place(p) = info.value
-            {
-                targets.push(p);
-            }
-        }
-        for data in self.body.basic_blocks.iter() {
-            for stmt in &data.statements {
-                match &stmt.kind {
-                    StatementKind::Assign(a) => {
-                        let (dest, rvalue) = &**a;
-                        targets.push(*dest);
-                        targets.extend(mutably_lent(rvalue));
-                    }
-                    StatementKind::SetDiscriminant { place, .. } => targets.push(**place),
-                    _ => {}
-                }
-            }
-            match &data.terminator().kind {
-                TerminatorKind::Call { destination, .. } => targets.push(*destination),
-                TerminatorKind::Yield { resume_arg, .. } => targets.push(*resume_arg),
-                _ => {}
-            }
-        }
-        for target in targets {
+    fn collect_kills(&mut self, targets: Vec<Place<'tcx>>) {
+        let receiver = self
+            .body
+            .var_debug_info
+            .iter()
+            .filter_map(|info| match info.value {
+                VarDebugInfoContents::Place(p) if info.name == kw::SelfLower => Some(p),
+                _ => None,
+            });
+        for target in receiver.chain(targets) {
             // A bare write to an alias local is the alias's own definition,
             // not a write to what it reads.
             if target.projection.is_empty() && self.aliases.contains_key(&target.local) {

--- a/src/unchecked_input_len.rs
+++ b/src/unchecked_input_len.rs
@@ -207,34 +207,19 @@ fn overlap(a: &[Step], b: &[Step]) -> bool {
 /// represents. An index or subslice ends the path inexactly: what was read is
 /// some part of the prefix.
 fn key_of(place: Place<'_>) -> (Key, bool) {
-    let mut path = Vec::new();
+    let mut key = Key {
+        local: place.local,
+        path: Vec::new(),
+    };
     for elem in place.projection.iter() {
         match elem {
             ProjectionElem::Deref => {}
-            ProjectionElem::Field(f, _) => path.push(Step::Field(f.as_u32())),
-            ProjectionElem::Downcast(_, v) => path.push(Step::Variant(v.as_u32())),
-            ProjectionElem::Index(_)
-            | ProjectionElem::ConstantIndex { .. }
-            | ProjectionElem::Subslice { .. }
-            | ProjectionElem::OpaqueCast(_)
-            | ProjectionElem::UnwrapUnsafeBinder(_) => {
-                return (
-                    Key {
-                        local: place.local,
-                        path,
-                    },
-                    false,
-                );
-            }
+            ProjectionElem::Field(f, _) => key.path.push(Step::Field(f.as_u32())),
+            ProjectionElem::Downcast(_, v) => key.path.push(Step::Variant(v.as_u32())),
+            _ => return (key, false),
         }
     }
-    (
-        Key {
-            local: place.local,
-            path,
-        },
-        true,
-    )
+    (key, true)
 }
 
 fn mutably_lent<'tcx>(rvalue: &Rvalue<'tcx>) -> Option<Place<'tcx>> {

--- a/src/unchecked_input_len.rs
+++ b/src/unchecked_input_len.rs
@@ -60,7 +60,7 @@ use rustc_span::symbol::kw;
 use rustc_span::{Span, Symbol};
 
 use crate::baseline::emit_with_note;
-use crate::mir_flow::{dominates, mir_for};
+use crate::mir_flow::mir_for;
 
 rustc_session::declare_lint! {
     /// Flags an integer the function received (a parameter other than
@@ -199,12 +199,8 @@ struct Analysis<'a, 'tcx> {
     taint: HashMap<Local, Vec<(Vec<Step>, Marks)>>,
 }
 
-fn is_prefix(short: &[Step], long: &[Step]) -> bool {
-    long.len() >= short.len() && short.iter().zip(long).all(|(a, b)| a == b)
-}
-
 fn overlap(a: &[Step], b: &[Step]) -> bool {
-    is_prefix(a, b) || is_prefix(b, a)
+    a.starts_with(b) || b.starts_with(a)
 }
 
 /// The field path of a place, and whether every projection was one the path
@@ -795,7 +791,7 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
                 continue;
             }
             let (k, exact) = key_of(p);
-            if exact && is_prefix(&k.path, &key.path) && best.is_none_or(|(d, _)| k.path.len() > d)
+            if exact && key.path.starts_with(&k.path) && best.is_none_or(|(d, _)| k.path.len() > d)
             {
                 best = Some((k.path.len(), info.name));
             }
@@ -1003,7 +999,10 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedInputLen {
                 };
                 // A sink is a call terminator and a check a switch terminator,
                 // so the two are never one block and plain dominance is exact.
-                if cs.iter().any(|(c, ..)| dominates(body, *c, sink.block)) {
+                if cs
+                    .iter()
+                    .any(|(c, ..)| dominators.dominates(*c, sink.block))
+                {
                     continue;
                 }
                 let Some(bound) = cs

--- a/src/unread_error_variant.rs
+++ b/src/unread_error_variant.rs
@@ -41,12 +41,6 @@ pub struct UnreadErrorVariant {
 
 rustc_session::impl_lint_pass!(UnreadErrorVariant => [UNREAD_ERROR_VARIANT]);
 
-impl UnreadErrorVariant {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// True when `hir_id` sits inside a TRAIT impl whose self type is `enum_did`.
 /// `Display`, `Debug`, `From` and derive expansions must match every variant
 /// to exist, so their patterns prove nothing. Inherent methods are not

--- a/src/unread_error_variant.rs
+++ b/src/unread_error_variant.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use rustc_hir::def_id::DefId;
-use rustc_hir::{BinOpKind, Expr, ExprKind, Pat, UnOp};
+use rustc_hir::{BinOpKind, Expr, ExprKind, Pat};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 
@@ -71,17 +71,6 @@ fn constructed_variant(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<(DefId, 
     Some((private_enum_of(cx, variant)?, variant))
 }
 
-fn peel_operand<'tcx>(mut e: &'tcx Expr<'tcx>) -> &'tcx Expr<'tcx> {
-    loop {
-        match e.kind {
-            ExprKind::AddrOf(_, _, inner)
-            | ExprKind::Unary(UnOp::Deref, inner)
-            | ExprKind::DropTemps(inner) => e = inner,
-            _ => return e,
-        }
-    }
-}
-
 impl<'tcx> LateLintPass<'tcx> for UnreadErrorVariant {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         match expr.kind {
@@ -91,7 +80,8 @@ impl<'tcx> LateLintPass<'tcx> for UnreadErrorVariant {
             // would.
             ExprKind::Binary(op, lhs, rhs) if matches!(op.node, BinOpKind::Eq | BinOpKind::Ne) => {
                 for side in [lhs, rhs] {
-                    if let Some((enum_did, variant)) = constructed_variant(cx, peel_operand(side))
+                    if let Some((enum_did, variant)) =
+                        constructed_variant(cx, clippy_utils::peel_ref_operators(cx, side))
                         && !inside_own_trait_impl(cx, expr.hir_id, enum_did)
                     {
                         self.enums

--- a/src/unread_none.rs
+++ b/src/unread_none.rs
@@ -34,12 +34,6 @@ pub struct UnreadNone {
 
 rustc_session::impl_lint_pass!(UnreadNone => [UNREAD_NONE]);
 
-impl UnreadNone {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// The crate-private local struct owning this field access, when the field is
 /// an `Option`.
 fn option_field_of<'tcx>(

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -11,6 +11,7 @@ use rustc_span::Span;
 use crate::MordantConfig;
 use crate::baseline::emit_hir_then;
 use crate::enum_facts::{pat_head_qpath, variant_of_res};
+use crate::hir_shapes::peel_blocks_unsafe;
 
 rustc_session::declare_lint! {
     /// Flags `_` (or a catch-all binding) matching over a small crate-local
@@ -93,14 +94,7 @@ fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
 /// the dispatch on; the inner match is where the variants are or are not
 /// listed, and this lint judges it on its own.
 fn redispatches(body: &Expr<'_>, binding: HirId) -> bool {
-    let mut body = body;
-    while let ExprKind::Block(block, None) = body.kind
-        && block.stmts.is_empty()
-        && let Some(tail) = block.expr
-    {
-        body = tail;
-    }
-    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = body.kind else {
+    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = peel_blocks_unsafe(body).kind else {
         return false;
     };
     while let ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) = scrut.kind {

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -3,7 +3,7 @@ use clippy_utils::source::snippet_opt;
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Arm, Expr, ExprKind, HirId, MatchSource, Pat, PatKind, StmtKind, UnOp};
+use rustc_hir::{Arm, Expr, ExprKind, HirId, MatchSource, Pat, PatKind, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
@@ -79,14 +79,11 @@ fn is_negative_extractor<'tcx>(cx: &LateContext<'tcx>, body: &Expr<'tcx>) -> boo
 /// A binding arm whose whole body is another `match` on the binding passes
 /// the dispatch on; the inner match is where the variants are or are not
 /// listed, and this lint judges it on its own.
-fn redispatches(body: &Expr<'_>, binding: HirId) -> bool {
-    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = peel_blocks_unsafe(body).kind else {
+fn redispatches(cx: &LateContext<'_>, body: &Expr<'_>, binding: HirId) -> bool {
+    let ExprKind::Match(scrut, _, MatchSource::Normal) = peel_blocks_unsafe(body).kind else {
         return false;
     };
-    while let ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) = scrut.kind {
-        scrut = inner;
-    }
-    scrut.res_local_id() == Some(binding)
+    clippy_utils::peel_ref_operators(cx, scrut).res_local_id() == Some(binding)
 }
 
 /// Every variant the non-catch-all arms cover, or None when an arm's shape is
@@ -193,7 +190,7 @@ impl<'tcx> LateLintPass<'tcx> for WildcardLocalEnum {
             if is_negative_extractor(cx, arm.body) {
                 continue;
             }
-            if binding.is_some_and(|b| redispatches(arm.body, b)) {
+            if binding.is_some_and(|b| redispatches(cx, arm.body, b)) {
                 continue;
             }
             // The fix replaces the catch-all with the uncovered variants,

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -1,9 +1,10 @@
+use clippy_utils::peel_blocks;
+use clippy_utils::res::MaybeResPath;
 use clippy_utils::source::snippet_opt;
 use rustc_ast::LitKind;
 use rustc_errors::Applicability;
-use rustc_hir::def::Res;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Arm, Expr, ExprKind, HirId, MatchSource, Pat, PatKind, QPath, StmtKind, UnOp};
+use rustc_hir::{Arm, Expr, ExprKind, HirId, MatchSource, Pat, PatKind, StmtKind, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
@@ -93,23 +94,13 @@ fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
 /// the dispatch on; the inner match is where the variants are or are not
 /// listed, and this lint judges it on its own.
 fn redispatches(body: &Expr<'_>, binding: HirId) -> bool {
-    let mut body = body;
-    while let ExprKind::Block(block, None) = body.kind
-        && block.stmts.is_empty()
-        && let Some(tail) = block.expr
-    {
-        body = tail;
-    }
-    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = body.kind else {
+    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = peel_blocks(body).kind else {
         return false;
     };
     while let ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) = scrut.kind {
         scrut = inner;
     }
-    matches!(
-        scrut.kind,
-        ExprKind::Path(QPath::Resolved(None, path)) if path.res == Res::Local(binding)
-    )
+    scrut.res_local_id() == Some(binding)
 }
 
 /// Every variant the non-catch-all arms cover, or None when an arm's shape is

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -11,7 +11,7 @@ use rustc_span::Span;
 use crate::MordantConfig;
 use crate::baseline::emit_hir_then;
 use crate::enum_facts::{pat_head_qpath, variant_of_res};
-use crate::hir_shapes::peel_blocks_unsafe;
+use crate::hir_shapes::{callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
     /// Flags `_` (or a catch-all binding) matching over a small crate-local

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -1,4 +1,3 @@
-use clippy_utils::peel_blocks;
 use clippy_utils::res::MaybeResPath;
 use clippy_utils::source::snippet_opt;
 use rustc_ast::LitKind;
@@ -94,7 +93,14 @@ fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
 /// the dispatch on; the inner match is where the variants are or are not
 /// listed, and this lint judges it on its own.
 fn redispatches(body: &Expr<'_>, binding: HirId) -> bool {
-    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = peel_blocks(body).kind else {
+    let mut body = body;
+    while let ExprKind::Block(block, None) = body.kind
+        && block.stmts.is_empty()
+        && let Some(tail) = block.expr
+    {
+        body = tail;
+    }
+    let ExprKind::Match(mut scrut, _, MatchSource::Normal) = body.kind else {
         return false;
     };
     while let ExprKind::AddrOf(_, _, inner) | ExprKind::Unary(UnOp::Deref, inner) = scrut.kind {

--- a/src/wildcard_local_enum.rs
+++ b/src/wildcard_local_enum.rs
@@ -30,20 +30,12 @@ rustc_session::declare_lint! {
 }
 
 pub struct WildcardLocalEnum {
-    max_variants: usize,
+    pub config: &'static MordantConfig,
 }
 
 rustc_session::impl_lint_pass!(WildcardLocalEnum => [WILDCARD_LOCAL_ENUM]);
 
-impl WildcardLocalEnum {
-    pub fn new(config: &MordantConfig) -> Self {
-        Self {
-            max_variants: config.wildcard_local_enum_max_variants,
-        }
-    }
-}
-
-fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
+fn is_negative_extractor<'tcx>(cx: &LateContext<'tcx>, body: &Expr<'tcx>) -> bool {
     match body.kind {
         // `""` and `b""` are the empty-slice answer spelled as a literal.
         ExprKind::Lit(lit) => match lit.node {
@@ -58,18 +50,12 @@ fn is_negative_extractor(cx: &LateContext<'_>, body: &Expr<'_>) -> bool {
         ExprKind::Array(elems) => elems.is_empty(),
         // `Vec::new()` / `String::new()`: an empty collection, constructed
         // fresh, is an answer with no content, not behavior.
-        ExprKind::Call(callee, []) => {
-            if let ExprKind::Path(qpath) = &callee.kind
-                && let Some(def) = cx.qpath_res(qpath, callee.hir_id).opt_def_id()
-            {
-                let path = cx.tcx.def_path_str(def);
-                path.ends_with("Vec::<T>::new")
-                    || path.ends_with("Vec::new")
-                    || path.ends_with("String::new")
-            } else {
-                false
-            }
-        }
+        ExprKind::Call(_, []) => callee_of(cx, body).is_some_and(|c| {
+            let path = cx.tcx.def_path_str(c.def());
+            path.ends_with("Vec::<T>::new")
+                || path.ends_with("Vec::new")
+                || path.ends_with("String::new")
+        }),
         // `return None` / `return false`: the early-exit spelling of the same
         // empty answers.
         ExprKind::Ret(Some(inner)) => is_negative_extractor(cx, inner),
@@ -189,7 +175,7 @@ impl<'tcx> LateLintPass<'tcx> for WildcardLocalEnum {
         // every match the lint sees, and it silenced the lint on exactly the
         // enums annotated *because* the author expects new variants.
         let n = adt.variants().len();
-        if n > self.max_variants {
+        if n > self.config.wildcard_local_enum_max_variants {
             return;
         }
         for arm in arms {

--- a/ui/lock_order.rs
+++ b/ui/lock_order.rs
@@ -103,6 +103,31 @@ impl Deferred {
     }
 }
 
+struct Spin {
+    g: Mutex<u32>,
+    h: Mutex<u32>,
+}
+
+impl Spin {
+    fn gh(&self) -> u32 {
+        let gg = self.g.lock().unwrap();
+        let gh = self.h.lock().unwrap();
+        *gg + *gh
+    }
+
+    // Flagged together with `gh`: the reverse order sits directly in a
+    // `loop {}` body, which is a block of its own.
+    fn hg_in_loop(&self) -> u32 {
+        loop {
+            let gh = self.h.lock().unwrap();
+            let gg = self.g.lock().unwrap();
+            if *gg > 0 {
+                return *gg + *gh;
+            }
+        }
+    }
+}
+
 fn main() {
     let s = S {
         a: Mutex::new(1),
@@ -128,4 +153,9 @@ fn main() {
         f: Mutex::new(10),
     };
     let _ = d.ef() + d.fe_later();
+    let sp = Spin {
+        g: Mutex::new(11),
+        h: Mutex::new(12),
+    };
+    let _ = sp.gh() + sp.hg_in_loop();
 }

--- a/ui/lock_order.stderr
+++ b/ui/lock_order.stderr
@@ -7,5 +7,13 @@ LL |         let gb = self.b.lock().unwrap();
    = help: both orders existing is the shape of a deadlock; pick one order and hold to it everywhere
    = note: `#[warn(lock_order)]` on by default
 
-warning: 1 warning emitted
+warning: `g` is locked before `h` here, but `h` before `g` at $DIR/lock_order.rs:123:22: 123:35
+  --> $DIR/lock_order.rs:114:18
+   |
+LL |         let gh = self.h.lock().unwrap();
+   |                  ^^^^^^^^^^^^^
+   |
+   = help: both orders existing is the shape of a deadlock; pick one order and hold to it everywhere
+
+warning: 2 warnings emitted
 


### PR DESCRIPTION
Thirty-seven small commits, each green on its own. About 620 lines of src/ go away: the lints that read assignment targets, walked field chains, peeled blocks, resolved callees or matched config paths by hand now go through one helper each in hir_shapes / adt_facts / enum_facts, several hand-rolled bits give way to what rustc and clippy_utils already provide, and the config derives its Default.

Everything reports what it did before with one exception: lock_order moved to scanning blocks and now also sees a reversed order inside a loop body (fixture case added; the existing findings are unchanged).