### PR TITLE
some_if: a Some that fails its guard is handled as None (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Mordant will not find every defect, but what it reports is real: a lint that can
 | `lock_order`           | two locks the crate acquires in both orders, with both locations named: the shape of a deadlock                                                                           |
 | `forbidden_reach`      | a config-declared ban ("from `sched::pick`, never reach `Vec::push`") violated by a concrete call path, printed as a witness chain                                        |
 | `unread_none`          | an `Option` field every reader unwraps and no reader handles: a state nobody survives, usually a two-phase object wanting two types                                       |
-| `some_if`              | `Some(x) if x.ready() => .., _ => wait()` over an `Option`, or as `if let .. &&`: a `Some` failing the check is handled as `None` is, so `Some` alone never meant present |
+| `some_if`              | opt-in via `some-if-enabled`: `Some(x) if x.ready() => .., _ => wait()` (or `if let .. &&`) over an `Option`: a `Some` that fails the check is handled as `None`, so `Some|
 | `insert_then_unwrap`   | `map.get(&k).unwrap()` re-fetching what `map.insert(k, ..)` just proved present, with nothing in between that could disturb either                                        |
 | `stored_projection`    | two fields whose constant values agree one-for-one at every construction site: one is a projection of the other, so the type admits pairings the constructors never make  |
 | `overwide_parameter`   | a panicking arm for a variant no existing call site passes: the parameter type is wider than the function's domain, and narrowing it turns the panic into a compile error |
@@ -123,6 +123,7 @@ flag-cluster-enabled = true
 stale-safety-comment-enabled = true
 unchecked-input-len-enabled = true
 parallel-params-enabled = true
+some-if-enabled = true
 
 # Opt-in: flag composite keys (tuples, structs one level deep) that carry a
 # denied type unless one of the fixing types sits beside it. With these two

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Mordant will not find every defect, but what it reports is real: a lint that can
 | `lock_order`           | two locks the crate acquires in both orders, with both locations named: the shape of a deadlock                                                                           |
 | `forbidden_reach`      | a config-declared ban ("from `sched::pick`, never reach `Vec::push`") violated by a concrete call path, printed as a witness chain                                        |
 | `unread_none`          | an `Option` field every reader unwraps and no reader handles: a state nobody survives, usually a two-phase object wanting two types                                       |
+| `some_if`              | `Some(x) if x.ready() => .., _ => wait()` over an `Option`, or as `if let .. &&`: a `Some` failing the check is handled as `None` is, so `Some` alone never meant present |
 | `insert_then_unwrap`   | `map.get(&k).unwrap()` re-fetching what `map.insert(k, ..)` just proved present, with nothing in between that could disturb either                                        |
 | `stored_projection`    | two fields whose constant values agree one-for-one at every construction site: one is a projection of the other, so the type admits pairings the constructors never make  |
 | `overwide_parameter`   | a panicking arm for a variant no existing call site passes: the parameter type is wider than the function's domain, and narrowing it turns the panic into a compile error |

--- a/src/crossed_index.rs
+++ b/src/crossed_index.rs
@@ -82,10 +82,9 @@ fn singular(word: &str) -> &str {
             return &word[..word.len() - 2];
         }
     }
-    match word.strip_suffix('s') {
-        Some(stem) if !stem.ends_with('s') => stem,
-        _ => word,
-    }
+    word.strip_suffix('s')
+        .filter(|stem| !stem.ends_with('s'))
+        .unwrap_or(word)
 }
 
 /// Two `_`-separated names name one kind when any word of one is, or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,10 @@ pub struct MordantConfig {
     /// signatures tells those from a value nobody declared; run it once and
     /// read the list.
     pub parallel_params_enabled: bool,
+    /// Opt-in: run `some_if`. Off by default because a `Some` that fails
+    /// the check usually is meant to read as absent; the lint is a sweep for
+    /// the places where a `.filter(..)` or a narrower type says so instead.
+    pub some_if_enabled: bool,
     /// Functions a parameter group must pass between, unchanged, before
     /// `parallel_params` names it.
     pub parallel_params_min_fns: usize = 3,
@@ -257,7 +261,7 @@ pub fn register_lints(sess: &rustc_session::Session, s: &mut rustc_lint::LintSto
     r.add(true, BoolParams::default);
     r.add(true, UnnamedTuple::default);
     r.add(true, || CrossedAlias);
-    r.add(true, || some_if::SomeIf);
+    r.add(config.some_if_enabled, || some_if::SomeIf);
     // Last, so its check_crate_post flushes after every lint has recorded.
     r.add(true, || BaselineWriter);
     let unknown = unknown_names(&config.disabled, &r.known);
@@ -329,6 +333,7 @@ fn ui() {
             stale-safety-comment-enabled = true
             unchecked-input-len-enabled = true
             parallel-params-enabled = true
+            some-if-enabled = true
 
             [[mordant.forbidden-reach]]
             from = "hot_path"
@@ -371,6 +376,7 @@ fn config_default_thresholds_match_docs() {
     assert!(!c.stale_safety_comment_enabled);
     assert!(!c.unchecked_input_len_enabled);
     assert!(!c.parallel_params_enabled);
+    assert!(!c.some_if_enabled);
     assert_eq!(c.parallel_params_min_fns, 3);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ mod parallel_vecs;
 mod reimplemented_helper;
 mod same_match_twice;
 mod sentinel_int;
+mod some_if;
 mod stale_across_reentry;
 mod stale_panic_message;
 mod stale_safety_comment;
@@ -256,6 +257,7 @@ pub fn register_lints(sess: &rustc_session::Session, s: &mut rustc_lint::LintSto
     r.add(true, BoolParams::default);
     r.add(true, UnnamedTuple::default);
     r.add(true, || CrossedAlias);
+    r.add(true, || some_if::SomeIf);
     // Last, so its check_crate_post flushes after every lint has recorded.
     r.add(true, || BaselineWriter);
     let unknown = unknown_names(&config.disabled, &r.known);

--- a/src/some_if.rs
+++ b/src/some_if.rs
@@ -1,0 +1,335 @@
+use clippy_utils::source::snippet;
+use clippy_utils::visitors::is_local_used;
+use clippy_utils::{SpanlessEq, is_lang_item_or_ctor, is_refutable};
+use rustc_hir::def::Res;
+use rustc_hir::{
+    Arm, BinOpKind, Expr, ExprKind, HirId, LangItem, LetExpr, MatchSource, Pat, PatKind,
+};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::Ty;
+use rustc_span::{Span, SyntaxContext, sym};
+
+use crate::baseline::emit_with_note;
+use crate::enum_facts::pat_head_qpath;
+use crate::hir_shapes::sole_expr;
+
+rustc_session::declare_lint! {
+    /// Flags a `match` or `if let` over an `Option` or `Result` whose
+    /// present case is only taken under a further condition on the value,
+    /// with the value that fails it handled exactly as the absent case is:
+    /// `Some(x) if x.ready() => go(x), _ => wait()`, `if let Some(x) = next
+    /// && x.ready() { .. } else { .. }`, or the same with the condition as an
+    /// inner `if` whose `else` repeats the outer one. The `Option` at this
+    /// point admits a `Some` the code does not want, and the condition that
+    /// says which is written here, at a consumer, rather than where the
+    /// value is produced; every other consumer has to repeat it or gets the
+    /// unwanted `Some` as a valid one. Filtering at the source, or a payload
+    /// type that cannot hold the unwanted value, makes `Some` mean present.
+    ///
+    /// Stays quiet when the condition never reads what the pattern bound (a
+    /// guard on unrelated state is a different shape), when the failing
+    /// value and the absent case are handled by different code, when a
+    /// second `Some` arm does its own work, when the fallback does nothing
+    /// (`_ => {}`, or an `if let` chain with no `else`), on any enum but
+    /// `Option` and `Result`, and inside macros; `matches!(v, Some(x) if ..)`
+    /// and `.is_some_and(..)` are conditions, not handling, and are left
+    /// alone.
+    pub SOME_IF,
+    Warn,
+    "a guarded `Some` arm whose failures fall through to the `None` handling"
+}
+
+rustc_session::declare_lint_pass!(SomeIf => [SOME_IF]);
+
+/// The two types this lint reads, each with a present and an absent variant.
+#[derive(Clone, Copy)]
+enum Wrapper {
+    Option,
+    Result,
+}
+
+impl Wrapper {
+    fn of(cx: &LateContext<'_>, ty: Ty<'_>) -> Option<Self> {
+        let did = ty.peel_refs().ty_adt_def()?.did();
+        if cx.tcx.is_diagnostic_item(sym::Option, did) {
+            Some(Wrapper::Option)
+        } else if cx.tcx.is_diagnostic_item(sym::Result, did) {
+            Some(Wrapper::Result)
+        } else {
+            None
+        }
+    }
+
+    fn present(self) -> LangItem {
+        match self {
+            Wrapper::Option => LangItem::OptionSome,
+            Wrapper::Result => LangItem::ResultOk,
+        }
+    }
+
+    fn absent(self) -> LangItem {
+        match self {
+            Wrapper::Option => LangItem::OptionNone,
+            Wrapper::Result => LangItem::ResultErr,
+        }
+    }
+
+    fn message(self, cond: &str) -> String {
+        match self {
+            Wrapper::Option => {
+                format!("a `Some` that fails `{cond}` is handled as if it were `None`")
+            }
+            Wrapper::Result => {
+                format!("an `Ok` that fails `{cond}` is handled as if it were `Err`")
+            }
+        }
+    }
+
+    fn note(self) -> &'static str {
+        match self {
+            Wrapper::Option => "the failing `Some` lands here, handled like `None`",
+            Wrapper::Result => "the failing `Ok` lands here, handled like `Err`",
+        }
+    }
+
+    fn help(self) -> &'static str {
+        match self {
+            Wrapper::Option => {
+                "filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here"
+            }
+            Wrapper::Result => {
+                "reject where the value is produced (an error for this case, or a type whose `Ok` is always valid) so `Ok` needs no second check here"
+            }
+        }
+    }
+}
+
+/// Whether the pattern's head names the lang variant `item` (`Some(..)`,
+/// `None`, `Ok(..)`, `Err(..)`), however the path to it is spelled.
+fn head_is(cx: &LateContext<'_>, pat: &Pat<'_>, item: LangItem) -> bool {
+    let Some(qpath) = pat_head_qpath(pat) else {
+        return false;
+    };
+    match cx.qpath_res(qpath, pat.hir_id) {
+        Res::Def(_, did) => is_lang_item_or_ctor(cx, did, item),
+        _ => false,
+    }
+}
+
+/// The locals bound by `Some(p)` / `Ok(p)` when `p` itself cannot fail, so
+/// the guard is the only thing standing between this arm and a present
+/// value. None for any other pattern.
+fn present_bindings(cx: &LateContext<'_>, pat: &Pat<'_>, w: Wrapper) -> Option<Vec<HirId>> {
+    let PatKind::TupleStruct(_, [inner], _) = pat.kind else {
+        return None;
+    };
+    if !head_is(cx, pat, w.present()) || is_refutable(cx, inner) {
+        return None;
+    }
+    let mut ids = Vec::new();
+    inner.each_binding(|_, id, _, _| ids.push(id));
+    (!ids.is_empty()).then_some(ids)
+}
+
+fn reads_any<'tcx>(cx: &LateContext<'tcx>, cond: &'tcx Expr<'tcx>, ids: &[HirId]) -> bool {
+    ids.iter().any(|id| is_local_used(cx, cond, *id))
+}
+
+/// A pattern that takes whatever the guarded arm let through without
+/// looking inside it: `_`, an unread binding, `None`, `Err(..)`, `Some(_)`,
+/// or an `|` of those.
+fn covers_rest<'tcx>(
+    cx: &LateContext<'tcx>,
+    pat: &Pat<'_>,
+    body: &'tcx Expr<'tcx>,
+    w: Wrapper,
+) -> bool {
+    match pat.kind {
+        PatKind::Wild => true,
+        PatKind::Binding(_, id, _, None) => !is_local_used(cx, body, id),
+        PatKind::Or(pats) => pats.iter().all(|p| covers_rest(cx, p, body, w)),
+        PatKind::TupleStruct(_, [inner], _) if head_is(cx, pat, w.present()) => {
+            matches!(inner.kind, PatKind::Wild | PatKind::Binding(.., None))
+        }
+        _ => head_is(cx, pat, w.absent()),
+    }
+}
+
+/// Whether a rest pattern receives present values (as opposed to naming
+/// only the absent variant), so the note can point at the arm the failing
+/// `Some` actually reaches.
+fn takes_present(cx: &LateContext<'_>, pat: &Pat<'_>, w: Wrapper) -> bool {
+    match pat.kind {
+        PatKind::Wild | PatKind::Binding(.., None) => true,
+        PatKind::Or(pats) => pats.iter().any(|p| takes_present(cx, p, w)),
+        _ => head_is(cx, pat, w.present()),
+    }
+}
+
+/// `{}`, `()` and nests of them: a fallback that handles nothing.
+fn does_nothing(e: &Expr<'_>) -> bool {
+    match e.kind {
+        ExprKind::Block(b, _) => b.stmts.is_empty() && b.expr.is_none_or(does_nothing),
+        ExprKind::Tup([]) => true,
+        ExprKind::DropTemps(inner) => does_nothing(inner),
+        _ => false,
+    }
+}
+
+/// The operands of an `&&` chain, left to right.
+fn and_operands<'h>(e: &'h Expr<'h>, out: &mut Vec<&'h Expr<'h>>) {
+    match e.kind {
+        ExprKind::Binary(op, l, r) if op.node == BinOpKind::And => {
+            and_operands(l, out);
+            and_operands(r, out);
+        }
+        ExprKind::DropTemps(inner) => and_operands(inner, out),
+        _ => out.push(e),
+    }
+}
+
+fn has_let(operands: &[&Expr<'_>]) -> bool {
+    operands.iter().any(|e| matches!(e.kind, ExprKind::Let(..)))
+}
+
+struct Finding {
+    w: Wrapper,
+    span: Span,
+    cond: Span,
+    lands: Span,
+}
+
+fn report(cx: &LateContext<'_>, f: Finding) {
+    let cond = snippet(cx, f.cond, "..");
+    emit_with_note(
+        cx,
+        SOME_IF,
+        f.span,
+        f.w.message(&cond),
+        f.lands,
+        f.w.note(),
+        f.w.help(),
+    );
+}
+
+fn check_match<'tcx>(
+    cx: &LateContext<'tcx>,
+    scrut: &'tcx Expr<'tcx>,
+    arms: &'tcx [Arm<'tcx>],
+) -> Option<Finding> {
+    let w = Wrapper::of(cx, cx.typeck_results().expr_ty(scrut))?;
+    let mut guarded = None;
+    let mut rest = Vec::new();
+    for arm in arms {
+        match arm.guard {
+            Some(guard) => {
+                if guarded.replace((arm, guard)).is_some() {
+                    return None;
+                }
+            }
+            None => rest.push(arm),
+        }
+    }
+    let (arm, cond) = guarded?;
+    let ids = present_bindings(cx, arm.pat, w)?;
+    let mut cond_parts = Vec::new();
+    and_operands(cond, &mut cond_parts);
+    if has_let(&cond_parts) || !reads_any(cx, cond, &ids) {
+        return None;
+    }
+    let (first, others) = rest.split_first()?;
+    if does_nothing(first.body) || !rest.iter().all(|a| covers_rest(cx, a.pat, a.body, w)) {
+        return None;
+    }
+    let mut eq = SpanlessEq::new(cx);
+    if !others
+        .iter()
+        .all(|a| eq.eq_expr(SyntaxContext::root(), first.body, a.body))
+    {
+        return None;
+    }
+    let lands = rest
+        .iter()
+        .find(|a| takes_present(cx, a.pat, w))
+        .unwrap_or(first);
+    Some(Finding {
+        w,
+        span: arm.pat.span.to(cond.span),
+        cond: cond.span,
+        lands: lands.pat.span,
+    })
+}
+
+/// `let Some(x) = init` at the head of a condition: the wrapper it opens
+/// and the locals it binds.
+fn present_let<'tcx>(cx: &LateContext<'tcx>, e: &Expr<'tcx>) -> Option<(Wrapper, Vec<HirId>)> {
+    let ExprKind::Let(LetExpr { pat, init, .. }) = e.kind else {
+        return None;
+    };
+    let w = Wrapper::of(cx, cx.typeck_results().expr_ty(init))?;
+    Some((w, present_bindings(cx, pat, w)?))
+}
+
+fn check_if<'tcx>(
+    cx: &LateContext<'tcx>,
+    cond: &'tcx Expr<'tcx>,
+    then: &'tcx Expr<'tcx>,
+    els: &'tcx Expr<'tcx>,
+) -> Option<Finding> {
+    if does_nothing(els) {
+        return None;
+    }
+    let mut parts = Vec::new();
+    and_operands(cond, &mut parts);
+    let (head, tail) = parts.split_first()?;
+    let (w, ids) = present_let(cx, head)?;
+    if let (Some(first), Some(last)) = (tail.first(), tail.last()) {
+        // `if let Some(x) = v && COND { A } else { B }`
+        if has_let(tail) || !tail.iter().any(|e| reads_any(cx, e, &ids)) {
+            return None;
+        }
+        return Some(Finding {
+            w,
+            span: cond.span,
+            cond: first.span.to(last.span),
+            lands: els.span,
+        });
+    }
+    // `if let Some(x) = v { if COND { A } else { B } } else { B }`
+    let ExprKind::Block(block, None) = then.kind else {
+        return None;
+    };
+    let ExprKind::If(inner_cond, _, Some(inner_els)) = sole_expr(block)?.kind else {
+        return None;
+    };
+    let mut inner_parts = Vec::new();
+    and_operands(inner_cond, &mut inner_parts);
+    if has_let(&inner_parts)
+        || !reads_any(cx, inner_cond, &ids)
+        || !SpanlessEq::new(cx).eq_expr(SyntaxContext::root(), inner_els, els)
+    {
+        return None;
+    }
+    Some(Finding {
+        w,
+        span: head.span,
+        cond: inner_cond.span,
+        lands: inner_els.span,
+    })
+}
+
+impl<'tcx> LateLintPass<'tcx> for SomeIf {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if expr.span.from_expansion() {
+            return;
+        }
+        let finding = match expr.kind {
+            ExprKind::Match(scrut, arms, MatchSource::Normal) => check_match(cx, scrut, arms),
+            ExprKind::If(cond, then, Some(els)) => check_if(cx, cond, then, els),
+            _ => None,
+        };
+        if let Some(f) = finding {
+            report(cx, f);
+        }
+    }
+}

--- a/ui/some_if.rs
+++ b/ui/some_if.rs
@@ -1,0 +1,196 @@
+// compile-flags: --edition=2024
+//
+// A `Some` (or `Ok`) taken only under a further condition, with the value
+// that fails it dropped into the same handling as `None`: the condition
+// belongs where the value is produced, not at this consumer.
+
+struct Job {
+    ready: bool,
+    id: u32,
+}
+
+fn next() -> Option<Job> {
+    Some(Job { ready: true, id: 1 })
+}
+
+fn parse() -> Result<u32, String> {
+    Ok(3)
+}
+
+fn wait() -> u32 {
+    0
+}
+
+// Flagged: the guard reads `j`, and a `Some` failing it falls to `_` with
+// `None`.
+fn guarded_arm_with_wildcard() -> u32 {
+    match next() {
+        Some(j) if j.ready => j.id,
+        _ => wait(),
+    }
+}
+
+// Flagged: the same fallthrough spelled as two arms with identical bodies,
+// whatever their order.
+fn guarded_arm_with_split_rest() -> u32 {
+    match next() {
+        None => wait(),
+        Some(j) if j.ready => j.id,
+        Some(_) => wait(),
+    }
+}
+
+// Flagged: `Some(_) | None` is `_` written out.
+fn guarded_arm_with_or_rest() -> u32 {
+    match next() {
+        Some(j) if j.ready && j.id > 0 => j.id,
+        Some(_) | None => wait(),
+    }
+}
+
+// Flagged: an `Ok` failing the guard is handled as the error is.
+fn guarded_ok_arm() -> u32 {
+    match parse() {
+        Ok(n) if n > 2 => n,
+        Err(_) | Ok(_) => wait(),
+    }
+}
+
+// Flagged: the let-chain spelling.
+fn let_chain_with_else() -> u32 {
+    if let Some(j) = next()
+        && j.ready
+    {
+        j.id
+    } else {
+        wait()
+    }
+}
+
+// Flagged: the condition as an inner `if` whose `else` repeats the outer.
+fn nested_if_repeating_else() -> u32 {
+    if let Some(j) = next() {
+        if j.ready { j.id } else { wait() + 1 }
+    } else {
+        wait() + 1
+    }
+}
+
+// Fine: the guard never reads the binding; that is a flag beside the
+// option, a different smell.
+fn guard_on_other_state(open: bool) -> u32 {
+    match next() {
+        Some(j) if open => j.id,
+        _ => wait(),
+    }
+}
+
+// Fine: the failing `Some` and `None` are handled by different code.
+fn rest_arms_differ() -> u32 {
+    match next() {
+        Some(j) if j.ready => j.id,
+        Some(_) => wait() + 1,
+        None => wait(),
+    }
+}
+
+// Fine: the inner `else` and the outer one differ.
+fn nested_if_different_else() -> u32 {
+    if let Some(j) = next() {
+        if j.ready { j.id } else { wait() + 1 }
+    } else {
+        wait()
+    }
+}
+
+// Fine: a condition, not handling; this is what the fixed consumer reads.
+fn is_some_and_condition() -> u32 {
+    if next().is_some_and(|j| j.ready) {
+        1
+    } else {
+        wait()
+    }
+}
+
+// Fine: `matches!` with a guard is a condition too.
+fn matches_condition() -> u32 {
+    if matches!(next(), Some(j) if j.ready) {
+        1
+    } else {
+        wait()
+    }
+}
+
+enum Slot {
+    Full(Job),
+    Empty,
+}
+
+// Fine: not an `Option` or a `Result`.
+fn local_enum_with_guard(s: Slot) -> u32 {
+    match s {
+        Slot::Full(j) if j.ready => j.id,
+        Slot::Full(_) | Slot::Empty => wait(),
+    }
+}
+
+// Fine: the second `Some` arm does its own work with the value.
+fn second_some_arm_works() -> u32 {
+    match next() {
+        Some(j) if j.ready => j.id,
+        Some(j) => j.id + 100,
+        None => wait(),
+    }
+}
+
+macro_rules! ready_or_wait {
+    ($e:expr) => {
+        match $e {
+            Some(j) if j.ready => j.id,
+            _ => wait(),
+        }
+    };
+}
+
+// Fine: inside a macro expansion.
+fn inside_macro() -> u32 {
+    ready_or_wait!(next())
+}
+
+// Fine: no `else`, so nothing handles either case here.
+fn let_chain_without_else() -> u32 {
+    if let Some(j) = next()
+        && j.ready
+    {
+        return j.id;
+    }
+    2
+}
+
+// Fine: the fallback does nothing.
+fn empty_fallback(total: &mut u32) {
+    match next() {
+        Some(j) if j.ready => *total += j.id,
+        _ => {}
+    }
+}
+
+fn main() {
+    let _ = guarded_arm_with_wildcard();
+    let _ = guarded_arm_with_split_rest();
+    let _ = guarded_arm_with_or_rest();
+    let _ = guarded_ok_arm();
+    let _ = let_chain_with_else();
+    let _ = nested_if_repeating_else();
+    let _ = guard_on_other_state(true);
+    let _ = rest_arms_differ();
+    let _ = nested_if_different_else();
+    let _ = is_some_and_condition();
+    let _ = matches_condition();
+    let _ = local_enum_with_guard(Slot::Empty);
+    let _ = local_enum_with_guard(Slot::Full(Job { ready: false, id: 0 }));
+    let _ = second_some_arm_works();
+    let _ = inside_macro();
+    let _ = let_chain_without_else();
+    empty_fallback(&mut 0);
+}

--- a/ui/some_if.stderr
+++ b/ui/some_if.stderr
@@ -1,0 +1,86 @@
+warning: a `Some` that fails `j.ready` is handled as if it were `None`
+  --> $DIR/some_if.rs:28:9
+   |
+LL |         Some(j) if j.ready => j.id,
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+note: the failing `Some` lands here, handled like `None`
+  --> $DIR/some_if.rs:29:9
+   |
+LL |         _ => wait(),
+   |         ^
+   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+   = note: `#[warn(some_if)]` on by default
+
+warning: a `Some` that fails `j.ready` is handled as if it were `None`
+  --> $DIR/some_if.rs:38:9
+   |
+LL |         Some(j) if j.ready => j.id,
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+note: the failing `Some` lands here, handled like `None`
+  --> $DIR/some_if.rs:39:9
+   |
+LL |         Some(_) => wait(),
+   |         ^^^^^^^
+   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+
+warning: a `Some` that fails `j.ready && j.id > 0` is handled as if it were `None`
+  --> $DIR/some_if.rs:46:9
+   |
+LL |         Some(j) if j.ready && j.id > 0 => j.id,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the failing `Some` lands here, handled like `None`
+  --> $DIR/some_if.rs:47:9
+   |
+LL |         Some(_) | None => wait(),
+   |         ^^^^^^^^^^^^^^
+   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+
+warning: an `Ok` that fails `n > 2` is handled as if it were `Err`
+  --> $DIR/some_if.rs:54:9
+   |
+LL |         Ok(n) if n > 2 => n,
+   |         ^^^^^^^^^^^^^^
+   |
+note: the failing `Ok` lands here, handled like `Err`
+  --> $DIR/some_if.rs:55:9
+   |
+LL |         Err(_) | Ok(_) => wait(),
+   |         ^^^^^^^^^^^^^^
+   = help: reject where the value is produced (an error for this case, or a type whose `Ok` is always valid) so `Ok` needs no second check here
+
+warning: a `Some` that fails `j.ready` is handled as if it were `None`
+  --> $DIR/some_if.rs:61:8
+   |
+LL |       if let Some(j) = next()
+   |  ________^
+LL | |         && j.ready
+   | |__________________^
+   |
+note: the failing `Some` lands here, handled like `None`
+  --> $DIR/some_if.rs:65:12
+   |
+LL |       } else {
+   |  ____________^
+LL | |         wait()
+LL | |     }
+   | |_____^
+   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+
+warning: a `Some` that fails `j.ready` is handled as if it were `None`
+  --> $DIR/some_if.rs:72:8
+   |
+LL |     if let Some(j) = next() {
+   |        ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the failing `Some` lands here, handled like `None`
+  --> $DIR/some_if.rs:73:34
+   |
+LL |         if j.ready { j.id } else { wait() + 1 }
+   |                                  ^^^^^^^^^^^^^^
+   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+
+warning: 6 warnings emitted
+


### PR DESCRIPTION
`match opt { Some(x) if ok(x) => .., _ => fallback }`, its `Some(_) | None` and `if let Some(x) = opt && ok(x) { .. } else { .. }` spellings, and the nested `if let` whose two else branches are the same: a present value that fails the check takes exactly the path an absent one takes, so `Some` on its own never meant "present" and every consumer has to repeat the check. The help points at filtering where the value is produced, or a type whose `Some` is always valid. It only fires when the guard reads the binding, the scrutinee is an `Option` or `Result` by definition (not by name), the other arms are unguarded catch-alls with the same body, and nothing is inside a macro; `is_some_and` and `matches!` are left alone.

Opt-in (`some-if-enabled`), because on a large codebase most of what it names is intended ("a JS null is absent", "a dot at index 0 is not an extension") and the change on offer is a `.filter(..)`, which is a matter of taste rather than a missing type. It found two in this crate, both now filters. A default-on subset (the arm that only yields the binding, which is `.filter` written by hand and can carry a fix) is the likely follow-up.