### PR TITLE
Run under a ratchet without a wrapper: disabled lints, deny-proof baseline findings, a count for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Configure per project in `dylint.toml` at the workspace root:
 
 ```toml
 [mordant]
+# Lints this project does not want, by name. A disabled lint never runs, but
+# it stays registered, so an `#[allow(guard_flag)]` left in the code still
+# resolves instead of tripping `unknown_lints`. A name that matches no lint
+# gets a warning naming it, not an error.
+disabled = ["guard_flag", "unit_mismatch"]
+
 nonidentity-key-types = ["my_crate::span::Span"]
 nonidentity-key-forms = ["ptr-cast"]
 nonidentity-key-methods = ["my_crate::value::Value::to_bits"]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Run the lints:
 cargo dylint --all
 ```
 
+Findings are warnings, so a workspace that denies warnings (`[workspace.lints.rust] warnings = "deny"`, `RUSTFLAGS=-Dwarnings`) turns the first one in a crate into an error and never sees the rest. Run under a baseline instead (see [Ratchet](#ratchet)): with one configured, mordant reports new findings as warnings that no lint level can raise, and such a workspace needs no extra flags.
+
 Some lints carry machine-applicable fixes. `wildcard_local_enum` rewrites each catch-all arm into the variants it was hiding, in the same path style the file already uses:
 
 ```sh
@@ -172,7 +174,17 @@ Generate or regenerate it:
 MORDANT_BASELINE_WRITE=1 cargo dylint --all
 ```
 
-The file records a count per lint and file. A run suppresses that many findings and reports anything beyond them, so new problems surface while the existing ones stay recorded. When you fix a finding, regenerate and commit the file; the count falls and stays down.
+The file records a count per lint and file. A run suppresses that many findings and reports anything beyond them, so new problems surface while the existing ones stay recorded. When you fix a finding, regenerate and commit the file; the count falls and stays down. Findings under an `#[allow]` or `#[expect]` are neither recorded nor counted.
+
+With a baseline configured, the baseline decides what fails the run, not the lint level. A finding over the recorded count is printed as a plain warning naming its lint (`` `guard_flag` over the mordant baseline (2 recorded for src/sched.rs) ``), which `-D warnings`, `[lints] warnings = "deny"` and `--cap-lints` leave alone, so one new finding cannot stop its crate and hide the findings after it or in the crates that depend on it. Each crate that goes over prints `warning: mordant: N finding(s) over the baseline in <crate>` and appends `<crate> <N>` to `target/mordant/over-baseline.txt` (under `CARGO_TARGET_DIR` when that is set, otherwise `target/` beside the baseline file). A clean run writes nothing there, and neither does a `MORDANT_BASELINE_WRITE=1` run. Every crate is a separate compiler process, so none of them can truncate the file first; remove it before the run and test it afterwards:
+
+```sh
+rm -f target/mordant/over-baseline.txt
+cargo dylint --all --workspace -- --keep-going
+test ! -s target/mordant/over-baseline.txt
+```
+
+The last line is the gate: it fails when any crate went over, and the file lists which.
 
 ## Name
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -18,8 +18,10 @@
 //! lint, so `-D warnings`, `[lints] warnings = "deny"` and `--cap-lints`
 //! cannot turn it into an error that stops the crate and hides every finding
 //! after it. `#[allow]` and `#[expect]` are still read, at the same node the
-//! lint path reads them. Without a baseline nothing here applies and findings
-//! are ordinary lints at their ordinary levels.
+//! lint path reads them. Each crate that goes over prints one summary line and
+//! appends itself to `target/mordant/over-baseline.txt`, which is the file CI
+//! tests. Without a baseline nothing here applies and findings are ordinary
+//! lints at their ordinary levels.
 //!
 //! Every diagnostic a mordant lint produces goes through one of the three
 //! entry points here (`emit`, `emit_with_note`, `emit_hir_then`), so each
@@ -27,8 +29,10 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then, span_lint_hir_and_then};
@@ -50,6 +54,10 @@ enum Mode {
         recorded: HashMap<Key, usize>,
         /// Findings weighed so far this run, per key.
         seen: Mutex<HashMap<Key, usize>>,
+        /// Over-baseline findings reported (not allowed away) in this crate.
+        over: AtomicUsize,
+        /// Where a crate that went over appends its name and count.
+        status_file: PathBuf,
     },
     /// Emit nothing; collect every finding and rewrite this crate's section of
     /// the file at `path` from `BaselineWriter::check_crate_post`.
@@ -102,6 +110,8 @@ fn init(file_name: &str) -> Option<Baseline> {
                 Mode::Ratchet {
                     recorded: read_recorded(&cand),
                     seen: Mutex::new(HashMap::new()),
+                    over: AtomicUsize::new(0),
+                    status_file: status_file(&dir, std::env::var_os("CARGO_TARGET_DIR")),
                 }
             };
             return Some(Baseline { root: dir, mode });
@@ -110,6 +120,16 @@ fn init(file_name: &str) -> Option<Baseline> {
             return None;
         }
     }
+}
+
+/// `${CARGO_TARGET_DIR or <root>/target}/mordant/over-baseline.txt`, a
+/// relative `CARGO_TARGET_DIR` taken from the workspace root as cargo does.
+fn status_file(root: &Path, target_dir: Option<OsString>) -> PathBuf {
+    let target = match target_dir {
+        Some(dir) if !dir.is_empty() => root.join(dir),
+        _ => root.join("target"),
+    };
+    target.join("mordant").join("over-baseline.txt")
 }
 
 /// Sums every crate section of the file, since a (lint, file) key can appear
@@ -155,6 +175,7 @@ struct Over {
     lint: &'static Lint,
     recorded: usize,
     file: String,
+    count: &'static AtomicUsize,
 }
 
 impl Over {
@@ -165,6 +186,7 @@ impl Over {
         msg: String,
         decorate: impl FnOnce(&mut Diag<'_, ()>),
     ) {
+        self.count.fetch_add(1, Ordering::Relaxed);
         let mut diag = cx.tcx.dcx().struct_span_warn(span, msg);
         decorate(&mut diag);
         diag.note(format!(
@@ -204,7 +226,12 @@ fn weigh(cx: &LateContext<'_>, lint: &'static Lint, span: Span, hir_id: HirId) -
             recorded.lock().unwrap().push(key);
             Verdict::Silent
         }
-        Mode::Ratchet { recorded, seen } => {
+        Mode::Ratchet {
+            recorded,
+            seen,
+            over,
+            ..
+        } => {
             let limit = recorded.get(&key).copied().unwrap_or(0);
             let within = {
                 let mut seen = seen.lock().unwrap();
@@ -219,6 +246,7 @@ fn weigh(cx: &LateContext<'_>, lint: &'static Lint, span: Span, hir_id: HirId) -
                 lint,
                 recorded: limit,
                 file: key.1,
+                count: over,
             })
         }
     }
@@ -295,20 +323,54 @@ fn section_name(cx: &LateContext<'_>) -> String {
 }
 
 // Registered last: flushes write-mode recordings for this crate into the
-// baseline file, replacing only this crate's section. It declares no lint of
-// its own; rustc always runs a lintless pass, so nothing can `allow` it away.
+// baseline file, replacing only this crate's section, or in ratchet mode
+// prints the crate's over-baseline summary. It declares no lint of its own;
+// rustc always runs a lintless pass, so nothing can `allow` it away.
 rustc_session::declare_lint_pass!(BaselineWriter => []);
 
 impl<'tcx> LateLintPass<'tcx> for BaselineWriter {
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        if let Some(Baseline {
-            mode: Mode::Record { path, recorded },
-            ..
-        }) = state()
-        {
-            write_section(cx, path, recorded);
+        match state() {
+            None => {}
+            Some(Baseline {
+                mode: Mode::Ratchet {
+                    over, status_file, ..
+                },
+                ..
+            }) => summarize(cx, over.load(Ordering::Relaxed), status_file),
+            Some(Baseline {
+                mode: Mode::Record { path, recorded },
+                ..
+            }) => write_section(cx, path, recorded),
         }
     }
+}
+
+/// One line for the reader and one for CI. The status file is appended to,
+/// never truncated: every crate is its own rustc process, so no process knows
+/// it is the first. CI removes the file before the run and tests it is empty
+/// or absent after.
+fn summarize(cx: &LateContext<'_>, over: usize, status_file: &Path) {
+    if over == 0 {
+        return;
+    }
+    let name = section_name(cx);
+    cx.tcx.dcx().warn(format!(
+        "mordant: {over} finding(s) over the baseline in {name}"
+    ));
+    if let Some(dir) = status_file.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(status_file)
+    else {
+        return;
+    };
+    let _ = f.lock();
+    let _ = f.write_all(format!("{name} {over}\n").as_bytes());
+    let _ = f.unlock();
 }
 
 fn write_section(cx: &LateContext<'_>, path: &Path, recorded: &Mutex<Vec<Key>>) {
@@ -346,4 +408,35 @@ fn write_section(cx: &LateContext<'_>, path: &Path, recorded: &Mutex<Vec<Key>>) 
         let _ = f.write_all(out.as_bytes());
     }
     let _ = f.unlock();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::status_file;
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn status_file_defaults_to_target_under_the_workspace_root() {
+        assert_eq!(
+            status_file(Path::new("/ws"), None),
+            PathBuf::from("/ws/target/mordant/over-baseline.txt"),
+        );
+        assert_eq!(
+            status_file(Path::new("/ws"), Some(OsString::new())),
+            PathBuf::from("/ws/target/mordant/over-baseline.txt"),
+        );
+    }
+
+    #[test]
+    fn status_file_follows_cargo_target_dir() {
+        assert_eq!(
+            status_file(Path::new("/ws"), Some("/elsewhere/tgt".into())),
+            PathBuf::from("/elsewhere/tgt/mordant/over-baseline.txt"),
+        );
+        assert_eq!(
+            status_file(Path::new("/ws"), Some("build/cargo".into())),
+            PathBuf::from("/ws/build/cargo/mordant/over-baseline.txt"),
+        );
+    }
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -29,7 +29,6 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::ffi::OsString;
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -111,7 +110,7 @@ fn init(file_name: &str) -> Option<Baseline> {
                     recorded: read_recorded(&cand),
                     seen: Mutex::new(HashMap::new()),
                     over: AtomicUsize::new(0),
-                    status_file: status_file(&dir, std::env::var_os("CARGO_TARGET_DIR")),
+                    status_file: status_file(&dir, cargo_target_dir().as_deref()),
                 }
             };
             return Some(Baseline { root: dir, mode });
@@ -122,12 +121,20 @@ fn init(file_name: &str) -> Option<Baseline> {
     }
 }
 
+/// `CARGO_TARGET_DIR` when it names a directory; cargo treats an empty
+/// value as unset, so that is `None` here too.
+fn cargo_target_dir() -> Option<PathBuf> {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .filter(|d| !d.is_empty())
+        .map(PathBuf::from)
+}
+
 /// `${CARGO_TARGET_DIR or <root>/target}/mordant/over-baseline.txt`, a
 /// relative `CARGO_TARGET_DIR` taken from the workspace root as cargo does.
-fn status_file(root: &Path, target_dir: Option<OsString>) -> PathBuf {
+fn status_file(root: &Path, target_dir: Option<&Path>) -> PathBuf {
     let target = match target_dir {
-        Some(dir) if !dir.is_empty() => root.join(dir),
-        _ => root.join("target"),
+        Some(dir) => root.join(dir),
+        None => root.join("target"),
     };
     target.join("mordant").join("over-baseline.txt")
 }
@@ -413,7 +420,6 @@ fn write_section(cx: &LateContext<'_>, path: &Path, recorded: &Mutex<Vec<Key>>) 
 #[cfg(test)]
 mod tests {
     use super::status_file;
-    use std::ffi::OsString;
     use std::path::{Path, PathBuf};
 
     #[test]
@@ -422,20 +428,16 @@ mod tests {
             status_file(Path::new("/ws"), None),
             PathBuf::from("/ws/target/mordant/over-baseline.txt"),
         );
-        assert_eq!(
-            status_file(Path::new("/ws"), Some(OsString::new())),
-            PathBuf::from("/ws/target/mordant/over-baseline.txt"),
-        );
     }
 
     #[test]
     fn status_file_follows_cargo_target_dir() {
         assert_eq!(
-            status_file(Path::new("/ws"), Some("/elsewhere/tgt".into())),
+            status_file(Path::new("/ws"), Some(Path::new("/elsewhere/tgt"))),
             PathBuf::from("/elsewhere/tgt/mordant/over-baseline.txt"),
         );
         assert_eq!(
-            status_file(Path::new("/ws"), Some("build/cargo".into())),
+            status_file(Path::new("/ws"), Some(Path::new("build/cargo"))),
             PathBuf::from("/ws/build/cargo/mordant/over-baseline.txt"),
         );
     }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -12,6 +12,15 @@
 //! files consumes allowance in one file and overflows in the other, which is
 //! the desired ratchet behavior.
 //!
+//! Severity: with a baseline configured, the baseline decides what fails the
+//! run, not the lint level. A finding over the recorded count is printed as a
+//! plain warning through the session's diagnostic context rather than as a
+//! lint, so `-D warnings`, `[lints] warnings = "deny"` and `--cap-lints`
+//! cannot turn it into an error that stops the crate and hides every finding
+//! after it. `#[allow]` and `#[expect]` are still read, at the same node the
+//! lint path reads them. Without a baseline nothing here applies and findings
+//! are ordinary lints at their ordinary levels.
+//!
 //! Every diagnostic a mordant lint produces goes through one of the three
 //! entry points here (`emit`, `emit_with_note`, `emit_hir_then`), so each
 //! finding is weighed against the baseline exactly once.
@@ -25,7 +34,7 @@ use std::sync::{Mutex, OnceLock};
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then, span_lint_hir_and_then};
 use rustc_errors::Diag;
 use rustc_hir::HirId;
-use rustc_lint::{LateContext, LateLintPass, Lint};
+use rustc_lint::{LateContext, LateLintPass, Lint, LintContext};
 use rustc_span::{FileName, Span};
 
 /// (lint, file relative to the workspace root): the unit the baseline counts.
@@ -35,10 +44,12 @@ type Key = (String, String);
 /// `setup`, since the environment variable that selects it cannot change
 /// while rustc is running.
 enum Mode {
-    /// Consume the accepted count for each key and let the overflow through.
+    /// Stay silent up to the recorded count for each key and report the
+    /// overflow as warnings.
     Ratchet {
-        /// Remaining suppressions this run.
-        allowance: Mutex<HashMap<Key, usize>>,
+        recorded: HashMap<Key, usize>,
+        /// Findings weighed so far this run, per key.
+        seen: Mutex<HashMap<Key, usize>>,
     },
     /// Emit nothing; collect every finding and rewrite this crate's section of
     /// the file at `path` from `BaselineWriter::check_crate_post`.
@@ -54,6 +65,10 @@ pub struct Baseline {
 }
 
 static STATE: OnceLock<Option<Baseline>> = OnceLock::new();
+
+fn state() -> Option<&'static Baseline> {
+    STATE.get().and_then(Option::as_ref)
+}
 
 fn write_mode() -> bool {
     std::env::var_os("MORDANT_BASELINE_WRITE").is_some()
@@ -85,7 +100,8 @@ fn init(file_name: &str) -> Option<Baseline> {
                 }
             } else {
                 Mode::Ratchet {
-                    allowance: Mutex::new(read_allowance(&cand)),
+                    recorded: read_recorded(&cand),
+                    seen: Mutex::new(HashMap::new()),
                 }
             };
             return Some(Baseline { root: dir, mode });
@@ -98,7 +114,7 @@ fn init(file_name: &str) -> Option<Baseline> {
 
 /// Sums every crate section of the file, since a (lint, file) key can appear
 /// under more than one crate (a file shared by a lib and a bin target).
-fn read_allowance(path: &Path) -> HashMap<Key, usize> {
+fn read_recorded(path: &Path) -> HashMap<Key, usize> {
     let doc = std::fs::read_to_string(path)
         .map(|s| read_doc(&s))
         .unwrap_or_default();
@@ -124,29 +140,87 @@ fn rel_file(cx: &LateContext<'_>, b: &Baseline, span: Span) -> Option<String> {
     Some(rel.to_string_lossy().into_owned())
 }
 
-/// True when this finding is consumed by the baseline (or recorded, in write
-/// mode) and must not be emitted. Consumes one unit of allowance, so each
-/// finding must pass through here exactly once.
-fn suppressed(cx: &LateContext<'_>, lint: &'static Lint, span: Span) -> bool {
-    let Some(Some(b)) = STATE.get().map(Option::as_ref) else {
-        return false;
+/// What the baseline decided about one finding.
+enum Verdict {
+    /// No baseline governs it: an ordinary lint at its ordinary level.
+    Lint,
+    /// Allowed or expected at its node, recorded in write mode, or within
+    /// the recorded count: nothing is printed.
+    Silent,
+    /// Over the recorded count: printed as a warning no lint level can raise.
+    Over(Over),
+}
+
+struct Over {
+    lint: &'static Lint,
+    recorded: usize,
+    file: String,
+}
+
+impl Over {
+    fn report(
+        self,
+        cx: &LateContext<'_>,
+        span: Span,
+        msg: String,
+        decorate: impl FnOnce(&mut Diag<'_, ()>),
+    ) {
+        let mut diag = cx.tcx.dcx().struct_span_warn(span, msg);
+        decorate(&mut diag);
+        diag.note(format!(
+            "`{}` over the mordant baseline ({} recorded for {})",
+            self.lint.name_lower(),
+            self.recorded,
+            self.file,
+        ));
+        diag.emit();
+    }
+}
+
+/// Weighs one finding against the baseline; each finding must pass through
+/// here exactly once, since it counts. `hir_id` is the node the lint path
+/// would read the level at, so the baseline honours exactly the `#[allow]` /
+/// `#[expect]` the lint would have: a finding allowed there prints nothing
+/// without a baseline, so it is neither recorded nor counted with one, and
+/// an expectation there is fulfilled whatever the count says, as the lint did
+/// fire under it.
+fn weigh(cx: &LateContext<'_>, lint: &'static Lint, span: Span, hir_id: HirId) -> Verdict {
+    let Some(b) = state() else {
+        return Verdict::Lint;
     };
     let Some(file) = rel_file(cx, b, span) else {
-        return false;
+        return Verdict::Lint;
     };
+    let spec = cx.tcx.lint_level_spec_at_node(lint, hir_id);
+    if let Some(expectation) = spec.lint_id() {
+        cx.fulfill_expectation(expectation);
+    }
+    if spec.is_allow() || spec.is_expect() || span.in_external_macro(cx.tcx.sess.source_map()) {
+        return Verdict::Silent;
+    }
     let key = (lint.name_lower(), file);
     match &b.mode {
         Mode::Record { recorded, .. } => {
             recorded.lock().unwrap().push(key);
-            true
+            Verdict::Silent
         }
-        Mode::Ratchet { allowance } => match allowance.lock().unwrap().get_mut(&key) {
-            Some(n) if *n > 0 => {
-                *n -= 1;
-                true
+        Mode::Ratchet { recorded, seen } => {
+            let limit = recorded.get(&key).copied().unwrap_or(0);
+            let within = {
+                let mut seen = seen.lock().unwrap();
+                let n = seen.entry(key.clone()).or_default();
+                *n += 1;
+                *n <= limit
+            };
+            if within {
+                return Verdict::Silent;
             }
-            _ => false,
-        },
+            Verdict::Over(Over {
+                lint,
+                recorded: limit,
+                file: key.1,
+            })
+        }
     }
 }
 
@@ -158,10 +232,13 @@ pub fn emit(
     msg: impl Into<String>,
     help: &'static str,
 ) {
-    if suppressed(cx, lint, span) {
-        return;
+    match weigh(cx, lint, span, cx.last_node_with_lint_attrs) {
+        Verdict::Silent => {}
+        Verdict::Lint => span_lint_and_help(cx, lint, span, msg.into(), None, help),
+        Verdict::Over(over) => over.report(cx, span, msg.into(), |diag| {
+            diag.help(help);
+        }),
     }
-    span_lint_and_help(cx, lint, span, msg.into(), None, help);
 }
 
 /// `emit` with a secondary span: the finding is at `span`, the evidence for
@@ -175,13 +252,15 @@ pub fn emit_with_note(
     note: &'static str,
     help: &'static str,
 ) {
-    if suppressed(cx, lint, span) {
-        return;
-    }
-    span_lint_and_then(cx, lint, span, msg.into(), |diag| {
+    let decorate = |diag: &mut Diag<'_, ()>| {
         diag.span_note(note_span, note);
         diag.help(help);
-    });
+    };
+    match weigh(cx, lint, span, cx.last_node_with_lint_attrs) {
+        Verdict::Silent => {}
+        Verdict::Lint => span_lint_and_then(cx, lint, span, msg.into(), decorate),
+        Verdict::Over(over) => over.report(cx, span, msg.into(), decorate),
+    }
 }
 
 /// `emit` for a finding whose lint level is read at `hir_id` rather than at
@@ -195,10 +274,24 @@ pub fn emit_hir_then(
     msg: impl Into<String>,
     decorate: impl FnOnce(&mut Diag<'_, ()>),
 ) {
-    if suppressed(cx, lint, span) {
-        return;
+    match weigh(cx, lint, span, hir_id) {
+        Verdict::Silent => {}
+        Verdict::Lint => span_lint_hir_and_then(cx, lint, hir_id, span, msg.into(), decorate),
+        Verdict::Over(over) => over.report(cx, span, msg.into(), decorate),
     }
-    span_lint_hir_and_then(cx, lint, hir_id, span, msg.into(), decorate);
+}
+
+/// The baseline section name for this compilation: the crate, with the bin
+/// target appended, since one crate name can cover a lib and several bins.
+fn section_name(cx: &LateContext<'_>) -> String {
+    let name = cx
+        .tcx
+        .crate_name(rustc_hir::def_id::LOCAL_CRATE)
+        .to_string();
+    match std::env::var_os("CARGO_BIN_NAME") {
+        Some(bin) => format!("{name} (bin {})", bin.to_string_lossy()),
+        None => name,
+    }
 }
 
 // Registered last: flushes write-mode recordings for this crate into the
@@ -208,54 +301,49 @@ rustc_session::declare_lint_pass!(BaselineWriter => []);
 
 impl<'tcx> LateLintPass<'tcx> for BaselineWriter {
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let Some(Some(Baseline {
+        if let Some(Baseline {
             mode: Mode::Record { path, recorded },
             ..
-        })) = STATE.get().map(Option::as_ref)
-        else {
-            return;
-        };
-        let recorded: Vec<Key> = std::mem::take(&mut *recorded.lock().unwrap());
-        let mut section: BTreeMap<String, u64> = BTreeMap::new();
-        for (lint, file) in recorded {
-            *section.entry(format!("{lint}:{file}")).or_default() += 1;
+        }) = state()
+        {
+            write_section(cx, path, recorded);
         }
-        // One crate name can cover several targets (lib + bin); suffix bins so
-        // sections never clobber each other.
-        let mut name = cx
-            .tcx
-            .crate_name(rustc_hir::def_id::LOCAL_CRATE)
-            .to_string();
-        if let Some(bin) = std::env::var_os("CARGO_BIN_NAME") {
-            name = format!("{name} (bin {})", bin.to_string_lossy());
-        }
-        let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            // Not `truncate`: the file is read first, then rewritten in place
-            // under the lock via `set_len(0)`.
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(path)
-        else {
-            return;
-        };
-        // Parallel rustc processes write concurrently; the lock serializes the
-        // read-modify-write.
-        let _ = f.lock();
-        let mut existing = String::new();
-        let _ = f.read_to_string(&mut existing);
-        let mut doc = read_doc(&existing);
-        if section.is_empty() {
-            doc.remove(&name);
-        } else {
-            doc.insert(name, section);
-        }
-        if let Ok(out) = toml::to_string_pretty(&doc) {
-            let _ = f.set_len(0);
-            let _ = f.rewind();
-            let _ = f.write_all(out.as_bytes());
-        }
-        let _ = f.unlock();
     }
+}
+
+fn write_section(cx: &LateContext<'_>, path: &Path, recorded: &Mutex<Vec<Key>>) {
+    let recorded: Vec<Key> = std::mem::take(&mut *recorded.lock().unwrap());
+    let mut section: BTreeMap<String, u64> = BTreeMap::new();
+    for (lint, file) in recorded {
+        *section.entry(format!("{lint}:{file}")).or_default() += 1;
+    }
+    let name = section_name(cx);
+    let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        // Not `truncate`: the file is read first, then rewritten in place
+        // under the lock via `set_len(0)`.
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+    else {
+        return;
+    };
+    // Parallel rustc processes write concurrently; the lock serializes the
+    // read-modify-write.
+    let _ = f.lock();
+    let mut existing = String::new();
+    let _ = f.read_to_string(&mut existing);
+    let mut doc = read_doc(&existing);
+    if section.is_empty() {
+        doc.remove(&name);
+    } else {
+        doc.insert(name, section);
+    }
+    if let Ok(out) = toml::to_string_pretty(&doc) {
+        let _ = f.set_len(0);
+        let _ = f.rewind();
+        let _ = f.write_all(out.as_bytes());
+    }
+    let _ = f.unlock();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@ mod wildcard_local_enum;
 #[serde(rename_all = "kebab-case", default)]
 #[cfg_attr(dylint_lib = "mordant", allow(flag_cluster))]
 pub struct MordantConfig {
+    /// Lints, by name, that stay registered (so an `allow` of one still
+    /// resolves) but never run.
+    pub disabled: Vec<String>,
     /// Fully qualified paths of types that are never a valid map key in this
     /// project (e.g. a span type with no file identity). Empty means silent.
     pub nonidentity_key_types: Vec<String>,
@@ -200,72 +203,110 @@ pub fn register_lints(sess: &rustc_session::Session, s: &mut rustc_lint::LintSto
     let config: MordantConfig = dylint_linting::config_or_default(env!("CARGO_PKG_NAME"));
     let config: &'static MordantConfig = Box::leak(Box::new(config));
     baseline::setup(&config.baseline);
-    add(s, true, move || StringlyError { config });
-    add(s, true, move || NonidentityKey::new(config));
-    add(s, true, || StringifiedError);
-    add(s, true, move || ExclusiveOptions::new(config));
-    add(s, true, ParallelBools::default);
-    add(s, config.flag_cluster_enabled, move || FlagCluster {
-        config,
-    });
-    add(s, true, move || BypassedValidator::new(config));
-    add(s, true, UnreadErrorVariant::default);
-    add(s, true, AsymmetricGuard::default);
-    add(
-        s,
+    let mut r = Registrar {
+        store: s,
+        disabled: &config.disabled,
+        known: Vec::new(),
+    };
+    r.add(true, move || StringlyError { config });
+    r.add(true, move || NonidentityKey::new(config));
+    r.add(true, || StringifiedError);
+    r.add(true, move || ExclusiveOptions::new(config));
+    r.add(true, ParallelBools::default);
+    r.add(config.flag_cluster_enabled, move || FlagCluster { config });
+    r.add(true, move || BypassedValidator::new(config));
+    r.add(true, UnreadErrorVariant::default);
+    r.add(true, AsymmetricGuard::default);
+    r.add(
         config.stale_safety_comment_enabled,
         StaleSafetyComment::default,
     );
-    add(s, true, || UnitMismatch);
-    add(s, true, StalePanicMessage::default);
-    add(s, true, LockOrder::default);
-    add(s, true, move || ForbiddenReach::new(config));
-    add(s, true, GuardFlag::default);
-    add(s, true, UnreadNone::default);
-    add(s, true, || InsertThenUnwrap);
-    add(s, true, OverwideParameter::default);
-    add(s, true, NarrowedReturn::default);
-    add(s, true, move || WildcardLocalEnum { config });
-    add(s, true, || DiscardedError);
-    add(s, true, move || StoredProjection::new(config));
-    add(s, true, move || StaleAcrossReentry { config });
-    add(s, true, move || DefaultedFailure::new(config));
-    add(s, config.unchecked_input_len_enabled, || UncheckedInputLen);
-    add(s, true, || MisboundArg);
-    add(s, true, move || BypassedConversion::new(config));
-    add(s, true, same_match_twice::SameMatchTwice::default);
-    add(s, true, move || {
+    r.add(true, || UnitMismatch);
+    r.add(true, StalePanicMessage::default);
+    r.add(true, LockOrder::default);
+    r.add(true, move || ForbiddenReach::new(config));
+    r.add(true, GuardFlag::default);
+    r.add(true, UnreadNone::default);
+    r.add(true, || InsertThenUnwrap);
+    r.add(true, OverwideParameter::default);
+    r.add(true, NarrowedReturn::default);
+    r.add(true, move || WildcardLocalEnum { config });
+    r.add(true, || DiscardedError);
+    r.add(true, move || StoredProjection::new(config));
+    r.add(true, move || StaleAcrossReentry { config });
+    r.add(true, move || DefaultedFailure::new(config));
+    r.add(config.unchecked_input_len_enabled, || UncheckedInputLen);
+    r.add(true, || MisboundArg);
+    r.add(true, move || BypassedConversion::new(config));
+    r.add(true, same_match_twice::SameMatchTwice::default);
+    r.add(true, move || {
         reimplemented_helper::ReimplementedHelper::new(config)
     });
-    add(s, true, DependentField::default);
-    add(s, true, CollapsedError::default);
-    add(s, true, UnevenNarrowing::default);
-    add(s, true, || CrossedIndex);
-    add(s, true, ParallelVecs::default);
-    add(s, true, bool_beside_option::BoolBesideOption::default);
-    add(s, true, SentinelInt::default);
-    add(s, true, StringlyState::default);
-    add(s, config.parallel_params_enabled, move || {
+    r.add(true, DependentField::default);
+    r.add(true, CollapsedError::default);
+    r.add(true, UnevenNarrowing::default);
+    r.add(true, || CrossedIndex);
+    r.add(true, ParallelVecs::default);
+    r.add(true, bool_beside_option::BoolBesideOption::default);
+    r.add(true, SentinelInt::default);
+    r.add(true, StringlyState::default);
+    r.add(config.parallel_params_enabled, move || {
         ParallelParams::new(config)
     });
-    add(s, true, BoolParams::default);
-    add(s, true, UnnamedTuple::default);
-    add(s, true, || CrossedAlias);
+    r.add(true, BoolParams::default);
+    r.add(true, UnnamedTuple::default);
+    r.add(true, || CrossedAlias);
     // Last, so its check_crate_post flushes after every lint has recorded.
-    add(s, true, || BaselineWriter);
+    r.add(true, || BaselineWriter);
+    let unknown = unknown_names(&config.disabled, &r.known);
+    if !unknown.is_empty() {
+        sess.dcx().warn(format!(
+            "mordant: `disabled` in dylint.toml names no lint of this pack: {}",
+            unknown.join(", ")
+        ));
+    }
 }
 
-/// Registers the pass's lints unconditionally, so `allow(..)` / `-A` of an
-/// opt-in lint still resolves when only its pass is skipped.
-fn add<T: for<'tcx> rustc_lint::LateLintPass<'tcx> + 'static>(
-    s: &mut rustc_lint::LintStore,
-    enabled: bool,
-    make: impl Fn() -> T + sync::DynSend + sync::DynSync + 'static,
-) {
-    s.register_lints(&make().get_lints());
-    if enabled {
-        s.register_late_pass(move |_| Box::new(make()));
+/// Registers lints and passes through one seam, so a pass that is off (an
+/// opt-in whose key is absent, or a lint listed under `disabled`) still has
+/// its lint registered and `allow(..)` / `-A` of it still resolves.
+struct Registrar<'a> {
+    store: &'a mut rustc_lint::LintStore,
+    disabled: &'a [String],
+    /// Every lint name registered so far, to tell which `disabled` entries
+    /// name nothing.
+    known: Vec<String>,
+}
+
+impl Registrar<'_> {
+    fn add<T: for<'tcx> rustc_lint::LateLintPass<'tcx> + 'static>(
+        &mut self,
+        enabled: bool,
+        make: impl Fn() -> T + sync::DynSend + sync::DynSync + 'static,
+    ) {
+        let lints = make().get_lints();
+        self.store.register_lints(&lints);
+        let names: Vec<String> = lints.iter().map(|l| l.name_lower()).collect();
+        let run = enabled && !all_disabled(&names, self.disabled);
+        self.known.extend(names);
+        if run {
+            self.store.register_late_pass(move |_| Box::new(make()));
+        }
     }
+}
+
+/// A pass is skipped when every lint it declares is disabled. A pass with
+/// no lints (the baseline writer) always runs.
+fn all_disabled(lints: &[String], disabled: &[String]) -> bool {
+    !lints.is_empty() && lints.iter().all(|l| disabled.contains(l))
+}
+
+fn unknown_names<'a>(disabled: &'a [String], known: &[String]) -> Vec<&'a str> {
+    disabled
+        .iter()
+        .filter(|d| !known.contains(d))
+        .map(String::as_str)
+        .collect()
 }
 
 #[test]
@@ -350,4 +391,38 @@ fn config_explicit_zero_thresholds_are_honored() {
     assert_eq!(parsed.exclusive_options_min_fields, 0);
     assert_eq!(parsed.wildcard_local_enum_max_variants, 0);
     assert_eq!(parsed.flag_cluster_min_bools, 0);
+}
+
+#[test]
+fn config_disabled_parses_and_defaults_empty() {
+    assert!(MordantConfig::default().disabled.is_empty());
+    let parsed: MordantConfig =
+        toml::from_str("disabled = [\"guard_flag\", \"lock_order\"]\n").expect("disabled parses");
+    assert_eq!(parsed.disabled, ["guard_flag", "lock_order"]);
+}
+
+#[test]
+fn disabled_skips_a_pass_only_when_every_lint_it_declares_is_named() {
+    let names = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    assert!(all_disabled(
+        &names(&["guard_flag"]),
+        &names(&["guard_flag"])
+    ));
+    assert!(!all_disabled(
+        &names(&["guard_flag"]),
+        &names(&["lock_order"])
+    ));
+    assert!(!all_disabled(&names(&["a", "b"]), &names(&["a"])));
+    assert!(!all_disabled(&[], &names(&["guard_flag"])));
+}
+
+#[test]
+fn disabled_names_that_match_no_lint_are_reported() {
+    let names = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+    let disabled = names(&["guard_flag", "gaurd_flag", "clippy::unwrap_used"]);
+    let known = names(&["guard_flag", "lock_order"]);
+    assert_eq!(
+        unknown_names(&disabled, &known),
+        ["gaurd_flag", "clippy::unwrap_used"]
+    );
 }


### PR DESCRIPTION
Three things that a workspace running mordant as a CI ratchet currently has to script around.

`disabled = ["lint", ...]` in dylint.toml turns lints off for the whole workspace. The lint stays registered, so `#[allow(lint)]` in code keeps resolving; only its pass is skipped. Names that match no lint get one warning listing them.

With a baseline configured, a finding over the recorded count is now printed as a plain warning (same message, help and notes, plus a note naming the lint and the recorded count) instead of going through the lint level machinery, so `warnings = "deny"` or `-D warnings` in the consuming workspace can no longer turn it into an error that stops the crate and hides every finding after it. `#[allow]` and `#[expect]` are read at the same node the lint path reads them, so their granularity is unchanged, and an expectation is fulfilled even when the finding is within the baseline. Without a baseline nothing changes; the ui outputs are identical.

At the end of each crate that had findings over the baseline, mordant prints one summary line and appends `<crate> <count>` to target/mordant/over-baseline.txt (under CARGO_TARGET_DIR if set), so CI is `rm -f` that file, run, `test ! -s` it. README's ratchet section shows the three lines.