### PR TITLE
Say what is wrong, where else, and what to do, in plain words

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The lints come in families, and each family is a lint group whose name is in its
 | `parallel_bools`             | bool fields only ever assigned as a pair, which together encode a state machine                                                                                           |
 | `bool_cluster`               | opt-in via `bool-cluster-enabled`: a named-field struct with several independent bools, 2^n representable states; if fewer are legal an enum names the ones that are      |
 | `runtime_typestate`          | a bool field that several methods test and bail on at entry, enforcing an ordering invariant at runtime                                                                   |
-| `always_unwrapped_option`    | an `Option` field every reader unwraps and no reader handles: a state nobody survives, usually a two-phase object wanting two types                                       |
-| `derived_field`              | two fields whose constant values agree one-for-one at every construction site: one is a projection of the other, so the type admits pairings the constructors never make  |
+| `always_unwrapped_option`    | an `Option` field unwrapped at every read while nothing handles `None`, so `None` only exists to crash on: usually a two-phase object wanting two types                   |
+| `derived_field`              | a field that always holds the same value for a given sibling wherever the type is built: a copy of something the sibling decides, and a mismatched pair still compiles    |
 | `field_valid_only_when`      | a field every reader tests a sibling for one value before touching, and every other construction fills with a placeholder: an enum payload stored flat beside its tag     |
 | `bool_beside_option`         | a bool field written only beside an `Option` field, `true` with `Some(..)` and `false` with `None`: it is that field's `is_some()` stored twice, kept equal only by habit |
 | `parallel_vecs`              | sequence fields of one struct that only change length side by side and are read at one index: element `i` of each is one record, so the type lets the lengths differ      |
@@ -41,7 +41,7 @@ The lints come in families, and each family is a lint group whose name is in its
 | `unchecked_construction`     | a literal, a write to a checked field, or `mem::zeroed`/`transmute` outside a validated type's module and impls, none of which runs the constructor's check               |
 | `defaulted_failure`          | `f(x).unwrap_or(0)` or `let Ok(v) = f(x) else { return Ok(()) }` where `f`'s own body rejects some of `x`: the rejection becomes a value and processing carries on        |
 | `unchecked_input_len`        | opt-in via `unchecked-input-len-enabled`: a received integer bounded on one path and turned into memory (`split_at`, `set_len`, `ptr.add`) on a path no check dominates   |
-| `guard_blind_to_action`      | `self.can_x()` gating a mutation that touches state the guard never reads, so the guard cannot be sound                                                                   |
+| `guard_blind_to_action`      | `self.can_x()` gating a mutation that changes state `can_x` never looks at, so the check cannot know whether the action is safe                                           |
 | `stale_across_reentry`       | a length, flag, or pointer read off a field of `self`, then a call that can re-enter (closure, fn pointer, `dyn`, `.await`, configured), then the field used through it   |
 | `error_collapsed_to_bool`    | `f(x);` or `let _ = f(x)` on a crate fn whose `false`/`None` is the bare `Err` arm of a `Result` it held: the typed error became one bit, and this call drops the bit     |
 | `narrowed_two_ways`          | an integer field or local converted with `try_from` at one site and a bare `as` at another: the check says the value may not fit, and `as` wraps silently when it doesn't |
@@ -54,7 +54,7 @@ The lints come in families, and each family is a lint group whose name is in its
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stringly_error`             | `Result<T, String>` in a public signature, where a caller has no variants to match on                                                                                     |
 | `stringified_error`          | the destruction site: `.map_err(\|e\| e.to_string())` on a typed error                                                                                                    |
-| `discarded_error`            | `.ok();` in statement position, which reads like handling and makes the error unobservable                                                                                |
+| `discarded_error`            | `.ok();` as a statement, which reads like handling and throws the error away on the spot                                                                                  |
 | `unread_error_variant`       | a private enum variant that is constructed but never named by a pattern outside the enum's own impls, so its structure is never read                                      |
 
 ### Enums (`mordant_enums`)
@@ -103,7 +103,7 @@ The lints come in families, and each family is a lint group whose name is in its
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `forbidden_reach`            | a config-declared ban ("from `sched::pick`, never reach `Vec::push`") violated by a concrete call path, printed as a witness chain                                        |
 
-Each diagnostic states what the lint found, why the type is wrong, and the type that replaces it.
+Each diagnostic says what is wrong at the place it points at, shows the other place that proves it when there is one, and ends with an edit that fixes it.
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The lints come in families, and each family is a lint group whose name is in its
 | `options_as_enum`            | a struct whose `Option` fields are never populated together, so the valid combinations are really an enum                                                                 |
 | `parallel_bools`             | bool fields only ever assigned as a pair, which together encode a state machine                                                                                           |
 | `bool_cluster`               | opt-in via `bool-cluster-enabled`: a named-field struct with several independent bools, 2^n representable states; if fewer are legal an enum names the ones that are      |
-| `runtime_typestate`          | a bool field that several methods test and bail on at entry, enforcing an ordering invariant at runtime                                                                   |
+| `runtime_typestate`          | a bool field that several methods test and bail on at entry, so whether they may be called yet is checked at runtime, one method at a time                                |
 | `always_unwrapped_option`    | an `Option` field unwrapped at every read while nothing handles `None`, so `None` only exists to crash on: usually a two-phase object wanting two types                   |
 | `derived_field`              | a field that always holds the same value for a given sibling wherever the type is built: a copy of something the sibling decides, and a mismatched pair still compiles    |
 | `field_valid_only_when`      | a field every reader tests a sibling for one value before touching, and every other construction fills with a placeholder: an enum payload stored flat beside its tag     |
@@ -40,7 +40,7 @@ The lints come in families, and each family is a lint group whose name is in its
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `unchecked_construction`     | a literal, a write to a checked field, or `mem::zeroed`/`transmute` outside a validated type's module and impls, none of which runs the constructor's check               |
 | `defaulted_failure`          | `f(x).unwrap_or(0)` or `let Ok(v) = f(x) else { return Ok(()) }` where `f`'s own body rejects some of `x`: the rejection becomes a value and processing carries on        |
-| `unchecked_input_len`        | opt-in via `unchecked-input-len-enabled`: a received integer bounded on one path and turned into memory (`split_at`, `set_len`, `ptr.add`) on a path no check dominates   |
+| `unchecked_input_len`        | opt-in via `unchecked-input-len-enabled`: a received integer bounded on one path and turned into memory (`split_at`, `set_len`, `ptr.add`) on another path with no check  |
 | `guard_blind_to_action`      | `self.can_x()` gating a mutation that changes state `can_x` never looks at, so the check cannot know whether the action is safe                                           |
 | `stale_across_reentry`       | a length, flag, or pointer read off a field of `self`, then a call that can re-enter (closure, fn pointer, `dyn`, `.await`, configured), then the field used through it   |
 | `error_collapsed_to_bool`    | `f(x);` or `let _ = f(x)` on a crate fn whose `false`/`None` is the bare `Err` arm of a `Result` it held: the typed error became one bit, and this call drops the bit     |
@@ -86,7 +86,7 @@ The lints come in families, and each family is a lint group whose name is in its
 
 | lint                         | flags                                                                                                                                                                     |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `key_not_identity`           | a map keyed on something that is not the canonical identity of what it names: a span, a pointer's bits, an unresolved path                                                |
+| `key_not_identity`           | a map keyed on something that does not identify what it names: a span, a pointer's bits, an unresolved path                                                               |
 | `insert_then_unwrap`         | `map.get(&k).unwrap()` re-fetching what `map.insert(k, ..)` just proved present, with nothing in between that could disturb either                                        |
 | `lock_order`                 | two locks the crate acquires in both orders, with both locations named: the shape of a deadlock                                                                           |
 

--- a/src/always_unwrapped_option.rs
+++ b/src/always_unwrapped_option.rs
@@ -6,16 +6,15 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Symbol;
 
 use crate::adt_facts::{field_ty, is_option_ty, private_local_struct, struct_field};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 
 rustc_session::declare_lint! {
-    /// Flags an `Option` field every read of which assumes `Some`: two or
-    /// more `unwrap`/`expect` reads and not one site that handles `None`.
-    /// The type admits a state no reader survives, which usually means a
-    /// two-phase object: `None` exists only between construction and setup.
-    /// Splitting the phases into types (a builder that yields the ready
-    /// shape, or a plain `T` field) deletes every one of those panics
-    /// structurally.
+    /// Flags an `Option` field that is unwrapped at every one of its reads
+    /// (two or more `unwrap`/`expect`s) while nothing ever handles `None`, so
+    /// `None` only exists to crash on. That usually means a two-phase object:
+    /// `None` between construction and setup. Storing the value directly and
+    /// constructing the struct once it is available, or splitting it into a
+    /// before type and an after type, deletes every one of those panics.
     pub ALWAYS_UNWRAPPED_OPTION,
     Warn,
     "Option field whose None is never handled by any reader"
@@ -111,16 +110,20 @@ impl<'tcx> LateLintPass<'tcx> for AlwaysUnwrappedOption {
             let Some(fdef) = struct_field(cx.tcx.adt_def(*adt), *field) else {
                 continue;
             };
-            emit(
+            let owner = cx.tcx.item_name(*adt);
+            emit_with_note(
                 cx,
                 ALWAYS_UNWRAPPED_OPTION,
                 cx.tcx.def_span(fdef.did),
                 format!(
-                    "every read of `{}.{field}` assumes `Some` ({} unwraps, 0 sites handle `None`)",
-                    cx.tcx.item_name(*adt),
+                    "`{owner}.{field}` is unwrapped at every one of its {} reads and nothing ever handles `None`, so `None` only exists to crash on",
                     facts.panicking.len(),
                 ),
-                "`None` is a state no reader survives; split the phases into types, or store `T` directly",
+                facts.panicking[0],
+                "one of the reads",
+                format!(
+                    "store the `{field}` value directly and construct `{owner}` once you have it, or split `{owner}` into a type without `{field}` and a later one with it"
+                ),
             );
         }
     }

--- a/src/always_unwrapped_option.rs
+++ b/src/always_unwrapped_option.rs
@@ -9,9 +9,9 @@ use crate::adt_facts::{field_ty, is_option_ty, private_local_struct, struct_fiel
 use crate::baseline::emit_with_note;
 
 rustc_session::declare_lint! {
-    /// Flags an `Option` field that is unwrapped at every one of its reads
-    /// (two or more `unwrap`/`expect`s) while nothing ever handles `None`, so
-    /// `None` only exists to crash on. That usually means a two-phase object:
+    /// Flags an `Option` field that is unwrapped at all of its reads (two or
+    /// more `unwrap`/`expect`s) and `None` is never handled, so `None` can
+    /// only crash. That usually means a two-phase object:
     /// `None` between construction and setup. Storing the value directly and
     /// constructing the struct once it is available, or splitting it into a
     /// before type and an after type, deletes every one of those panics.
@@ -116,13 +116,13 @@ impl<'tcx> LateLintPass<'tcx> for AlwaysUnwrappedOption {
                 ALWAYS_UNWRAPPED_OPTION,
                 cx.tcx.def_span(fdef.did),
                 format!(
-                    "`{owner}.{field}` is unwrapped at every one of its {} reads and nothing ever handles `None`, so `None` only exists to crash on",
+                    "`{owner}.{field}` is unwrapped at all {} of its reads and `None` is never handled, so `None` can only crash",
                     facts.panicking.len(),
                 ),
                 facts.panicking[0],
                 "one of the reads",
                 format!(
-                    "store the `{field}` value directly and construct `{owner}` once you have it, or split `{owner}` into a type without `{field}` and a later one with it"
+                    "store the `{field}` value itself and build `{owner}` once you have it. Or split `{owner}` into a type without `{field}` and one with it"
                 ),
             );
         }

--- a/src/arg_named_like_other_param.rs
+++ b/src/arg_named_like_other_param.rs
@@ -18,9 +18,9 @@ rustc_session::declare_lint! {
     /// own name and the same type: `resize(height, width)` against
     /// `fn resize(width: u32, height: u32)`, or `spawn(opts.inherit_stderr,
     /// opts.inherit_stdout)`. It looks like an argument in the wrong
-    /// position, and since the two share a type the compiler cannot tell;
-    /// distinct types per parameter (a newtype per quantity, an enum per
-    /// flag) would.
+    /// position, and since the two share a type the swap compiles. Distinct
+    /// types per parameter (a newtype per quantity, an enum per flag) would
+    /// make it a compile error.
     ///
     /// The argument's name is a local or parameter it is spelled as, or the
     /// last field of a field access. Silent when the names agree after
@@ -222,7 +222,7 @@ impl<'tcx> LateLintPass<'tcx> for ArgNamedLikeOtherParam {
                     span,
                     msg,
                     cx.tcx.def_span(def),
-                    format!("`{fn_name}`'s parameters, in the order it declares them"),
+                    format!("`{fn_name}` declares them in this order"),
                     help,
                 );
             } else {
@@ -241,8 +241,7 @@ impl<'tcx> LateLintPass<'tcx> for ArgNamedLikeOtherParam {
             });
             let other = param_name(c.names_param).unwrap_or(c.name);
             let types = format!(
-                "give `{}` and `{other}` distinct types (a newtype per quantity, an enum per \
-                 flag) so the next mix-up is a type error",
+                "Distinct types for `{}` and `{other}` would make the next swap a compile error",
                 c.bound_to,
             );
             if let Some(j) = partner {
@@ -251,27 +250,27 @@ impl<'tcx> LateLintPass<'tcx> for ArgNamedLikeOtherParam {
                 report(
                     expr.span,
                     format!(
-                        "`{}` and `{}` are passed where `{fn_name}` expects `{}` and `{}`, in that \
-                         order, and since all are `{}` the compiler cannot tell they are swapped",
+                        "`{}` and `{}` are passed where `{fn_name}` expects `{}` then `{}`. All \
+                         are `{}`, so the swap compiles",
                         c.name, d.name, c.bound_to, d.bound_to, c.ty,
                     ),
                     format!(
-                        "swap them, or if the call is right as written, rename the values so they \
-                         stop contradicting the parameters; then {types}"
+                        "swap the arguments. If the call is right, rename the values to match. \
+                         {types}"
                     ),
                 );
             } else {
                 report(
                     args[c.arg].span,
                     format!(
-                        "`{}` is passed as `{fn_name}`'s `{}` parameter, though `{fn_name}` also \
-                         has a `{other}` parameter of the same type `{}`, so this looks like an \
-                         argument in the wrong position and the compiler cannot tell",
+                        "`{}` is passed as `{fn_name}`'s `{}` parameter, but `{fn_name}` also \
+                         has a parameter named `{other}` and both are `{}`. This looks like an \
+                         argument in the wrong position",
                         c.name, c.bound_to, c.ty,
                     ),
                     format!(
-                        "move `{}` to the `{other}` position, or if it really is the `{}` here, \
-                         rename it; then {types}",
+                        "move `{}` to the `{other}` position. If it really is the `{}` here, \
+                         rename it. {types}",
                         c.name, c.bound_to,
                     ),
                 );

--- a/src/arg_named_like_other_param.rs
+++ b/src/arg_named_like_other_param.rs
@@ -7,19 +7,20 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{BinOpKind, Expr, ExprKind, QPath, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::Ty;
-use rustc_span::Symbol;
+use rustc_span::{Span, Symbol};
 
-use crate::baseline::emit;
+use crate::baseline::{emit, emit_with_note};
 use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
-    /// Flags a call argument whose own name is the name of a *different*
-    /// parameter of the callee than the one it is bound to, when both
-    /// parameters have the same type: `resize(height, width)` against
+    /// Flags a call argument passed where the callee expects a parameter of
+    /// another name, when the callee also has a parameter of the argument's
+    /// own name and the same type: `resize(height, width)` against
     /// `fn resize(width: u32, height: u32)`, or `spawn(opts.inherit_stderr,
-    /// opts.inherit_stdout)`. The two values are told apart by position and
-    /// by nothing else, so the transposition type-checks; distinct types
-    /// per parameter (a newtype per quantity, an enum per flag) reject it.
+    /// opts.inherit_stdout)`. It looks like an argument in the wrong
+    /// position, and since the two share a type the compiler cannot tell;
+    /// distinct types per parameter (a newtype per quantity, an enum per
+    /// flag) would.
     ///
     /// The argument's name is a local or parameter it is spelled as, or the
     /// last field of a field access. Silent when the names agree after
@@ -211,6 +212,23 @@ impl<'tcx> LateLintPass<'tcx> for ArgNamedLikeOtherParam {
             });
         }
         let fn_name = cx.tcx.item_name(def);
+        // The callee's signature is the other half of the crossing, when this
+        // crate has it to show.
+        let report = |span: Span, msg: String, help: String| {
+            if def.is_local() {
+                emit_with_note(
+                    cx,
+                    ARG_NAMED_LIKE_OTHER_PARAM,
+                    span,
+                    msg,
+                    cx.tcx.def_span(def),
+                    format!("`{fn_name}`'s parameters, in the order it declares them"),
+                    help,
+                );
+            } else {
+                emit(cx, ARG_NAMED_LIKE_OTHER_PARAM, span, msg, help);
+            }
+        };
         let mut reported = vec![false; crossings.len()];
         for (k, c) in crossings.iter().enumerate() {
             if reported[k] {
@@ -221,34 +239,41 @@ impl<'tcx> LateLintPass<'tcx> for ArgNamedLikeOtherParam {
                 let d = &crossings[j];
                 d.arg + offset == c.names_param && c.arg + offset == d.names_param
             });
+            let other = param_name(c.names_param).unwrap_or(c.name);
+            let types = format!(
+                "give `{}` and `{other}` distinct types (a newtype per quantity, an enum per \
+                 flag) so the next mix-up is a type error",
+                c.bound_to,
+            );
             if let Some(j) = partner {
                 reported[j] = true;
                 let d = &crossings[j];
-                emit(
-                    cx,
-                    ARG_NAMED_LIKE_OTHER_PARAM,
+                report(
                     expr.span,
                     format!(
-                        "arguments `{}` and `{}` are bound to `{fn_name}`'s parameters `{}` and `{}`; \
-                         all are `{}`, so the transposition type-checks",
+                        "`{}` and `{}` are passed where `{fn_name}` expects `{}` and `{}`, in that \
+                         order, and since all are `{}` the compiler cannot tell they are swapped",
                         c.name, d.name, c.bound_to, d.bound_to, c.ty,
                     ),
-                    "give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error",
+                    format!(
+                        "swap them, or if the call is right as written, rename the values so they \
+                         stop contradicting the parameters; then {types}"
+                    ),
                 );
             } else {
-                emit(
-                    cx,
-                    ARG_NAMED_LIKE_OTHER_PARAM,
+                report(
                     args[c.arg].span,
                     format!(
-                        "argument `{}` is bound to `{fn_name}`'s parameter `{}`, but `{fn_name}` also takes \
-                         a parameter `{}` of the same type `{}`",
-                        c.name,
-                        c.bound_to,
-                        param_name(c.names_param).unwrap_or(c.name),
-                        c.ty,
+                        "`{}` is passed as `{fn_name}`'s `{}` parameter, though `{fn_name}` also \
+                         has a `{other}` parameter of the same type `{}`, so this looks like an \
+                         argument in the wrong position and the compiler cannot tell",
+                        c.name, c.bound_to, c.ty,
                     ),
-                    "give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error",
+                    format!(
+                        "move `{}` to the `{other}` position, or if it really is the `{}` here, \
+                         rename it; then {types}",
+                        c.name, c.bound_to,
+                    ),
                 );
             }
         }

--- a/src/bare_bool_args.rs
+++ b/src/bare_bool_args.rs
@@ -13,11 +13,10 @@ use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
     /// Flags a crate-private function with two or more `bool` parameters
-    /// when a call site fills at least two of them with bare `true` /
-    /// `false`. At `f(x, true, false)` nothing says which flag each literal
-    /// sets, and the literals share a type, so the call with them in the
-    /// other order (or the wrong one flipped) is a program the compiler
-    /// accepts. The parameter names exist only in the signature; a
+    /// when a call fills at least two of them with bare `true` / `false`. At
+    /// `f(x, true, false)` nothing says which flag is which, and the
+    /// literals share a type, so the swapped call (or the wrong one flipped)
+    /// compiles too. The parameter names exist only in the signature; a
     /// two-variant enum per flag (or an options struct) carries them to
     /// every call and makes a swap a type error.
     ///
@@ -155,7 +154,7 @@ impl<'tcx> LateLintPass<'tcx> for BareBoolArgs {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut findings: Vec<(Span, String, Span)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, String)> = Vec::new();
         for (def, calls) in &mut self.calls {
             calls.bare.sort_by_key(|(span, _)| span.lo());
             let Some((first, written)) = calls.bare.first() else {
@@ -184,27 +183,30 @@ impl<'tcx> LateLintPass<'tcx> for BareBoolArgs {
                 .tcx
                 .def_ident_span(*def)
                 .unwrap_or_else(|| cx.tcx.def_span(*def));
+            let params = format!("{} and {last}", names.join(", "));
             findings.push((
                 span,
                 format!(
-                    "`{}` takes `bool` parameters {} and {last}, and {k} of its {n} call sites {pass} bare `true`/`false` for {which}: nothing at `{written}` says which flag each one sets",
+                    "`{}` takes `bool` parameters {params}, and {k} of its {n} calls {pass} bare `true`/`false` for {which}, so at `{written}` nothing says which flag is which and the swapped call compiles too",
                     cx.tcx.item_name(*def),
-                    names.join(", "),
                 ),
                 *first,
+                format!(
+                    "give {params} each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error"
+                ),
             ));
         }
         // `calls` is a HashMap; report in source order.
         findings.sort_by_key(|(span, ..)| span.lo());
-        for (span, msg, call) in findings {
+        for (span, msg, call, help) in findings {
             emit_with_note(
                 cx,
                 BARE_BOOL_ARGS,
                 span,
                 msg,
                 call,
-                "one such call",
-                "a two-variant enum per flag, or one options struct, names every argument at the call site and turns a swapped pair into a type error",
+                "one of those calls",
+                help,
             );
         }
     }

--- a/src/bare_bool_args.rs
+++ b/src/bare_bool_args.rs
@@ -12,13 +12,11 @@ use crate::baseline::emit_with_note;
 use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
-    /// Flags a crate-private function with two or more `bool` parameters
-    /// when a call fills at least two of them with bare `true` / `false`. At
-    /// `f(x, true, false)` nothing says which flag is which, and the
-    /// literals share a type, so the swapped call (or the wrong one flipped)
-    /// compiles too. The parameter names exist only in the signature; a
-    /// two-variant enum per flag (or an options struct) carries them to
-    /// every call and makes a swap a type error.
+    /// Flags a crate-private function that takes two or more bools when a
+    /// call passes bare `true` / `false` for at least two of them. At
+    /// `f(x, true, false)` nothing says which is which, and the swapped call
+    /// compiles too. A two-variant enum per flag, or an options struct,
+    /// makes every call name what it sets.
     ///
     /// Stays quiet on a single `bool` parameter (nothing to confuse it
     /// with), on exported, `extern` and trait functions (their signature is
@@ -187,12 +185,12 @@ impl<'tcx> LateLintPass<'tcx> for BareBoolArgs {
             findings.push((
                 span,
                 format!(
-                    "`{}` takes `bool` parameters {params}, and {k} of its {n} calls {pass} bare `true`/`false` for {which}, so at `{written}` nothing says which flag is which and the swapped call compiles too",
+                    "`{}` takes bools {params}, and {k} of its {n} calls {pass} bare `true`/`false` for {which}. At `{written}` nothing says which is which",
                     cx.tcx.item_name(*def),
                 ),
                 *first,
                 format!(
-                    "give {params} each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error"
+                    "give {params} a two-variant enum each, or an options struct, so every call names what it sets"
                 ),
             ));
         }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -265,8 +265,9 @@ pub fn emit(
     lint: &'static Lint,
     span: Span,
     msg: impl Into<String>,
-    help: &'static str,
+    help: impl Into<String>,
 ) {
+    let help: String = help.into();
     match weigh(cx, lint, span, cx.last_node_with_lint_attrs) {
         Verdict::Silent => {}
         Verdict::Lint => span_lint_and_help(cx, lint, span, msg.into(), None, help),
@@ -284,9 +285,10 @@ pub fn emit_with_note(
     span: Span,
     msg: impl Into<String>,
     note_span: Span,
-    note: &'static str,
-    help: &'static str,
+    note: impl Into<String>,
+    help: impl Into<String>,
 ) {
+    let (note, help): (String, String) = (note.into(), help.into());
     let decorate = |diag: &mut Diag<'_, ()>| {
         diag.span_note(note_span, note);
         diag.help(help);

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -259,6 +259,15 @@ fn weigh(cx: &LateContext<'_>, lint: &'static Lint, span: Span, hir_id: HirId) -
     }
 }
 
+/// `a`, `a and b`, `a, b and c`, with `conj` as the last separator.
+pub fn join(items: &[String], conj: &str) -> String {
+    match items {
+        [] => String::new(),
+        [one] => one.clone(),
+        [head @ .., last] => format!("{} {conj} {last}", head.join(", ")),
+    }
+}
+
 /// Every mordant lint reports through here so the ratchet sees all of them.
 pub fn emit(
     cx: &LateContext<'_>,

--- a/src/bool_beside_option.rs
+++ b/src/bool_beside_option.rs
@@ -3,7 +3,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::ControlFlow;
 
 use crate::adt_facts::{field_ty, has_fixed_repr, is_option_ty, struct_field};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{assigned_field, field_chain, peel_blocks_unsafe};
 use clippy_utils::visitors::for_each_expr_without_closures;
 use clippy_utils::{as_some_expr, get_parent_expr, hash_expr, is_default_equivalent, is_none_expr};
@@ -21,13 +21,13 @@ use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::{Span, Symbol, sym};
 
 rustc_session::declare_lint! {
-    /// Flags a bool field that stores whether a sibling `Option` field is
-    /// `Some`: every write to either of them, struct literal or field
+    /// Flags a bool field that is only ever written together with a sibling
+    /// `Option` field, `true` with `Some(..)` and `false` with `None` (or
+    /// always the reverse): every write to either, struct literal or field
     /// assignment, sits beside a write to the other in the same struct
-    /// expression or straight-line block, `true` always with `Some(..)` and
-    /// `false` always with `None` (or always the reverse). The flag is the
-    /// `Option`'s discriminant kept a second time, and nothing but that habit
-    /// keeps the two agreeing.
+    /// expression or straight-line block. The flag is that field's
+    /// `is_some()` stored a second time, and nothing but habit keeps the two
+    /// equal.
     ///
     /// Only fires on named fields nothing outside the crate can name, when
     /// every write to the pair is a literal `true`/`false` and
@@ -73,6 +73,8 @@ struct FieldWrites {
     /// (site, set): where the field is written, and whether it is written
     /// `true` / `Some(..)` there.
     sites: HashSet<(Site, bool)>,
+    /// The first write recorded, for the note.
+    first: Option<Span>,
 }
 
 #[derive(Default)]
@@ -214,6 +216,7 @@ impl BoolBesideOption {
                 kind,
                 unprovable: false,
                 sites: HashSet::new(),
+                first: None,
             })
     }
 
@@ -223,6 +226,7 @@ impl BoolBesideOption {
         base_ty: ty::Ty<'tcx>,
         name: Symbol,
         site: Site,
+        at: Span,
         value: &Expr<'_>,
     ) {
         let Some((adt, kind)) = tracked_field(cx, base_ty, name) else {
@@ -235,6 +239,13 @@ impl BoolBesideOption {
             Some(set) if facts.sites.contains(&(site, !set)) => facts.unprovable = true,
             Some(set) => {
                 facts.sites.insert((site, set));
+                // A write the user spelled, over one a derive expanded to.
+                if facts
+                    .first
+                    .is_none_or(|f| f.from_expansion() && !at.from_expansion())
+                {
+                    facts.first = Some(at);
+                }
             }
             None => facts.unprovable = true,
         }
@@ -272,7 +283,7 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                     place: 0,
                 };
                 for field in fields {
-                    self.record(cx, ty, field.ident.name, site, field.expr);
+                    self.record(cx, ty, field.ident.name, site, field.span, field.expr);
                 }
             }
             ExprKind::Assign(place, value, _) => {
@@ -290,7 +301,7 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                             stretch,
                             place: place_key(cx, base),
                         };
-                        self.record(cx, base_ty, ident.name, site, value);
+                        self.record(cx, base_ty, ident.name, site, expr.span, value);
                     }
                     None => self.poison(cx, base_ty, ident.name),
                 }
@@ -365,7 +376,7 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                 per_struct.entry(did).or_default().push((name, facts));
             }
         }
-        let mut findings: Vec<(Span, String)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, String)> = Vec::new();
         for (did, mut fields) in per_struct {
             fields.sort_by_key(|(name, _)| name.as_str().to_owned());
             let adt = cx.tcx.adt_def(did);
@@ -377,6 +388,9 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                 {
                     continue;
                 }
+                let Some(first) = flag_facts.first else {
+                    continue;
+                };
                 for (opt, opt_facts) in fields.iter().filter(|(_, f)| f.kind == Kind::Opt) {
                     let inverted: HashSet<(Site, bool)> =
                         opt_facts.sites.iter().map(|&(s, set)| (s, !set)).collect();
@@ -397,23 +411,29 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                     findings.push((
                         cx.tcx.def_span(field.did),
                         format!(
-                            "`{flag}` is only ever written beside `{opt}` of `{}`, `true` with `{with_true}` and `false` with `{with_false}` ({} sites): it stores `{opt}.{reading}()` a second time",
+                            "`{flag}` of `{}` is written only together with `{opt}` in all {} places, `true` with `{with_true}` and `false` with `{with_false}`, so it is `{opt}.{reading}()` stored a second time and kept equal only by habit",
                             cx.tcx.def_path_str(did),
                             flag_facts.sites.len(),
+                        ),
+                        first,
+                        format!(
+                            "delete `{flag}` and ask `{opt}.{reading}()` where it was read; the two then cannot disagree"
                         ),
                     ));
                     break;
                 }
             }
         }
-        findings.sort_by_key(|(span, _)| span.lo());
-        for (span, msg) in findings {
-            emit(
+        findings.sort_by_key(|(span, ..)| span.lo());
+        for (span, msg, first, help) in findings {
+            emit_with_note(
                 cx,
                 BOOL_BESIDE_OPTION,
                 span,
                 msg,
-                "the `Option` already carries this state; drop the flag and ask the `Option`, so the two cannot disagree",
+                first,
+                "one of the writes that pairs them",
+                help,
             );
         }
     }

--- a/src/bool_beside_option.rs
+++ b/src/bool_beside_option.rs
@@ -21,13 +21,12 @@ use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::{Span, Symbol, sym};
 
 rustc_session::declare_lint! {
-    /// Flags a bool field that is only ever written together with a sibling
-    /// `Option` field, `true` with `Some(..)` and `false` with `None` (or
-    /// always the reverse): every write to either, struct literal or field
+    /// Flags a bool field that is only ever written next to a sibling
+    /// `Option` field, `true` with `Some` and `false` with `None` (or always
+    /// the reverse): every write to either, struct literal or field
     /// assignment, sits beside a write to the other in the same struct
     /// expression or straight-line block. The flag is that field's
-    /// `is_some()` stored a second time, and nothing but habit keeps the two
-    /// equal.
+    /// `is_some()` stored twice.
     ///
     /// Only fires on named fields nothing outside the crate can name, when
     /// every write to the pair is a literal `true`/`false` and
@@ -402,8 +401,8 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                         continue;
                     };
                     let (with_true, with_false) = match reading {
-                        "is_some" => ("Some(..)", "None"),
-                        _ => ("None", "Some(..)"),
+                        "is_some" => ("Some", "None"),
+                        _ => ("None", "Some"),
                     };
                     let Some(field) = struct_field(adt, *flag) else {
                         continue;
@@ -411,13 +410,13 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                     findings.push((
                         cx.tcx.def_span(field.did),
                         format!(
-                            "`{flag}` of `{}` is written only together with `{opt}` in all {} places, `true` with `{with_true}` and `false` with `{with_false}`, so it is `{opt}.{reading}()` stored a second time and kept equal only by habit",
+                            "`{}.{flag}` is only ever written next to `{opt}`, `true` with `{with_true}` and `false` with `{with_false}`, in all {} places. It is `{opt}.{reading}()` stored twice",
                             cx.tcx.def_path_str(did),
                             flag_facts.sites.len(),
                         ),
                         first,
                         format!(
-                            "delete `{flag}` and ask `{opt}.{reading}()` where it was read; the two then cannot disagree"
+                            "delete `{flag}` and call `{opt}.{reading}()` where it was read"
                         ),
                     ));
                     break;
@@ -432,7 +431,7 @@ impl<'tcx> LateLintPass<'tcx> for BoolBesideOption {
                 span,
                 msg,
                 first,
-                "one of the writes that pairs them",
+                "one of the paired writes",
                 help,
             );
         }

--- a/src/bool_cluster.rs
+++ b/src/bool_cluster.rs
@@ -6,10 +6,10 @@ use rustc_lint::{LateContext, LateLintPass};
 use crate::MordantConfig;
 
 rustc_session::declare_lint! {
-    /// Flags a named-field struct carrying `bool-cluster-min-bools` or more
-    /// `bool` fields, however they are assigned. `n` bools is `2^n`
-    /// representable states; if fewer are legal, an enum names the ones that
-    /// are.
+    /// Flags a named-field struct with `bool-cluster-min-bools` or more
+    /// `bool` fields, however they are assigned: `n` bools allow `2^n`
+    /// combinations whether or not all of them mean something. If only some
+    /// are legal, an enum names those.
     ///
     /// Silent on any struct with an explicit `repr` — its layout is dictated
     /// from outside Rust (a hardware register, a wire format), so all `2^n`
@@ -53,18 +53,20 @@ impl<'tcx> LateLintPass<'tcx> for BoolCluster {
             return;
         }
         let names: Vec<String> = bools.iter().map(|s| format!("`{s}`")).collect();
+        let n = states(bools.len());
+        let path = cx.tcx.def_path_str(did);
         emit(
             cx,
             BOOL_CLUSTER,
             cx.tcx.def_span(did),
             format!(
-                "the {} bool fields {} of `{}` are {} representable states",
+                "`{path}` has {} bool fields ({}), which allows {n} combinations whether or not all {n} mean something",
                 bools.len(),
                 names.join(", "),
-                cx.tcx.def_path_str(did),
-                states(bools.len()),
             ),
-            "if fewer are legal, name them in an enum; if the layout is fixed elsewhere, give it a repr",
+            format!(
+                "if only some of the {n} are legal, replace these bools with an enum of the legal ones; if the layout is fixed from outside, say so with a `repr` on `{path}`"
+            ),
         );
     }
 }

--- a/src/bool_cluster.rs
+++ b/src/bool_cluster.rs
@@ -7,9 +7,8 @@ use crate::MordantConfig;
 
 rustc_session::declare_lint! {
     /// Flags a named-field struct with `bool-cluster-min-bools` or more
-    /// `bool` fields, however they are assigned: `n` bools allow `2^n`
-    /// combinations whether or not all of them mean something. If only some
-    /// are legal, an enum names those.
+    /// `bool` fields, however they are assigned. `n` bools are `2^n`
+    /// possible combinations. If only some are valid, an enum names those.
     ///
     /// Silent on any struct with an explicit `repr` — its layout is dictated
     /// from outside Rust (a hardware register, a wire format), so all `2^n`
@@ -60,12 +59,12 @@ impl<'tcx> LateLintPass<'tcx> for BoolCluster {
             BOOL_CLUSTER,
             cx.tcx.def_span(did),
             format!(
-                "`{path}` has {} bool fields ({}), which allows {n} combinations whether or not all {n} mean something",
+                "`{path}` has {} bool fields ({}). That is {n} possible combinations",
                 bools.len(),
                 names.join(", "),
             ),
             format!(
-                "if only some of the {n} are legal, replace these bools with an enum of the legal ones; if the layout is fixed from outside, say so with a `repr` on `{path}`"
+                "if only some combinations are valid, replace the bools with an enum of those. If the layout is fixed from outside, add a `repr` to `{path}` to say so"
             ),
         );
     }

--- a/src/cast_bypasses_from.rs
+++ b/src/cast_bypasses_from.rs
@@ -15,16 +15,15 @@ rustc_session::declare_lint! {
     /// Flags a value of a struct, enum or union produced by reinterpreting
     /// the bits of some other type -- `mem::transmute` /
     /// `mem::transmute_copy`, or a pointer cast (`p as *const T`,
-    /// `p.cast::<T>()`) between different pointee types -- when a conversion
-    /// from that same source type to that same target type already exists:
-    /// an `impl From<A> for B`, an `impl TryFrom<A> for B`, or a safe
-    /// receiver-less associated function of `B` taking one `A` (or `&A`) and
-    /// returning `B`, `Option<B>` or `Result<B, _>`, by value or by
-    /// reference. That function is where the crate decided which `A` values
-    /// are a `B` and how; the reinterpreting site takes any bit pattern, so
-    /// whatever the conversion rejects or remaps arrives as a `B` anyway, and
-    /// for an enum an unlisted discriminant is undefined behaviour on the
-    /// spot.
+    /// `p.cast::<T>()`) between different pointee types -- going around a
+    /// conversion from that same source type to that same target type that
+    /// already exists: an `impl From<A> for B`, an `impl TryFrom<A> for B`,
+    /// or a safe receiver-less associated function of `B` taking one `A` (or
+    /// `&A`) and returning `B`, `Option<B>` or `Result<B, _>`, by value or by
+    /// reference. That function is where the crate says how an `A` becomes a
+    /// `B`; the reinterpreting site accepts any bit pattern, including the
+    /// ones the conversion would refuse or remap, and for an enum an
+    /// unlisted discriminant is undefined behaviour on the spot.
     ///
     /// For a transmute of a value, every integer type counts as the same
     /// source: `transmute::<u16, E>(n as u16)` had to pick the repr width,
@@ -242,19 +241,20 @@ impl CastBypassesFrom {
         if how == TRANSMUTE && shape == Shape::Value && self.has_validator(cx, adt) {
             return;
         }
+        let (name, input) = (&conv.name, conv.from);
         let consequence = if conv.fallible {
             format!(
-                "`{}` converts `{}` to `{to}` and can refuse a value; this site accepts any bit pattern",
-                conv.name, conv.from
+                "which accepts any bit pattern, including values `{name}` (the crate's checked `{input}` to `{to}` conversion) would refuse"
             )
         } else {
             format!(
-                "`{}` is how `{}` becomes `{to}`; this site goes around it",
-                conv.name, conv.from
+                "going around `{name}`, which is where the crate says how `{input}` becomes `{to}`"
             )
         };
-        let msg = format!("`{from}` is reinterpreted as `{to}` by {how} here, but {consequence}");
-        let help = "convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on";
+        let msg = format!("`{from}` is reinterpreted as `{to}` by {how} here, {consequence}");
+        let help = format!(
+            "call `{name}` instead; if this path must skip it, add an explicitly unchecked constructor next to `{name}` so both sit beside the layout they depend on"
+        );
         if conv.def.is_local() {
             emit_with_note(
                 cx,
@@ -262,7 +262,7 @@ impl CastBypassesFrom {
                 expr.span,
                 msg,
                 tcx.def_span(conv.def),
-                "the conversion this site skips",
+                format!("`{name}`, the conversion this cast goes around"),
                 help,
             );
         } else {

--- a/src/cast_bypasses_from.rs
+++ b/src/cast_bypasses_from.rs
@@ -12,18 +12,17 @@ use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 use rustc_span::{Symbol, sym};
 
 rustc_session::declare_lint! {
-    /// Flags a value of a struct, enum or union produced by reinterpreting
-    /// the bits of some other type -- `mem::transmute` /
-    /// `mem::transmute_copy`, or a pointer cast (`p as *const T`,
-    /// `p.cast::<T>()`) between different pointee types -- going around a
-    /// conversion from that same source type to that same target type that
+    /// Flags a `mem::transmute` / `mem::transmute_copy`, or a pointer cast
+    /// (`p as *const T`, `p.cast::<T>()`) between different pointee types,
+    /// that turns some other type into a struct, enum or union when a
+    /// conversion from that same source type to that same target type
     /// already exists: an `impl From<A> for B`, an `impl TryFrom<A> for B`,
     /// or a safe receiver-less associated function of `B` taking one `A` (or
     /// `&A`) and returning `B`, `Option<B>` or `Result<B, _>`, by value or by
     /// reference. That function is where the crate says how an `A` becomes a
-    /// `B`; the reinterpreting site accepts any bit pattern, including the
-    /// ones the conversion would refuse or remap, and for an enum an
-    /// unlisted discriminant is undefined behaviour on the spot.
+    /// `B`. The cast accepts any bit pattern, including the ones the
+    /// conversion would reject or remap, and for an enum an unlisted
+    /// discriminant is undefined behaviour on the spot.
     ///
     /// For a transmute of a value, every integer type counts as the same
     /// source: `transmute::<u16, E>(n as u16)` had to pick the repr width,
@@ -242,18 +241,26 @@ impl CastBypassesFrom {
             return;
         }
         let (name, input) = (&conv.name, conv.from);
-        let consequence = if conv.fallible {
-            format!(
-                "which accepts any bit pattern, including values `{name}` (the crate's checked `{input}` to `{to}` conversion) would refuse"
+        let (existing, note, skipped) = if conv.fallible {
+            (
+                format!(
+                    "`{name}` is the checked conversion from `{input}` and would reject some of them"
+                ),
+                format!("`{name}`, the checked conversion"),
+                "the check",
             )
         } else {
-            format!(
-                "going around `{name}`, which is where the crate says how `{input}` becomes `{to}`"
+            (
+                format!("`{name}` is where the crate says how `{input}` becomes `{to}`"),
+                format!("`{name}`, the conversion this skips"),
+                "it",
             )
         };
-        let msg = format!("`{from}` is reinterpreted as `{to}` by {how} here, {consequence}");
+        let msg = format!(
+            "{how} turns `{from}` into `{to}` here and accepts any bit pattern. {existing}"
+        );
         let help = format!(
-            "call `{name}` instead; if this path must skip it, add an explicitly unchecked constructor next to `{name}` so both sit beside the layout they depend on"
+            "call `{name}` instead. If this path must skip {skipped}, add an unchecked constructor next to it so both live beside the layout"
         );
         if conv.def.is_local() {
             emit_with_note(
@@ -262,7 +269,7 @@ impl CastBypassesFrom {
                 expr.span,
                 msg,
                 tcx.def_span(conv.def),
-                format!("`{name}`, the conversion this cast goes around"),
+                note,
                 help,
             );
         } else {

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -13,15 +13,15 @@ use crate::enum_facts::{arm_variant, ctor_literal_variant};
 use crate::hir_shapes::{callee_of, peel_blocks_unsafe, sole_expr};
 
 rustc_session::declare_lint! {
-    /// Flags a call to a function that can reject its input, whose
-    /// rejection is swapped for a fixed value and never looked at --
+    /// Flags a call to a function that can reject its input, where the
+    /// rejection is replaced with a fixed value and never looked at:
     /// `f(x).unwrap_or(0)`, `.unwrap_or_default()`,
     /// `.unwrap_or_else(|_| CONST)`, `.ok()` feeding one of those, `let
     /// Ok(v) = f(x) else { return Ok(()) }` or `let Some(v) = f(x).ok() else {
-    /// return }` -- when `f` is a `Result`-returning function of this crate
+    /// return }`, when `f` is a `Result`-returning function of this crate
     /// whose body rejects some of what it is handed (see
-    /// `ctor_flow::argument_decided_failure`): input `f` refused goes on
-    /// being processed as if it had passed. Callees the
+    /// `ctor_flow::argument_decided_failure`). Rejected input carries on as
+    /// if it were fine. Callees the
     /// analysis cannot see into (other crates, `Option` returners,
     /// combinator-built failures) are covered only when listed in
     /// `defaulted-failure-callees`.
@@ -97,15 +97,12 @@ impl DefaultedFailure {
         let name = cx.tcx.def_path_str(callee);
         let consequence = match replaced {
             Replaced::Default(method) => format!(
-                "`.{method}` here swaps that rejection for a fixed value, so input `{name}` refused is processed as if it had passed"
+                "`.{method}` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine"
             ),
-            Replaced::ElseSuccess => format!(
-                "the `else` here returns success when it does, so input `{name}` refused is reported as handled"
-            ),
+            Replaced::ElseSuccess => "the `else` here returns success when that happens. Rejected input is reported as handled".to_string(),
         };
-        let help = format!(
-            "propagate the error with `?` or `return Err(..)`, or match on it here while `{name}`'s reason is still attached"
-        );
+        let help =
+            "pass the error on with `?`, or match on it here while the reason is still attached";
         if wrapper == Wrapper::Result
             && let Some(local) = callee.as_local()
             && let Some(check) = self.fact(cx, local)
@@ -116,7 +113,7 @@ impl DefaultedFailure {
                 at,
                 format!("`{name}` can reject its input, and {consequence}"),
                 check,
-                format!("the check in `{name}` whose failure is replaced"),
+                format!("the check in `{name}` that gets overridden"),
                 help,
             );
         } else if self.is_listed(cx, callee) {

--- a/src/defaulted_failure.rs
+++ b/src/defaulted_failure.rs
@@ -13,14 +13,15 @@ use crate::enum_facts::{arm_variant, ctor_literal_variant};
 use crate::hir_shapes::{callee_of, peel_blocks_unsafe, sole_expr};
 
 rustc_session::declare_lint! {
-    /// Flags a call whose failure is replaced by a fixed value and never
-    /// looked at -- `f(x).unwrap_or(0)`, `.unwrap_or_default()`,
+    /// Flags a call to a function that can reject its input, whose
+    /// rejection is swapped for a fixed value and never looked at --
+    /// `f(x).unwrap_or(0)`, `.unwrap_or_default()`,
     /// `.unwrap_or_else(|_| CONST)`, `.ok()` feeding one of those, `let
     /// Ok(v) = f(x) else { return Ok(()) }` or `let Some(v) = f(x).ok() else {
     /// return }` -- when `f` is a `Result`-returning function of this crate
     /// whose body rejects some of what it is handed (see
-    /// `ctor_flow::argument_decided_failure`): the value that failed `f`'s
-    /// check goes on being processed as if it had passed. Callees the
+    /// `ctor_flow::argument_decided_failure`): input `f` refused goes on
+    /// being processed as if it had passed. Callees the
     /// analysis cannot see into (other crates, `Option` returners,
     /// combinator-built failures) are covered only when listed in
     /// `defaulted-failure-callees`.
@@ -88,14 +89,23 @@ impl DefaultedFailure {
         cx: &LateContext<'tcx>,
         call: &Expr<'tcx>,
         at: Span,
-        replaced: &str,
+        replaced: Replaced,
     ) {
         let Some(FallibleCall { callee, wrapper }) = fallible_call(cx, call) else {
             return;
         };
         let name = cx.tcx.def_path_str(callee);
-        let help =
-            "propagate the failure, or handle the failing arm where its cause is still visible";
+        let consequence = match replaced {
+            Replaced::Default(method) => format!(
+                "`.{method}` here swaps that rejection for a fixed value, so input `{name}` refused is processed as if it had passed"
+            ),
+            Replaced::ElseSuccess => format!(
+                "the `else` here returns success when it does, so input `{name}` refused is reported as handled"
+            ),
+        };
+        let help = format!(
+            "propagate the error with `?` or `return Err(..)`, or match on it here while `{name}`'s reason is still attached"
+        );
         if wrapper == Wrapper::Result
             && let Some(local) = callee.as_local()
             && let Some(check) = self.fact(cx, local)
@@ -104,11 +114,9 @@ impl DefaultedFailure {
                 cx,
                 DEFAULTED_FAILURE,
                 at,
-                format!(
-                    "`{name}` rejects some of what it is handed, and {replaced} in place of the rejection"
-                ),
+                format!("`{name}` can reject its input, and {consequence}"),
                 check,
-                "the check whose failure is replaced",
+                format!("the check in `{name}` whose failure is replaced"),
                 help,
             );
         } else if self.is_listed(cx, callee) {
@@ -117,12 +125,21 @@ impl DefaultedFailure {
                 DEFAULTED_FAILURE,
                 at,
                 format!(
-                    "`{name}` is listed in `defaulted-failure-callees`, and {replaced} in place of its failure"
+                    "`{name}` is listed in `defaulted-failure-callees` as able to reject its input, and {consequence}"
                 ),
                 help,
             );
         }
     }
+}
+
+/// How the caller disposed of the failure.
+#[derive(Clone, Copy)]
+enum Replaced {
+    /// `.unwrap_or(..)` and kin, by method name.
+    Default(rustc_span::Symbol),
+    /// `let Ok(v) = .. else { return <success> }`.
+    ElseSuccess,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -341,12 +358,7 @@ impl<'tcx> LateLintPass<'tcx> for DefaultedFailure {
             return;
         }
         let call = through_ok(cx, recv);
-        self.report(
-            cx,
-            call,
-            expr.span,
-            &format!("`{name}` carries on with a fixed value"),
-        );
+        self.report(cx, call, expr.span, Replaced::Default(name));
     }
 
     /// `let Ok(v) = f(x) else { return Ok(()) };`, or the same with the
@@ -377,6 +389,6 @@ impl<'tcx> LateLintPass<'tcx> for DefaultedFailure {
         if !head_is_failure_of_call || !else_reports_success(cx, els) {
             return;
         }
-        self.report(cx, call, *span, "the `else` returns success");
+        self.report(cx, call, *span, Replaced::ElseSuccess);
     }
 }

--- a/src/derived_field.rs
+++ b/src/derived_field.rs
@@ -4,19 +4,20 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_span::Symbol;
+use rustc_span::{Span, Symbol};
 
 use crate::MordantConfig;
 use crate::adt_facts::{has_fixed_repr, has_positional_fields};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::enum_facts::ctor_literal_variant;
 use crate::hir_shapes::{assigned_adt_field, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
-    /// Flags two fields of one type whose constant values agree one-for-one
-    /// across every place the type is built: field `a` is a stored projection
-    /// of field `b`, so the type admits pairings the constructors never make
-    /// and nothing rejects one written by hand.
+    /// Flags a field that always holds the same value for a given value of a
+    /// sibling field, in every place the type is built: it is a copy of
+    /// something the sibling already decides, and nothing rejects a
+    /// mismatched pair written by hand. A method on the sibling's enum
+    /// replaces it.
     ///
     /// Fires only when one of the two is a variant of an enum *this crate
     /// defined* at every site — a closed set of states, which is what makes
@@ -58,6 +59,7 @@ impl DerivedField {
 }
 
 struct Site {
+    span: Span,
     fields: BTreeMap<Symbol, Val>,
 }
 
@@ -176,10 +178,10 @@ impl<'tcx> LateLintPass<'tcx> for DerivedField {
                 vals.insert(f.ident.name, v);
             }
         }
-        self.seen
-            .entry(variant.def_id)
-            .or_default()
-            .push(Site { fields: vals });
+        self.seen.entry(variant.def_id).or_default().push(Site {
+            span: expr.span,
+            fields: vals,
+        });
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
@@ -223,20 +225,32 @@ impl<'tcx> LateLintPass<'tcx> for DerivedField {
                     if !bijective(&va, &vb) {
                         continue;
                     }
-                    emit(
+                    // The side drawn from a local enum decides the other; the
+                    // repair is a method on that enum.
+                    let (deciding, derived, by) = if va.iter().all(|v| v.decides()) {
+                        (a, b, va[0])
+                    } else {
+                        (b, a, vb[0])
+                    };
+                    let Val::Variant(variant) = by else { continue };
+                    let enum_name = cx.tcx.item_name(cx.tcx.parent(*variant));
+                    emit_with_note(
                         cx,
                         DERIVED_FIELD,
                         cx.tcx.def_span(did),
                         format!(
-                            "`{}` and `{}` of `{}` agree one-for-one across all {} places it is \
-                             constructed, so one is a stored projection of the other",
-                            a,
-                            b,
-                            cx.tcx.def_path_str(did),
+                            "`{derived}` is always the same value for a given `{deciding}` in all {} \
+                             places `{}` is constructed, so it is a copy of something `{deciding}` \
+                             already decides",
                             sites.len(),
+                            cx.tcx.def_path_str(did),
                         ),
-                        "give the deciding field a method returning the other and drop the stored \
-                         copy, so a pairing the constructors never make cannot be written",
+                        sites[0].span,
+                        "one of the constructions that pairs them",
+                        format!(
+                            "give `{enum_name}` a `fn {derived}(&self)` and delete the `{derived}` \
+                             field; then a mismatched pair cannot be written"
+                        ),
                     );
                 }
             }

--- a/src/derived_field.rs
+++ b/src/derived_field.rs
@@ -13,11 +13,10 @@ use crate::enum_facts::ctor_literal_variant;
 use crate::hir_shapes::{assigned_adt_field, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
-    /// Flags a field that always holds the same value for a given value of a
-    /// sibling field, in every place the type is built: it is a copy of
-    /// something the sibling already decides, and nothing rejects a
-    /// mismatched pair written by hand. A method on the sibling's enum
-    /// replaces it.
+    /// Flags a field that always has the same value for a given value of a
+    /// sibling field, in every place the type is built. It is a stored copy
+    /// of something the sibling decides, and nothing rejects a mismatched
+    /// pair written by hand. A method on the sibling's enum replaces it.
     ///
     /// Fires only when one of the two is a variant of an enum *this crate
     /// defined* at every site — a closed set of states, which is what makes
@@ -239,17 +238,16 @@ impl<'tcx> LateLintPass<'tcx> for DerivedField {
                         DERIVED_FIELD,
                         cx.tcx.def_span(did),
                         format!(
-                            "`{derived}` is always the same value for a given `{deciding}` in all {} \
-                             places `{}` is constructed, so it is a copy of something `{deciding}` \
-                             already decides",
+                            "`{derived}` always has the same value for a given `{deciding}`, in all \
+                             {} places `{}` is built. It is a stored copy of something `{deciding}` \
+                             decides",
                             sites.len(),
                             cx.tcx.def_path_str(did),
                         ),
                         sites[0].span,
-                        "one of the constructions that pairs them",
+                        "one of the constructions",
                         format!(
-                            "give `{enum_name}` a `fn {derived}(&self)` and delete the `{derived}` \
-                             field; then a mismatched pair cannot be written"
+                            "add `fn {derived}(&self)` to `{enum_name}` and delete the `{derived}` field"
                         ),
                     );
                 }

--- a/src/discarded_error.rs
+++ b/src/discarded_error.rs
@@ -4,10 +4,10 @@ use rustc_hir::{ExprKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 
 rustc_session::declare_lint! {
-    /// Flags `.ok();` in statement position: the `Result` becomes an `Option`
-    /// that is immediately dropped, so the error value is unobservable. A
-    /// deliberate discard is written `let _ = ...`, which states the intent
-    /// and survives review; `.ok();` reads like handling and handles nothing.
+    /// Flags `.ok();` as a statement: the `Result` becomes an `Option` that
+    /// is dropped on the spot, so the error is thrown away by something that
+    /// reads like handling. A deliberate discard is written `let _ = ...`,
+    /// which states the intent and survives review.
     pub DISCARDED_ERROR,
     Warn,
     "statement-position .ok() makes the error unobservable"
@@ -27,15 +27,17 @@ impl<'tcx> LateLintPass<'tcx> for DiscardedError {
             return;
         }
         let recv_ty = cx.typeck_results().expr_ty_adjusted(recv).peel_refs();
-        if result_err_ty(cx.tcx, recv_ty).is_none() {
+        let Some(err_ty) = result_err_ty(cx.tcx, recv_ty) else {
             return;
-        }
+        };
         emit(
             cx,
             DISCARDED_ERROR,
             expr.span,
-            "`.ok()` in statement position discards the error unobserved",
-            "handle the error, or state the discard with `let _ = ...`",
+            format!(
+                "`.ok();` turns this `Result` into an `Option` and drops it on the spot, so its `{err_ty}` error is thrown away by something that reads like handling"
+            ),
+            "handle the `Err` or propagate it with `?`; if dropping it is intended, write `let _ = ...;` so the discard is stated",
         );
     }
 }

--- a/src/discarded_error.rs
+++ b/src/discarded_error.rs
@@ -4,13 +4,13 @@ use rustc_hir::{ExprKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 
 rustc_session::declare_lint! {
-    /// Flags `.ok();` as a statement: the `Result` becomes an `Option` that
-    /// is dropped on the spot, so the error is thrown away by something that
-    /// reads like handling. A deliberate discard is written `let _ = ...`,
-    /// which states the intent and survives review.
+    /// Flags `.ok();` as a statement: it converts the `Result` to an
+    /// `Option` and drops it, so the error disappears in a line that looks
+    /// like handling. A deliberate discard is written `let _ = ...`, which
+    /// states the intent and survives review.
     pub DISCARDED_ERROR,
     Warn,
-    "statement-position .ok() makes the error unobservable"
+    "statement-position .ok() drops the error in a line that looks like handling"
 }
 
 rustc_session::declare_lint_pass!(DiscardedError => [DISCARDED_ERROR]);
@@ -35,9 +35,9 @@ impl<'tcx> LateLintPass<'tcx> for DiscardedError {
             DISCARDED_ERROR,
             expr.span,
             format!(
-                "`.ok();` turns this `Result` into an `Option` and drops it on the spot, so its `{err_ty}` error is thrown away by something that reads like handling"
+                "`.ok();` converts this `Result` to an `Option` and drops it, so the `{err_ty}` error disappears in a line that looks like handling"
             ),
-            "handle the `Err` or propagate it with `?`; if dropping it is intended, write `let _ = ...;` so the discard is stated",
+            "handle the `Err` or pass it on with `?`. If dropping it is intended, write `let _ = ...;` to say so",
         );
     }
 }

--- a/src/error_collapsed_to_bool.rs
+++ b/src/error_collapsed_to_bool.rs
@@ -25,16 +25,16 @@ use crate::enum_facts::{arm_variant, ctor_literal_variant};
 use crate::hir_shapes::{callee_of, peel_blocks_unsafe, peel_not, sole_expr};
 
 rustc_session::declare_lint! {
-    /// Flags a call that drops the `bool` or `Option` a function of this
-    /// crate collapsed a typed error into. The callee returns `bool` (or
+    /// Flags a call that ignores the `bool` or `Option` a function of this
+    /// crate turned its typed error into, so a failure inside that function
+    /// is silently treated as success. The callee returns `bool` (or
     /// `Option<T>`) and somewhere in its body the `Err` of a `Result` it held
     /// becomes a bare `false` (or `None`) and nothing else -- `match r {
     /// Err(_) => return false, .. }`, `if r.is_err() { return false }`, `let
     /// Ok(v) = r else { return None }`, `r.ok()?`, or `r.is_ok()` / `r.ok()`
     /// as the value returned -- so the error's kind is already gone from its
     /// signature; the reported call then ignores even that bit (`f(x);`,
-    /// `let _ = f(x);`), and the failure can no longer be observed anywhere.
-    /// A `Result` return would have made this caller decide.
+    /// `let _ = f(x);`). A `Result` return would have made this caller decide.
     ///
     /// Silent when the `Err` arm or `else` block does anything besides exit
     /// (logs, stores or converts the error: it was looked at), or an `Err`
@@ -436,7 +436,7 @@ impl<'tcx> LateLintPass<'tcx> for ErrorCollapsedToBool {
                 dropped.hir_id,
                 dropped.span,
                 format!(
-                    "`{name}` reports `{err}` only as `{exit}`, and this call drops the `{exit}`: the failure can no longer be observed anywhere"
+                    "`{name}` turns its `{err}` into `{exit}`, and this call ignores the `{exit}`, so a failure inside `{name}` is silently treated as success"
                 ),
                 |diag| {
                     let more = match collapse.more {
@@ -445,11 +445,11 @@ impl<'tcx> LateLintPass<'tcx> for ErrorCollapsedToBool {
                     };
                     diag.span_note(
                         collapse.at,
-                        format!("the error becomes `{exit}` here{more}, and nothing else is done with it"),
+                        format!("the error becomes `{exit}` here{more}"),
                     );
-                    diag.help(
-                        "return the `Result` and let this caller decide; failing that, `#[must_use]`",
-                    );
+                    diag.help(format!(
+                        "make `{name}` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer"
+                    ));
                 },
             );
         }

--- a/src/error_collapsed_to_bool.rs
+++ b/src/error_collapsed_to_bool.rs
@@ -27,13 +27,13 @@ use crate::hir_shapes::{callee_of, peel_blocks_unsafe, peel_not, sole_expr};
 rustc_session::declare_lint! {
     /// Flags a call that ignores the `bool` or `Option` a function of this
     /// crate turned its typed error into, so a failure inside that function
-    /// is silently treated as success. The callee returns `bool` (or
+    /// is treated as success. The callee returns `bool` (or
     /// `Option<T>`) and somewhere in its body the `Err` of a `Result` it held
     /// becomes a bare `false` (or `None`) and nothing else -- `match r {
     /// Err(_) => return false, .. }`, `if r.is_err() { return false }`, `let
     /// Ok(v) = r else { return None }`, `r.ok()?`, or `r.is_ok()` / `r.ok()`
     /// as the value returned -- so the error's kind is already gone from its
-    /// signature; the reported call then ignores even that bit (`f(x);`,
+    /// signature. The reported call then ignores even that bit (`f(x);`,
     /// `let _ = f(x);`). A `Result` return would have made this caller decide.
     ///
     /// Silent when the `Err` arm or `else` block does anything besides exit
@@ -436,19 +436,19 @@ impl<'tcx> LateLintPass<'tcx> for ErrorCollapsedToBool {
                 dropped.hir_id,
                 dropped.span,
                 format!(
-                    "`{name}` turns its `{err}` into `{exit}`, and this call ignores the `{exit}`, so a failure inside `{name}` is silently treated as success"
+                    "`{name}` turns its `{err}` into `{exit}`, and this call ignores the `{exit}`. A failure inside `{name}` is treated as success"
                 ),
                 |diag| {
                     let more = match collapse.more {
                         0 => String::new(),
-                        n => format!(" (and at {n} more like it)"),
+                        n => format!(" (and in {n} more places)"),
                     };
                     diag.span_note(
                         collapse.at,
                         format!("the error becomes `{exit}` here{more}"),
                     );
                     diag.help(format!(
-                        "make `{name}` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer"
+                        "return the `Result` from `{name}` and decide here what failure means. At minimum mark it `#[must_use]`"
                     ));
                 },
             );

--- a/src/field_valid_only_when.rs
+++ b/src/field_valid_only_when.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::adt_facts::{has_fixed_repr, has_positional_fields, private_local_struct, struct_field};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::enum_facts::{arm_variant, ctor_literal_variant};
 use clippy_utils::eq_expr_value;
 use clippy_utils::{get_enclosing_block, in_automatically_derived, is_default_equivalent};
@@ -17,16 +17,16 @@ use rustc_middle::ty::adjustment::{Adjust, AutoBorrow, AutoBorrowMutability};
 use rustc_span::{Span, Symbol, SyntaxContext, sym};
 
 rustc_session::declare_lint! {
-    /// Flags a struct field that is read only where a sibling field is known
-    /// to hold one particular value — every read in the crate sits under an
-    /// `if`, `match`, `let .. else` or diverging guard that tests the sibling
-    /// against the same variant or literal — while a construction site that
-    /// gives the sibling any other value fills the field with a placeholder
+    /// Flags a struct field that only means something when a sibling field
+    /// has one particular value: every read in the crate sits under an `if`,
+    /// `match`, `let .. else` or diverging guard that tests the sibling
+    /// against the same variant or literal, and every construction that
+    /// gives the sibling another value fills the field with a placeholder
     /// (`None`, `0`, `""`, `false`, `Default::default()`, a null pointer).
-    /// The field is the payload of one case of the sibling, stored flat: the
-    /// struct lets every other case carry a value that means nothing and lets
-    /// any new reader use it without the test. An enum whose variant carries
-    /// the field cannot be built or read that way.
+    /// The struct carries the field in every case anyway, so any new reader
+    /// can use it without the test. Making that case of the sibling an enum
+    /// variant that carries the field leaves the other cases nothing to fill
+    /// in or misread.
     ///
     /// Only fires on structs private to the crate with named fields and no
     /// explicit `repr`, and only on proof: one read the lint cannot place
@@ -78,11 +78,17 @@ struct Init {
     placeholder: bool,
 }
 
+/// One read of a field: where it is and the sibling tests that dominate it.
+/// An empty set is a read nothing is known at.
+struct Read {
+    at: Span,
+    tests: HashSet<Test>,
+}
+
 #[derive(Default)]
 pub struct FieldValidOnlyWhen {
-    /// (struct, field) -> per read, the sibling tests that dominate it. An
-    /// empty set is a read nothing is known at.
-    reads: HashMap<(DefId, Symbol), Vec<HashSet<Test>>>,
+    /// (struct, field) -> its reads.
+    reads: HashMap<(DefId, Symbol), Vec<Read>>,
     /// struct -> per literal construction site, what each named field got.
     sites: HashMap<DefId, Vec<HashMap<Symbol, Init>>>,
     /// (struct, field) -> the values assigned to it after construction
@@ -436,8 +442,11 @@ fn mutated_in_place(cx: &LateContext<'_>, place: &Expr<'_>, parent: Node<'_>) ->
 }
 
 impl FieldValidOnlyWhen {
-    fn record_read(&mut self, adt: DefId, field: Symbol, tests: HashSet<Test>) {
-        self.reads.entry((adt, field)).or_default().push(tests);
+    fn record_read(&mut self, adt: DefId, field: Symbol, at: Span, tests: HashSet<Test>) {
+        self.reads
+            .entry((adt, field))
+            .or_default()
+            .push(Read { at, tests });
     }
 }
 
@@ -515,7 +524,7 @@ impl<'tcx> LateLintPass<'tcx> for FieldValidOnlyWhen {
                         .insert(None);
                 }
                 let tests = dominating_tests(cx, expr, base);
-                self.record_read(adt.did(), ident.name, tests);
+                self.record_read(adt.did(), ident.name, expr.span, tests);
             }
             _ => {}
         }
@@ -535,16 +544,16 @@ impl<'tcx> LateLintPass<'tcx> for FieldValidOnlyWhen {
             return;
         }
         for f in fields {
-            self.record_read(adt.did(), f.ident.name, HashSet::new());
+            self.record_read(adt.did(), f.ident.name, f.span, HashSet::new());
         }
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut findings: Vec<(Span, String)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, String)> = Vec::new();
         for ((did, field), reads) in &self.reads {
             // The tests every read agrees on; one bare read empties it.
             let mut common: Option<HashSet<Test>> = None;
-            for tests in reads {
+            for Read { tests, .. } in reads {
                 common = Some(match common {
                     None => tests.clone(),
                     Some(c) => c.intersection(tests).copied().collect(),
@@ -607,39 +616,53 @@ impl<'tcx> LateLintPass<'tcx> for FieldValidOnlyWhen {
                 let Some(fdef) = struct_field(adt, *field) else {
                     continue;
                 };
-                let holds = match test.value {
-                    Value::Variant(v) => format!(
-                        "{} == {}::{}",
-                        test.sibling,
-                        cx.tcx.item_name(cx.tcx.parent(v)),
-                        cx.tcx.item_name(v)
-                    ),
-                    Value::Bool(true) => test.sibling.to_string(),
-                    Value::Bool(false) => format!("!{}", test.sibling),
-                    Value::Int(n) => format!("{} == {n}", test.sibling),
+                let sibling = test.sibling;
+                let (holds, case) = match test.value {
+                    Value::Variant(v) => {
+                        let variant = cx.tcx.item_name(v);
+                        (
+                            format!(
+                                "{sibling} == {}::{variant}",
+                                cx.tcx.item_name(cx.tcx.parent(v))
+                            ),
+                            format!("`{variant}`"),
+                        )
+                    }
+                    Value::Bool(true) => (sibling.to_string(), "`true`".to_owned()),
+                    Value::Bool(false) => (format!("!{sibling}"), "`false`".to_owned()),
+                    Value::Int(n) => (format!("{sibling} == {n}"), format!("`{n}`")),
+                };
+                let first_read = reads.iter().map(|r| r.at).min_by_key(|at| at.lo());
+                let Some(first_read) = first_read else {
+                    continue;
                 };
                 findings.push((
                     cx.tcx.def_span(fdef.did),
                     format!(
-                        "`{field}` is only read where `{holds}` has been tested ({} read{}), and every `{}` made with another `{}` fills it with a placeholder ({placeholders} site{})",
+                        "`{field}` is read only after testing `{holds}` ({} read{}) and gets a placeholder wherever `{}` is constructed with another `{sibling}` ({placeholders} site{}), so it only means something in that one case, yet the struct carries it in all of them",
                         reads.len(),
                         if reads.len() == 1 { "" } else { "s" },
                         cx.tcx.item_name(*did),
-                        test.sibling,
                         if placeholders == 1 { "" } else { "s" },
+                    ),
+                    first_read,
+                    format!(
+                        "turn the {case} case of `{sibling}` into an enum variant that carries `{field}`, and delete the flat field; the other cases then have nothing to fill in or misread"
                     ),
                 ));
                 break;
             }
         }
-        findings.sort_by_key(|(span, _)| span.lo());
-        for (span, msg) in findings {
-            emit(
+        findings.sort_by_key(|(span, ..)| span.lo());
+        for (span, msg, read, help) in findings {
+            emit_with_note(
                 cx,
                 FIELD_VALID_ONLY_WHEN,
                 span,
                 msg,
-                "the field is the payload of that one case, stored flat; an enum variant carrying it leaves the other cases nothing to fill in or misread",
+                read,
+                "one of the reads, under that test",
+                help,
             );
         }
     }

--- a/src/field_valid_only_when.rs
+++ b/src/field_valid_only_when.rs
@@ -18,7 +18,7 @@ use rustc_span::{Span, Symbol, SyntaxContext, sym};
 
 rustc_session::declare_lint! {
     /// Flags a struct field that only means something when a sibling field
-    /// has one particular value: every read in the crate sits under an `if`,
+    /// has one particular value: every read in the crate comes after an `if`,
     /// `match`, `let .. else` or diverging guard that tests the sibling
     /// against the same variant or literal, and every construction that
     /// gives the sibling another value fills the field with a placeholder
@@ -639,7 +639,7 @@ impl<'tcx> LateLintPass<'tcx> for FieldValidOnlyWhen {
                 findings.push((
                     cx.tcx.def_span(fdef.did),
                     format!(
-                        "`{field}` is read only after testing `{holds}` ({} read{}) and gets a placeholder wherever `{}` is constructed with another `{sibling}` ({placeholders} site{}), so it only means something in that one case, yet the struct carries it in all of them",
+                        "`{field}` is only read after checking `{holds}` ({} read{}), and every other `{}` fills it with a placeholder ({placeholders} place{}). The field only means something in that one case",
                         reads.len(),
                         if reads.len() == 1 { "" } else { "s" },
                         cx.tcx.item_name(*did),
@@ -647,7 +647,7 @@ impl<'tcx> LateLintPass<'tcx> for FieldValidOnlyWhen {
                     ),
                     first_read,
                     format!(
-                        "turn the {case} case of `{sibling}` into an enum variant that carries `{field}`, and delete the flat field; the other cases then have nothing to fill in or misread"
+                        "make the {case} case of `{sibling}` an enum variant that carries `{field}`, and drop the flat field"
                     ),
                 ));
                 break;
@@ -661,7 +661,7 @@ impl<'tcx> LateLintPass<'tcx> for FieldValidOnlyWhen {
                 span,
                 msg,
                 read,
-                "one of the reads, under that test",
+                "one of the guarded reads",
                 help,
             );
         }

--- a/src/forbidden_reach.rs
+++ b/src/forbidden_reach.rs
@@ -13,13 +13,13 @@ use crate::baseline::{emit, emit_with_note};
 use crate::hir_shapes::{callee_of, def_path_names};
 
 rustc_session::declare_lint! {
-    /// Flags a function that can call something this project's
-    /// `forbidden-reach` config bans from it ("from `scheduler::pick`, no
-    /// call path may reach allocation, locking, or panic"), printing the
-    /// chain of calls that gets there, every edge of which is a real call
-    /// expression in this crate. Dynamic dispatch and function pointers are
-    /// invisible to the walk, so absence of a finding proves nothing — but a
-    /// finding is a concrete path that exists.
+    /// Flags a function that can reach something the `forbidden-reach`
+    /// config bans for it ("from `scheduler::pick`, no call path may reach
+    /// allocation, locking, or panic"), printing the path of calls that gets
+    /// there, each arrow of which is a real call expression in this crate.
+    /// Dynamic dispatch and function pointers are invisible to the walk, so
+    /// absence of a finding proves nothing, but a finding is a concrete path
+    /// that exists.
     ///
     /// **One finding per (root, banned definition).** A root breaking two
     /// entries of its `never` list reports twice; several call paths to the
@@ -158,19 +158,19 @@ impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
                 // than the one call site on it.
                 let more = match sites {
                     0 | 1 => String::new(),
-                    2 => " (and 1 further call site to it)".to_string(),
-                    n => format!(" (and {} further call sites to it)", n - 1),
+                    2 => " (1 more call site reaches it)".to_string(),
+                    n => format!(" ({} more call sites reach it)", n - 1),
                 };
                 let (root_name, banned_name) =
                     (cx.tcx.def_path_str(root), cx.tcx.def_path_str(banned));
                 let msg = format!(
-                    "`{root_name}` can call `{banned_name}`, which this project's `forbidden-reach` \
-                     config bans from it, through {}{more}",
+                    "`{root_name}` can reach `{banned_name}`, which the `forbidden-reach` config \
+                     bans for it. Path: {}{more}",
                     chain.join(" -> "),
                 );
                 let help = format!(
-                    "break that chain (every arrow is a real call in this crate), or if the call \
-                     is acceptable after all, amend the `forbidden-reach` rule for `{}`",
+                    "break the path (each arrow is a real call in this crate), or relax the \
+                     `forbidden-reach` rule for `{}` if the call is fine",
                     rule.from,
                 );
                 match parent.get(&banned) {
@@ -180,7 +180,7 @@ impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
                         root_span,
                         msg,
                         at,
-                        format!("the last call in the chain, reaching `{banned_name}`"),
+                        format!("the last call in that path, to `{banned_name}`"),
                         help,
                     ),
                     None => emit(cx, FORBIDDEN_REACH, root_span, msg, help),

--- a/src/forbidden_reach.rs
+++ b/src/forbidden_reach.rs
@@ -9,13 +9,14 @@ use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
 use crate::MordantConfig;
-use crate::baseline::emit;
+use crate::baseline::{emit, emit_with_note};
 use crate::hir_shapes::{callee_of, def_path_names};
 
 rustc_session::declare_lint! {
-    /// Config-declared reachability bans: "from `scheduler::pick`, no call
-    /// path may reach allocation, locking, or panic". On a violation the
-    /// finding prints the witness path, every edge of which is a real call
+    /// Flags a function that can call something this project's
+    /// `forbidden-reach` config bans from it ("from `scheduler::pick`, no
+    /// call path may reach allocation, locking, or panic"), printing the
+    /// chain of calls that gets there, every edge of which is a real call
     /// expression in this crate. Dynamic dispatch and function pointers are
     /// invisible to the walk, so absence of a finding proves nothing — but a
     /// finding is a concrete path that exists.
@@ -160,20 +161,30 @@ impl<'tcx> LateLintPass<'tcx> for ForbiddenReach {
                     2 => " (and 1 further call site to it)".to_string(),
                     n => format!(" (and {} further call sites to it)", n - 1),
                 };
-                emit(
-                    cx,
-                    FORBIDDEN_REACH,
-                    root_span,
-                    format!(
-                        "`{}` reaches `{}`, which this project bans from it: {}{}",
-                        cx.tcx.def_path_str(root),
-                        cx.tcx.def_path_str(banned),
-                        chain.join(" -> "),
-                        more,
-                    ),
-                    "one finding per banned definition reached; every arrow is a real call in \
-                     this crate, so break the chain or amend the rule",
+                let (root_name, banned_name) =
+                    (cx.tcx.def_path_str(root), cx.tcx.def_path_str(banned));
+                let msg = format!(
+                    "`{root_name}` can call `{banned_name}`, which this project's `forbidden-reach` \
+                     config bans from it, through {}{more}",
+                    chain.join(" -> "),
                 );
+                let help = format!(
+                    "break that chain (every arrow is a real call in this crate), or if the call \
+                     is acceptable after all, amend the `forbidden-reach` rule for `{}`",
+                    rule.from,
+                );
+                match parent.get(&banned) {
+                    Some(&(_, at)) => emit_with_note(
+                        cx,
+                        FORBIDDEN_REACH,
+                        root_span,
+                        msg,
+                        at,
+                        format!("the last call in the chain, reaching `{banned_name}`"),
+                        help,
+                    ),
+                    None => emit(cx, FORBIDDEN_REACH, root_span, msg, help),
+                }
             }
         }
     }

--- a/src/guard_blind_to_action.rs
+++ b/src/guard_blind_to_action.rs
@@ -10,18 +10,17 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, Symbol};
 
 use crate::adt_facts::impl_self_adt;
-use crate::baseline::emit;
+use crate::baseline::emit_hir_then;
 use crate::hir_shapes::{
     Callee, SelfField, callee_of, ends_in_return, is_self_path, peel_not, self_field, stmt_expr,
 };
 
 rustc_session::declare_lint! {
-    /// Flags a guarded call whose guard cannot be sound: `self.can_x()` gates
-    /// `self.y()`, but `y` touches a field of `self` that `can_x` never reads,
-    /// directly or through anything it calls. A predicate blind to part of the
-    /// state its action manipulates answers a different question than the one
-    /// being asked. The guard/mutator pair drifting apart is how a live
-    /// connection gets evicted by a donation its guard approved.
+    /// Flags a call that runs only if `self.can_x()` says yes, when the call
+    /// changes a field of `self` that `can_x` never looks at, directly or
+    /// through anything it calls: the check cannot know whether the call is
+    /// safe. The guard/mutator pair drifting apart is how a live connection
+    /// gets evicted by a donation its guard approved.
     ///
     /// Only calls at the guard's own level count as its actions. A call
     /// nested under a further `if`, `match` or loop is gated by that
@@ -184,6 +183,32 @@ impl GuardBlindToAction {
     }
 }
 
+impl GuardBlindToAction {
+    /// The fields `guard` reads, directly or through the same-type methods
+    /// it calls, sorted by name; None when it hands `self` to something the
+    /// walk cannot follow, so its coverage is not computable.
+    fn coverage(&self, guard: DefId) -> Option<Vec<Symbol>> {
+        let mut read: HashSet<Symbol> = HashSet::new();
+        let mut queue = vec![guard];
+        let mut seen: HashSet<DefId> = HashSet::new();
+        while let Some(m) = queue.pop() {
+            if !seen.insert(m) {
+                continue;
+            }
+            if let Some(f) = self.facts.get(&m) {
+                if f.escapes {
+                    return None;
+                }
+                read.extend(f.touched.iter().copied());
+                queue.extend(f.calls.iter().copied());
+            }
+        }
+        let mut read: Vec<Symbol> = read.into_iter().collect();
+        read.sort_by_key(|s| s.as_str().to_owned());
+        Some(read)
+    }
+}
+
 impl<'tcx> LateLintPass<'tcx> for GuardBlindToAction {
     fn check_fn(
         &mut self,
@@ -278,27 +303,24 @@ impl<'tcx> LateLintPass<'tcx> for GuardBlindToAction {
             if !mutates {
                 continue;
             }
-            // The guards' coverage is everything they touch transitively
+            // A guard's coverage is everything it touches transitively
             // through same-type calls, so a guard delegating to helpers is
             // never accused falsely; one delegating to something the walk
             // cannot follow has no computable coverage, and is not judged.
-            let mut covered: HashSet<Symbol> = HashSet::new();
-            let mut queue = gate.guards.clone();
-            let mut seen: HashSet<DefId> = HashSet::new();
-            let mut computable = true;
-            while let Some(m) = queue.pop() {
-                if !seen.insert(m) {
-                    continue;
-                }
-                if let Some(f) = self.facts.get(&m) {
-                    computable &= !f.escapes;
-                    covered.extend(f.touched.iter().copied());
-                    queue.extend(f.calls.iter().copied());
-                }
+            let mut guards: Vec<(String, DefId, Vec<Symbol>)> = Vec::new();
+            for &g in &gate.guards {
+                let Some(reads) = self.coverage(g) else {
+                    break;
+                };
+                guards.push((format!("`{}`", cx.tcx.item_name(g)), g, reads));
             }
-            if !computable {
+            if guards.len() != gate.guards.len() {
                 continue;
             }
+            let covered: HashSet<Symbol> = guards
+                .iter()
+                .flat_map(|(.., r)| r.iter().copied())
+                .collect();
             let mut missed: Vec<&Symbol> = action
                 .touched
                 .iter()
@@ -309,26 +331,58 @@ impl<'tcx> LateLintPass<'tcx> for GuardBlindToAction {
             }
             missed.sort_by_key(|s| s.as_str().to_owned());
             let fields: Vec<String> = missed.iter().map(|s| format!("`{s}`")).collect();
-            let mut guards: Vec<String> = gate
-                .guards
-                .iter()
-                .map(|&g| format!("`{}`", cx.tcx.item_name(g)))
-                .collect();
-            guards.sort();
-            let (guards, reader) = match guards.as_slice() {
-                [one] => (one.clone(), "the guard never reads"),
-                many => (many.join(" and "), "none of the guards read"),
+            let fields = fields.join(", ");
+            guards.sort_by(|a, b| a.0.cmp(&b.0));
+            let names: Vec<&str> = guards.iter().map(|(n, ..)| n.as_str()).collect();
+            let (named, says, blind, checks, either) = match names.as_slice() {
+                [one] => (
+                    (*one).to_owned(),
+                    "says",
+                    format!("{one} never looks at"),
+                    "the check",
+                    (*one).to_owned(),
+                ),
+                [a, b] => (
+                    format!("{a} and {b}"),
+                    "say",
+                    format!("neither {a} nor {b} looks at"),
+                    "the checks",
+                    format!("{a} or {b}"),
+                ),
+                [head @ .., last] => (
+                    format!("{} and {last}", head.join(", ")),
+                    "say",
+                    format!("none of {} and {last} looks at", head.join(", ")),
+                    "the checks",
+                    format!("{} or {last}", head.join(", ")),
+                ),
+                [] => continue,
             };
-            emit(
+            let action = cx.tcx.item_name(gate.action);
+            emit_hir_then(
                 cx,
                 GUARD_BLIND_TO_ACTION,
+                cx.last_node_with_lint_attrs,
                 gate.span,
                 format!(
-                    "`{}` is gated by {guards}, but touches {} which {reader}",
-                    cx.tcx.item_name(gate.action),
-                    fields.join(", "),
+                    "`{action}` runs only if {named} {says} yes, but it changes {fields}, which {blind}, so {checks} cannot know whether `{action}` is safe here"
                 ),
-                "a guard blind to part of the state its action manipulates cannot be sound; align what the pair reads",
+                |diag| {
+                    // What each guard does read: the other half of the
+                    // mismatch, shown at the guard.
+                    for (name, g, reads) in &guards {
+                        let read: Vec<String> = reads.iter().map(|s| format!("`{s}`")).collect();
+                        let what = if read.is_empty() {
+                            "no field of `self`".to_owned()
+                        } else {
+                            format!("only {}", read.join(", "))
+                        };
+                        diag.span_note(cx.tcx.def_span(*g), format!("{name} reads {what}"));
+                    }
+                    diag.help(format!(
+                        "make {either} look at {fields} too, or move the {fields} work out from under this check"
+                    ));
+                },
             );
         }
     }

--- a/src/guard_blind_to_action.rs
+++ b/src/guard_blind_to_action.rs
@@ -16,9 +16,9 @@ use crate::hir_shapes::{
 };
 
 rustc_session::declare_lint! {
-    /// Flags a call that runs only if `self.can_x()` says yes, when the call
-    /// changes a field of `self` that `can_x` never looks at, directly or
-    /// through anything it calls: the check cannot know whether the call is
+    /// Flags a call that only runs when `self.can_x()` returns true, but
+    /// changes a field of `self` that `can_x` never reads, directly or
+    /// through anything it calls. The check cannot tell whether the call is
     /// safe. The guard/mutator pair drifting apart is how a live connection
     /// gets evicted by a donation its guard approved.
     ///
@@ -334,26 +334,26 @@ impl<'tcx> LateLintPass<'tcx> for GuardBlindToAction {
             let fields = fields.join(", ");
             guards.sort_by(|a, b| a.0.cmp(&b.0));
             let names: Vec<&str> = guards.iter().map(|(n, ..)| n.as_str()).collect();
-            let (named, says, blind, checks, either) = match names.as_slice() {
+            let (named, returns, blind, checks, either) = match names.as_slice() {
                 [one] => (
                     (*one).to_owned(),
-                    "says",
-                    format!("{one} never looks at"),
-                    "the check",
+                    "returns",
+                    format!("{one} never reads"),
+                    "The check",
                     (*one).to_owned(),
                 ),
                 [a, b] => (
                     format!("{a} and {b}"),
-                    "say",
-                    format!("neither {a} nor {b} looks at"),
-                    "the checks",
+                    "return",
+                    format!("neither {a} nor {b} reads"),
+                    "The checks",
                     format!("{a} or {b}"),
                 ),
                 [head @ .., last] => (
                     format!("{} and {last}", head.join(", ")),
-                    "say",
-                    format!("none of {} and {last} looks at", head.join(", ")),
-                    "the checks",
+                    "return",
+                    format!("none of {} and {last} reads", head.join(", ")),
+                    "The checks",
                     format!("{} or {last}", head.join(", ")),
                 ),
                 [] => continue,
@@ -365,7 +365,7 @@ impl<'tcx> LateLintPass<'tcx> for GuardBlindToAction {
                 cx.last_node_with_lint_attrs,
                 gate.span,
                 format!(
-                    "`{action}` runs only if {named} {says} yes, but it changes {fields}, which {blind}, so {checks} cannot know whether `{action}` is safe here"
+                    "`{action}` only runs when {named} {returns} true, but it changes {fields}, which {blind}. {checks} cannot tell whether `{action}` is safe"
                 ),
                 |diag| {
                     // What each guard does read: the other half of the

--- a/src/index_of_other_kind.rs
+++ b/src/index_of_other_kind.rs
@@ -16,9 +16,9 @@ rustc_session::declare_lint! {
     /// on a place that everywhere else in the function is indexed by names
     /// of another kind, when the function also shows the crossing name
     /// indexing a table named after it: `sources[source_index]`,
-    /// `parts[part_index]` twice, then `parts[source_index]`. It looks like
-    /// an index into the wrong table, and both indices being plain integers,
-    /// it compiles. `[]`, `.get`, `.get_mut` and `get_unchecked*` with an
+    /// `parts[part_index]` twice, then `parts[source_index]`. This looks
+    /// like the wrong table, and since both indices are plain integers it
+    /// compiles. `[]`, `.get`, `.get_mut` and `get_unchecked*` with an
     /// integer operand all count as indexing (a newtyped index is already
     /// told apart by the compiler); a place is the binding or item at the
     /// root plus the
@@ -367,19 +367,18 @@ impl<'tcx> LateLintPass<'tcx> for IndexOfOtherKind {
                 INDEX_OF_OTHER_KIND,
                 site.span,
                 format!(
-                    "`{place}` is indexed by `{name}` here, but everywhere else in this function \
-                     ({major_n} site{s}) it is indexed by `{major}` and {by} is what indexes \
-                     `{home_place}`, so this looks like an index into the wrong table and, both \
-                     being plain integers, it compiles",
+                    "`{place}` is indexed by `{name}` here. Elsewhere in this function it is \
+                     indexed by `{major}` ({major_n} place{s}), and {by} indexes `{home_place}`. \
+                     This looks like the wrong table",
                     major = major_first.name,
                     s = if major_n == 1 { "" } else { "s" },
                 ),
                 major_first.span,
-                format!("`{place}` indexed by its usual kind"),
+                format!("`{place}` indexed the usual way"),
                 format!(
-                    "give `{place}` and `{home_place}` each an index newtype and implement `Index` \
-                     only for its own, so `{place}[{name}]` is a type error; if this line is \
-                     intended, rename the index to say so"
+                    "give `{place}` and `{home_place}` their own index newtypes so \
+                     `{place}[{name}]` cannot compile. If this line is intended, rename the \
+                     index to say so"
                 ),
             );
         }

--- a/src/index_of_other_kind.rs
+++ b/src/index_of_other_kind.rs
@@ -13,12 +13,12 @@ use crate::hir_shapes::value_name;
 rustc_session::declare_lint! {
     /// Flags an index whose name claims one kind (`source_index`, `pkg_id`:
     /// the non-empty prefix before `_index`, `_idx`, `_id` or `_i`) landing
-    /// on a place the same function otherwise indexes by names of another
-    /// kind, when the function also shows the crossing name indexing a table
-    /// named after it: `sources[source_index]`, `parts[part_index]` twice,
-    /// then `parts[source_index]`. Both indices are plain integers, so
-    /// `parts` accepts a source index and returns whichever element sits at
-    /// that offset. `[]`, `.get`, `.get_mut` and `get_unchecked*` with an
+    /// on a place that everywhere else in the function is indexed by names
+    /// of another kind, when the function also shows the crossing name
+    /// indexing a table named after it: `sources[source_index]`,
+    /// `parts[part_index]` twice, then `parts[source_index]`. It looks like
+    /// an index into the wrong table, and both indices being plain integers,
+    /// it compiles. `[]`, `.get`, `.get_mut` and `get_unchecked*` with an
     /// integer operand all count as indexing (a newtyped index is already
     /// told apart by the compiler); a place is the binding or item at the
     /// root plus the
@@ -359,25 +359,28 @@ impl<'tcx> LateLintPass<'tcx> for IndexOfOtherKind {
             } else {
                 format!("`{}` (the same kind as `{}`)", home.name, site.name)
             };
+            let place = &sites.places[site.place].shown;
+            let home_place = &sites.places[home.place].shown;
+            let name = site.name;
             emit_with_note(
                 cx,
                 INDEX_OF_OTHER_KIND,
                 site.span,
                 format!(
-                    "`{place}` is indexed by `{name}` here but by `{major}` elsewhere in this \
-                     function ({major_n} site{s}), while {by} is what indexes `{home}`: \
-                     the names claim different index kinds and both are plain integers, so \
-                     the crossing compiles",
-                    place = sites.places[site.place].shown,
-                    name = site.name,
+                    "`{place}` is indexed by `{name}` here, but everywhere else in this function \
+                     ({major_n} site{s}) it is indexed by `{major}` and {by} is what indexes \
+                     `{home_place}`, so this looks like an index into the wrong table and, both \
+                     being plain integers, it compiles",
                     major = major_first.name,
                     s = if major_n == 1 { "" } else { "s" },
-                    home = sites.places[home.place].shown,
                 ),
                 major_first.span,
-                "indexed by the other kind here",
-                "an index newtype per table, with `Index` implemented only for its own, turns \
-                 the crossing into a type error",
+                format!("`{place}` indexed by its usual kind"),
+                format!(
+                    "give `{place}` and `{home_place}` each an index newtype and implement `Index` \
+                     only for its own, so `{place}[{name}]` is a type error; if this line is \
+                     intended, rename the index to say so"
+                ),
             );
         }
     }

--- a/src/insert_then_unwrap.rs
+++ b/src/insert_then_unwrap.rs
@@ -8,11 +8,10 @@ use crate::baseline::emit_with_note;
 use crate::hir_shapes::{FieldChain, dotted, field_chain, stmt_expr};
 
 rustc_session::declare_lint! {
-    /// Flags `map.get(&k).unwrap()` straight after a `map.insert(k, ..)` put
+    /// Flags `map.get(&k).unwrap()` right after a `map.insert(k, ..)` put
     /// the key there, with nothing in between that could touch the map or the
-    /// key: no calls, no assignments to either. The lookup and its panic path
-    /// are both redundant; keeping the inserted value (or the entry API)
-    /// removes them.
+    /// key: no calls, no assignments to either. The lookup and its panic are
+    /// redundant. Keeping the inserted value (or the entry API) removes them.
     ///
     /// Silent once a `let` in between rebinds the name the map or key was
     /// spelled with, and treats `-k` / `!k` as a different key from `k`.
@@ -151,12 +150,12 @@ impl<'tcx> LateLintPass<'tcx> for InsertThenUnwrap {
                         INSERT_THEN_UNWRAP,
                         at,
                         format!(
-                            "this looks `{shown}` up in `{map_shown}` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant"
+                            "this looks up `{shown}` in `{map_shown}` and unwraps it right after the `insert` above put it there. Nothing in between could remove it, so the lookup and its panic are redundant"
                         ),
                         e.span,
-                        "the insert that already proves it present",
+                        "the insert",
                         format!(
-                            "keep the value you inserted (or use `{map_shown}.entry({shown})`, which hands it back) instead of fetching it again"
+                            "keep the value you inserted, or use `{map_shown}.entry({shown})` which hands it back"
                         ),
                     );
                     return;

--- a/src/insert_then_unwrap.rs
+++ b/src/insert_then_unwrap.rs
@@ -4,15 +4,15 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::sym;
 
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{FieldChain, dotted, field_chain, stmt_expr};
 
 rustc_session::declare_lint! {
-    /// Flags `map.get(&k).unwrap()` when the presence it bets on was proved a
-    /// few statements up by `map.insert(k, ..)`, with nothing in between that
-    /// could touch the map or the key: no calls, no assignments to either.
-    /// The unwrap re-fetches a value the code already held, and the panic
-    /// path plus the second hash both disappear by keeping it.
+    /// Flags `map.get(&k).unwrap()` straight after a `map.insert(k, ..)` put
+    /// the key there, with nothing in between that could touch the map or the
+    /// key: no calls, no assignments to either. The lookup and its panic path
+    /// are both redundant; keeping the inserted value (or the entry API)
+    /// removes them.
     ///
     /// Silent once a `let` in between rebinds the name the map or key was
     /// spelled with, and treats `-k` / `!k` as a different key from `k`.
@@ -146,14 +146,18 @@ impl<'tcx> LateLintPass<'tcx> for InsertThenUnwrap {
                     && gkey == key
                 {
                     let map_shown = map.strip_prefix("self.").unwrap_or(&map);
-                    emit(
+                    emit_with_note(
                         cx,
                         INSERT_THEN_UNWRAP,
                         at,
                         format!(
-                            "this unwrap re-fetches `{map_shown}[{shown}]`, which the insert above just proved present"
+                            "this looks `{shown}` up in `{map_shown}` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant"
                         ),
-                        "keep the inserted value, or use the entry API; the panic path and the second lookup both vanish",
+                        e.span,
+                        "the insert that already proves it present",
+                        format!(
+                            "keep the value you inserted (or use `{map_shown}.entry({shown})`, which hands it back) instead of fetching it again"
+                        ),
                     );
                     return;
                 }

--- a/src/interchangeable_aliases.rs
+++ b/src/interchangeable_aliases.rs
@@ -20,10 +20,10 @@ rustc_session::declare_lint! {
     /// `let p: PackageId = ..`, returned from a `-> PackageId` function,
     /// defining a `PackageId` const, or compared with a `PackageId` value,
     /// where both aliases name the same primitive integer. Two aliases over
-    /// one integer exist to tell two kinds of number apart, but since both
-    /// are the plain integer the compiler accepts one where the other is
-    /// meant; a newtype per kind would not. The
-    /// kinds are read off the written types of this crate's locals,
+    /// one integer exist to tell two kinds of number apart, but both are the
+    /// plain integer, so the mix-up compiles. A newtype per kind would
+    /// reject it. The kinds are read off the written types of this crate's
+    /// locals,
     /// parameters, fields, consts and signatures, so the lint stays quiet
     /// when either side has no alias (a literal, a plain `u32`, arithmetic
     /// between two values), when one alias is declared as the other, through
@@ -221,15 +221,18 @@ fn check_value<'tcx>(cx: &LateContext<'tcx>, src: &'tcx Expr<'tcx>, to: &Kind<'t
                 .flatten()
                 .map_or_else(|| format!("#{idx}"), |i| i.to_string());
             format!(
-                "is passed as `{to_name}` parameter `{param}` of `{}`",
+                "is passed as the `{to_name}` parameter `{param}` of `{}`",
                 def_name(cx, callee)
             )
         }
-        &Slot::Field(f) => format!("is stored in `{to_name}` field `{}`", def_name(cx, f)),
+        &Slot::Field(f) => format!("is stored in the `{to_name}` field `{}`", def_name(cx, f)),
         Slot::Local(pat) => format!("is bound to `{pat}: {to_name}`"),
-        &Slot::Return(f) => format!("is returned from `{}` as `{to_name}`", def_name(cx, f)),
-        &Slot::Const(c) => format!("defines `{to_name}` const `{}`", def_name(cx, c)),
-        Slot::Compared(other) => format!("is compared with `{other}`, declared `{to_name}`"),
+        &Slot::Return(f) => format!("is returned from `{}` as a `{to_name}`", def_name(cx, f)),
+        &Slot::Const(c) => format!(
+            "is used to define the `{to_name}` const `{}`",
+            def_name(cx, c)
+        ),
+        Slot::Compared(other) => format!("is compared with `{other}`, a `{to_name}`"),
     };
     let from_name = def_name(cx, from.written);
     emit_with_note(
@@ -237,15 +240,14 @@ fn check_value<'tcx>(cx: &LateContext<'tcx>, src: &'tcx Expr<'tcx>, to: &Kind<'t
         INTERCHANGEABLE_ALIASES,
         src.span,
         format!(
-            "`{}` is declared `{from_name}` but {lands}, and since both aliases are plain `{}` the compiler accepts one where the other is meant",
+            "`{}` is a `{from_name}` but {lands}. Both are plain `{}`, so the mix-up compiles",
             snippet(cx, src.span, ".."),
             to.int,
         ),
         from.decl,
-        format!("the `{from_name}` declaration this value comes from"),
+        format!("the `{from_name}` this value comes from"),
         format!(
-            "make `{from_name}` and `{to_name}` newtypes (`struct {to_name}({});`) instead of aliases; this line then fails to compile until the right id is passed",
-            to.int,
+            "make `{from_name}` and `{to_name}` newtypes instead of aliases. This line then fails to compile until the right id is used"
         ),
     );
 }

--- a/src/interchangeable_aliases.rs
+++ b/src/interchangeable_aliases.rs
@@ -4,9 +4,10 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{BinOpKind, Body, Expr, ExprKind, LetStmt, Node, Ty as HirTy};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty, VariantDef};
+use rustc_span::Span;
 
 use crate::adt_facts::cfg_selected;
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{
     Callee, assigned_adt_field, callee_of, declared_ty, field_decl_ty, param_decl_ty,
     return_decl_ty, value_expr, written_alias,
@@ -19,8 +20,9 @@ rustc_session::declare_lint! {
     /// `let p: PackageId = ..`, returned from a `-> PackageId` function,
     /// defining a `PackageId` const, or compared with a `PackageId` value,
     /// where both aliases name the same primitive integer. Two aliases over
-    /// one integer exist to tell two kinds of number apart, and rustc erases
-    /// both, so nothing rejects the crossing; a newtype per kind would. The
+    /// one integer exist to tell two kinds of number apart, but since both
+    /// are the plain integer the compiler accepts one where the other is
+    /// meant; a newtype per kind would not. The
     /// kinds are read off the written types of this crate's locals,
     /// parameters, fields, consts and signatures, so the lint stays quiet
     /// when either side has no alias (a literal, a plain `u32`, arithmetic
@@ -42,6 +44,8 @@ struct Kind<'tcx> {
     written: DefId,
     root: DefId,
     int: Ty<'tcx>,
+    /// Where the type was written.
+    decl: Span,
 }
 
 /// `type A = B;` names `B`'s kind; follow the chain while it stays visible.
@@ -82,7 +86,12 @@ fn kind_of<'tcx>(cx: &LateContext<'tcx>, ty: &HirTy<'_>) -> Option<Kind<'tcx>> {
         .type_of(root)
         .instantiate_identity()
         .skip_normalization();
-    matches!(int.kind(), ty::Int(_) | ty::Uint(_)).then_some(Kind { written, root, int })
+    matches!(int.kind(), ty::Int(_) | ty::Uint(_)).then_some(Kind {
+        written,
+        root,
+        int,
+        decl: ty.span,
+    })
 }
 
 fn is_lit(e: &Expr<'_>) -> bool {
@@ -222,17 +231,22 @@ fn check_value<'tcx>(cx: &LateContext<'tcx>, src: &'tcx Expr<'tcx>, to: &Kind<'t
         &Slot::Const(c) => format!("defines `{to_name}` const `{}`", def_name(cx, c)),
         Slot::Compared(other) => format!("is compared with `{other}`, declared `{to_name}`"),
     };
-    emit(
+    let from_name = def_name(cx, from.written);
+    emit_with_note(
         cx,
         INTERCHANGEABLE_ALIASES,
         src.span,
         format!(
-            "`{}` is declared `{}` but {lands}; both are `{}`, so nothing rejects the crossing",
+            "`{}` is declared `{from_name}` but {lands}, and since both aliases are plain `{}` the compiler accepts one where the other is meant",
             snippet(cx, src.span, ".."),
-            def_name(cx, from.written),
             to.int,
         ),
-        "a newtype per id kind makes this a type error",
+        from.decl,
+        format!("the `{from_name}` declaration this value comes from"),
+        format!(
+            "make `{from_name}` and `{to_name}` newtypes (`struct {to_name}({});`) instead of aliases; this line then fails to compile until the right id is passed",
+            to.int,
+        ),
     );
 }
 

--- a/src/key_not_identity.rs
+++ b/src/key_not_identity.rs
@@ -8,9 +8,12 @@ use rustc_span::sym;
 use crate::MordantConfig;
 
 rustc_session::declare_lint! {
-    /// Flags maps keyed on values that are not the canonical identity of the
-    /// thing they name. Which types and expression forms count is declared per
-    /// project in `dylint.toml`; with no configuration the lint is silent.
+    /// Flags a map keyed on something that does not identify the thing it
+    /// names, so distinct things can collide under one key or one thing can
+    /// land under several: a type or method the project lists as not an
+    /// identity, a float's `to_bits()`, a pointer cast to an integer. Which
+    /// types and expression forms count is declared per project in
+    /// `dylint.toml`; with no configuration the lint is silent.
     pub KEY_NOT_IDENTITY,
     Warn,
     "map keyed on a value that is not the canonical identity of what it names"
@@ -85,10 +88,15 @@ impl KeyNotIdentity {
     }
 
     /// A direct hit, or (opt-in) a denied type inside a tuple or one level of
-    /// struct fields with no declared identity-fixing component beside it.
-    fn denied_type_name<'tcx>(&self, cx: &LateContext<'tcx>, key_ty: Ty<'tcx>) -> Option<String> {
+    /// struct fields with no declared identity-fixing component beside it:
+    /// the key as the message shows it, and the denied type in it.
+    fn denied_type_name<'tcx>(
+        &self,
+        cx: &LateContext<'tcx>,
+        key_ty: Ty<'tcx>,
+    ) -> Option<(String, String)> {
         if let Some(path) = self.is_denied(cx, key_ty) {
-            return Some(path);
+            return Some((format!("`{path}`"), path));
         }
         if !self.config.key_not_identity_composite {
             return None;
@@ -107,8 +115,7 @@ impl KeyNotIdentity {
         if components.iter().any(|t| self.is_fixing(cx, *t)) {
             return None;
         }
-        // Renders as: map keyed on `(Span, u32)` carrying `Span`, ...
-        Some(format!("{key_ty}` carrying `{hit}"))
+        Some((format!("`{key_ty}`, which contains a `{hit}`"), hit))
     }
 }
 
@@ -181,13 +188,31 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
             return;
         };
 
-        if let Some(path) = self.denied_type_name(cx, key_ty) {
+        if let Some((shown, denied)) = self.denied_type_name(cx, key_ty) {
+            let fixes: Vec<String> = self
+                .config
+                .key_not_identity_fixes
+                .iter()
+                .map(|f| format!("`{f}`"))
+                .collect();
+            let help = if fixes.is_empty() {
+                format!(
+                    "key on what does identify the value in this project instead of its `{denied}`"
+                )
+            } else {
+                format!(
+                    "key on what does identify the value: this project's `key-not-identity-fixes` names {} as what makes a `{denied}` unambiguous, so put that in the key beside it",
+                    fixes.join(", "),
+                )
+            };
             emit(
                 cx,
                 KEY_NOT_IDENTITY,
                 expr.span,
-                format!("map keyed on `{path}`, which this project declares is not an identity"),
-                "key on the canonical identity of the thing this names",
+                format!(
+                    "this map is keyed on {shown}, and `{denied}` is listed in this project's `key-not-identity-types`: equal `{denied}`s need not mean the same thing, so distinct entries can collide"
+                ),
+                help,
             );
             return;
         }
@@ -205,8 +230,8 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
                 cx,
                 KEY_NOT_IDENTITY,
                 key_expr.span,
-                "map keyed on `to_bits()` of a float",
-                "for boxed or interned values the bits are a pointer, not the value; key on the canonical identity",
+                "this map is keyed on a float's `to_bits()`; for a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys",
+                "key on the value itself or its canonical handle, not on its bit pattern",
             );
         }
         // Project-declared methods whose result is not an identity (e.g. a
@@ -217,15 +242,15 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
             && let Some(mdid) = cx.typeck_results().type_dependent_def_id(key_expr.hir_id)
             && configured(cx, mdid, deny_methods).is_some()
         {
+            let method = kseg.ident;
             emit(
                 cx,
                 KEY_NOT_IDENTITY,
                 key_expr.span,
                 format!(
-                    "map keyed on `{}()`, which this project declares is not an identity",
-                    kseg.ident
+                    "this map is keyed on the result of `{method}()`, which this project's `key-not-identity-methods` lists as not an identity, so equal things can land under different keys"
                 ),
-                "key on the canonical identity of the thing this names",
+                format!("key on the value's identity rather than on what `{method}()` returns"),
             );
         }
         if self.forms.contains(&KeyForm::PtrCast) && is_ptr_to_int_cast(cx, key_expr) {
@@ -233,8 +258,8 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
                 cx,
                 KEY_NOT_IDENTITY,
                 key_expr.span,
-                "map keyed on a pointer cast to an integer",
-                "pointer bits name an allocation, not a value; key on the canonical identity",
+                "this map is keyed on a pointer cast to an integer, which names an allocation rather than a value: equal values at two addresses get two entries, and a freed-and-reused address aliases an old one",
+                "key on the value, or on an id assigned when it is created, not on its address",
             );
         }
     }

--- a/src/key_not_identity.rs
+++ b/src/key_not_identity.rs
@@ -9,14 +9,15 @@ use crate::MordantConfig;
 
 rustc_session::declare_lint! {
     /// Flags a map keyed on something that does not identify the thing it
-    /// names, so distinct things can collide under one key or one thing can
-    /// land under several: a type or method the project lists as not an
-    /// identity, a float's `to_bits()`, a pointer cast to an integer. Which
-    /// types and expression forms count is declared per project in
-    /// `dylint.toml`; with no configuration the lint is silent.
+    /// names, so two different things can share a key and overwrite each
+    /// other, or one thing can land under several: a type or method the
+    /// project lists as not an identity, a float's `to_bits()`, a pointer
+    /// cast to an integer. Which types and expression forms count is declared
+    /// per project in `dylint.toml`. With no configuration the lint is
+    /// silent.
     pub KEY_NOT_IDENTITY,
     Warn,
-    "map keyed on a value that is not the canonical identity of what it names"
+    "map keyed on a value that does not identify what it names"
 }
 
 /// A key-expression form `key-not-identity-forms` can opt into. These variants
@@ -89,14 +90,17 @@ impl KeyNotIdentity {
 
     /// A direct hit, or (opt-in) a denied type inside a tuple or one level of
     /// struct fields with no declared identity-fixing component beside it:
-    /// the key as the message shows it, and the denied type in it.
+    /// how the message introduces the key, and the denied type in it.
     fn denied_type_name<'tcx>(
         &self,
         cx: &LateContext<'tcx>,
         key_ty: Ty<'tcx>,
     ) -> Option<(String, String)> {
         if let Some(path) = self.is_denied(cx, key_ty) {
-            return Some((format!("`{path}`"), path));
+            return Some((
+                format!("`{path}`, which this project's config says is not an identity"),
+                path,
+            ));
         }
         if !self.config.key_not_identity_composite {
             return None;
@@ -115,7 +119,12 @@ impl KeyNotIdentity {
         if components.iter().any(|t| self.is_fixing(cx, *t)) {
             return None;
         }
-        Some((format!("`{key_ty}`, which contains a `{hit}`"), hit))
+        Some((
+            format!(
+                "`{key_ty}`, which contains a `{hit}`, and this project's config says `{hit}` is not an identity"
+            ),
+            hit,
+        ))
     }
 }
 
@@ -196,12 +205,10 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
                 .map(|f| format!("`{f}`"))
                 .collect();
             let help = if fixes.is_empty() {
-                format!(
-                    "key on what does identify the value in this project instead of its `{denied}`"
-                )
+                format!("key on something that does identify the value instead of its `{denied}`")
             } else {
                 format!(
-                    "key on what does identify the value: this project's `key-not-identity-fixes` names {} as what makes a `{denied}` unambiguous, so put that in the key beside it",
+                    "key on something that does identify the value. The config names {} as what makes a `{denied}` unambiguous, so add it to the key",
                     fixes.join(", "),
                 )
             };
@@ -210,7 +217,7 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
                 KEY_NOT_IDENTITY,
                 expr.span,
                 format!(
-                    "this map is keyed on {shown}, and `{denied}` is listed in this project's `key-not-identity-types`: equal `{denied}`s need not mean the same thing, so distinct entries can collide"
+                    "this map is keyed on {shown}. Two different things can share a `{denied}` and overwrite each other"
                 ),
                 help,
             );
@@ -230,8 +237,8 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
                 cx,
                 KEY_NOT_IDENTITY,
                 key_expr.span,
-                "this map is keyed on a float's `to_bits()`; for a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys",
-                "key on the value itself or its canonical handle, not on its bit pattern",
+                "this map is keyed on a float's `to_bits()`. For a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys",
+                "key on the value itself or its handle, not on its bit pattern",
             );
         }
         // Project-declared methods whose result is not an identity (e.g. a
@@ -248,9 +255,9 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
                 KEY_NOT_IDENTITY,
                 key_expr.span,
                 format!(
-                    "this map is keyed on the result of `{method}()`, which this project's `key-not-identity-methods` lists as not an identity, so equal things can land under different keys"
+                    "this map is keyed on the result of `{method}()`, which this project's config says is not an identity. Two equal things can land under different keys"
                 ),
-                format!("key on the value's identity rather than on what `{method}()` returns"),
+                format!("key on what identifies the value, not on what `{method}()` returns"),
             );
         }
         if self.forms.contains(&KeyForm::PtrCast) && is_ptr_to_int_cast(cx, key_expr) {
@@ -258,7 +265,7 @@ impl<'tcx> LateLintPass<'tcx> for KeyNotIdentity {
                 cx,
                 KEY_NOT_IDENTITY,
                 key_expr.span,
-                "this map is keyed on a pointer cast to an integer, which names an allocation rather than a value: equal values at two addresses get two entries, and a freed-and-reused address aliases an old one",
+                "this map is keyed on a pointer cast to an integer, which names an allocation and not a value. Equal values at two addresses get two entries, and a freed and reused address looks like an old one",
                 "key on the value, or on an id assigned when it is created, not on its address",
             );
         }

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -11,9 +11,9 @@ use crate::baseline::emit_with_note;
 use crate::hir_shapes::{FieldChain, dotted, field_chain, is_self_path, stmt_expr};
 
 rustc_session::declare_lint! {
-    /// Flags two locks the crate takes in both orders: one body locks `b`
+    /// Flags two locks the crate takes in both orders: one place locks `b`
     /// while `a` is held, another locks `a` while `b` is held. Each order
-    /// alone is fine; with both, two threads taking one path each can
+    /// alone is fine. With both, two threads, one on each path, can
     /// deadlock. The claim is only that both orders exist, with the two
     /// locations shown.
     ///
@@ -168,12 +168,12 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
                 findings.push((
                     *span,
                     format!(
-                        "`{b}` is locked here while `{a}` is held, and another place locks `{a}` while `{b}` is held, so two threads taking one path each can deadlock"
+                        "`{b}` is locked here while `{a}` is held. Another place locks `{a}` while `{b}` is held. Two threads, one on each path, can deadlock"
                     ),
                     *rev_span,
-                    format!("the opposite order: `{a}` locked while `{b}` is held"),
+                    "the opposite order is here".to_string(),
                     format!(
-                        "pick one order for `{a}` and `{b}` and take them that way in both places, or take both under one lock"
+                        "pick one order for `{a}` and `{b}` and use it in both places, or guard both with one lock"
                     ),
                 ));
             }

--- a/src/lock_order.rs
+++ b/src/lock_order.rs
@@ -7,15 +7,15 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_span::Span;
 
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{FieldChain, dotted, field_chain, is_self_path, stmt_expr};
 
 rustc_session::declare_lint! {
-    /// Flags two lock acquisitions the crate performs in both orders: one
-    /// body takes `a` then `b` while `a`'s guard is still live, another takes
-    /// `b` then `a`. Each order alone is fine; both together are the shape of
-    /// a deadlock waiting for the right interleaving. The claim is only that
-    /// both orders exist, with the two locations named.
+    /// Flags two locks the crate takes in both orders: one body locks `b`
+    /// while `a` is held, another locks `a` while `b` is held. Each order
+    /// alone is fine; with both, two threads taking one path each can
+    /// deadlock. The claim is only that both orders exist, with the two
+    /// locations shown.
     ///
     /// Conservative on purpose: only `.lock()`, `.read()` and `.write()` on
     /// receivers whose type is a `Mutex` or `RwLock`, only guards bound by
@@ -156,8 +156,7 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let sm = cx.tcx.sess.source_map();
-        let mut findings: Vec<(Span, String)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, String, String)> = Vec::new();
         for ((a, b), span) in &self.pairs {
             // Report each conflicting pair once, from the lexically smaller
             // side, so the two orders produce one finding, not two.
@@ -169,22 +168,20 @@ impl<'tcx> LateLintPass<'tcx> for LockOrder {
                 findings.push((
                     *span,
                     format!(
-                        "`{a}` is locked before `{b}` here, but `{b}` before `{a}` at {}",
-                        sm.span_to_diagnostic_string(*rev_span),
+                        "`{b}` is locked here while `{a}` is held, and another place locks `{a}` while `{b}` is held, so two threads taking one path each can deadlock"
+                    ),
+                    *rev_span,
+                    format!("the opposite order: `{a}` locked while `{b}` is held"),
+                    format!(
+                        "pick one order for `{a}` and `{b}` and take them that way in both places, or take both under one lock"
                     ),
                 ));
             }
         }
         // `pairs` is a HashMap; report in source order.
-        findings.sort_by_key(|(span, _)| span.lo());
-        for (span, msg) in findings {
-            emit(
-                cx,
-                LOCK_ORDER,
-                span,
-                msg,
-                "both orders existing is the shape of a deadlock; pick one order and hold to it everywhere",
-            );
+        findings.sort_by_key(|(span, ..)| span.lo());
+        for (span, msg, rev, note, help) in findings {
+            emit_with_note(cx, LOCK_ORDER, span, msg, rev, note, help);
         }
     }
 }

--- a/src/narrowed_two_ways.rs
+++ b/src/narrowed_two_ways.rs
@@ -16,13 +16,12 @@ use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
     /// Flags an integer place — a struct field, or a local or parameter
-    /// within one function — that the crate narrows two ways: at one site it
-    /// is converted into a smaller or differently signed integer through
-    /// `u32::try_from(x)` or `x.try_into()`, and at another the same place
-    /// goes through a bare `as`, which wraps silently. The check says the
-    /// value may not fit; the `as` site is where it will not. The place's
-    /// declared type is wider than what its readers need, so the range
-    /// invariant lives in whichever reader remembered it.
+    /// within one function — that is cut down with a bare `as` at one site,
+    /// which silently wraps a value that does not fit, while another site
+    /// converts the same place into a type no wider with `u32::try_from(x)`
+    /// or `x.try_into()` because it might not fit. The place's declared type
+    /// is wider than what its readers need, so the range check lives in
+    /// whichever reader remembered it.
     ///
     /// A field is one place whatever it is read through, keyed by the struct
     /// that declares it; a local is a place only inside its own body. Only
@@ -314,7 +313,7 @@ impl<'tcx> LateLintPass<'tcx> for NarrowedTwoWays {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut findings: Vec<(Span, Span, String)> = Vec::new();
+        let mut findings: Vec<(Span, Span, String, String)> = Vec::new();
         for (place, sites) in &self.sites {
             // The widest checked target: a check into `i64` says the value
             // may exceed even that, so every narrower `as` is condemned; a
@@ -337,23 +336,31 @@ impl<'tcx> LateLintPass<'tcx> for NarrowedTwoWays {
                     site.span,
                     check.span,
                     format!(
-                        "narrowed two ways: `{}` is `{}` and becomes `{}` through `as` here, which wraps silently, while another site converts the same place into `{}` with a range check",
-                        site.shown, site.src, site.dst, check.dst,
+                        "`{shown}` is `{}` and is cut down to `{dst}` with `as` here, which silently wraps a value that does not fit, while another place converts the same `{shown}` to `{}` with `try_from`/`try_into` because it might not",
+                        site.src,
+                        check.dst,
+                        shown = site.shown,
+                        dst = site.dst,
+                    ),
+                    format!(
+                        "declare `{}` as `{dst}` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `{dst}::try_from` here too",
+                        site.shown,
+                        dst = site.dst,
                     ),
                 ));
             }
         }
         // `sites` is a HashMap; report in source order.
         findings.sort_by_key(|(span, ..)| span.lo());
-        for (span, check, msg) in findings {
+        for (span, check, msg, help) in findings {
             emit_with_note(
                 cx,
                 NARROWED_TWO_WAYS,
                 span,
                 msg,
                 check,
-                "the same place, converted with a check here",
-                "the check says the value may not fit; declare the place with the narrow type, or a newtype whose constructor checks the range once, so no reader can truncate it (or convert with `try_from` here as well)",
+                "the checked conversion of the same place",
+                help,
             );
         }
     }

--- a/src/narrowed_two_ways.rs
+++ b/src/narrowed_two_ways.rs
@@ -15,11 +15,11 @@ use crate::baseline::emit_with_note;
 use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
-    /// Flags an integer place — a struct field, or a local or parameter
-    /// within one function — that is cut down with a bare `as` at one site,
-    /// which silently wraps a value that does not fit, while another site
-    /// converts the same place into a type no wider with `u32::try_from(x)`
-    /// or `x.try_into()` because it might not fit. The place's declared type
+    /// Flags an integer place (a struct field, or a local or parameter
+    /// within one function) that is cut down with a bare `as` at one site,
+    /// which wraps silently, while another site converts the same place into
+    /// a type no wider with `u32::try_from(x)` or `x.try_into()` because it
+    /// might not fit. The place's declared type
     /// is wider than what its readers need, so the range check lives in
     /// whichever reader remembered it.
     ///
@@ -336,14 +336,14 @@ impl<'tcx> LateLintPass<'tcx> for NarrowedTwoWays {
                     site.span,
                     check.span,
                     format!(
-                        "`{shown}` is `{}` and is cut down to `{dst}` with `as` here, which silently wraps a value that does not fit, while another place converts the same `{shown}` to `{}` with `try_from`/`try_into` because it might not",
+                        "`{shown}` is a `{}` cut down to `{dst}` with `as` here, which wraps silently. Another place converts the same `{shown}` to `{}` with `try_from` because it might not fit",
                         site.src,
                         check.dst,
                         shown = site.shown,
                         dst = site.dst,
                     ),
                     format!(
-                        "declare `{}` as `{dst}` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `{dst}::try_from` here too",
+                        "store `{}` as `{dst}` (or a newtype checked once at construction) so nobody has to narrow it. At least use `{dst}::try_from` here as well",
                         site.shown,
                         dst = site.dst,
                     ),
@@ -359,7 +359,7 @@ impl<'tcx> LateLintPass<'tcx> for NarrowedTwoWays {
                 span,
                 msg,
                 check,
-                "the checked conversion of the same place",
+                "the checked conversion",
                 help,
             );
         }

--- a/src/options_as_enum.rs
+++ b/src/options_as_enum.rs
@@ -13,9 +13,9 @@ use crate::MordantConfig;
 
 rustc_session::declare_lint! {
     /// Flags a struct whose `Option` fields are alternatives: none of the
-    /// places it is built sets more than one of them to `Some`, yet the
-    /// struct lets them be set together. One enum field with a variant per
-    /// case says what the code means and cannot hold two at once.
+    /// places it is built sets more than one of them to `Some`, but the
+    /// struct allows both at once. One enum field with a variant per case
+    /// says what the code means and cannot hold two at once.
     ///
     /// Only fires on structs private to the crate, with every construction a
     /// literal `Some(..)`/`None` struct expression and no later field
@@ -144,15 +144,13 @@ impl<'tcx> LateLintPass<'tcx> for OptionsAsEnum {
                 OPTIONS_AS_ENUM,
                 cx.tcx.def_span(*did),
                 format!(
-                    "none of the {} places `{}` is constructed sets more than one of {names} to `Some`, so these fields are alternatives that the struct nevertheless lets be set together",
-                    facts.sites.len(),
+                    "`{}` is built in {} places and none sets more than one of {names} to `Some`. The fields are alternatives, but the struct allows both at once",
                     cx.tcx.def_path_str(*did),
+                    facts.sites.len(),
                 ),
                 facts.sites[0].0,
                 "one of the constructions",
-                format!(
-                    "replace {names} with one enum field that has a variant per case; two `Some`s at once then cannot be written"
-                ),
+                format!("replace {names} with one enum field, one variant per case"),
             );
         }
     }

--- a/src/options_as_enum.rs
+++ b/src/options_as_enum.rs
@@ -1,21 +1,21 @@
 use std::collections::HashMap;
 
 use crate::adt_facts::{field_ty, is_option_ty, private_local_struct};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::assigned_field;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, StructTailExpr};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
-use rustc_span::Symbol;
+use rustc_span::{Span, Symbol};
 
 use crate::MordantConfig;
 
 rustc_session::declare_lint! {
-    /// Flags structs where several `Option` fields together encode one state:
-    /// every construction site in the crate sets at most one of them to
-    /// `Some`. The type permits combinations the crate never builds; an enum
-    /// with one variant per field says what the code means.
+    /// Flags a struct whose `Option` fields are alternatives: none of the
+    /// places it is built sets more than one of them to `Some`, yet the
+    /// struct lets them be set together. One enum field with a variant per
+    /// case says what the code means and cannot hold two at once.
     ///
     /// Only fires on structs private to the crate, with every construction a
     /// literal `Some(..)`/`None` struct expression and no later field
@@ -29,8 +29,9 @@ rustc_session::declare_lint! {
 #[derive(Default)]
 struct Facts {
     unprovable: bool,
-    /// Per construction site: which option fields were `Some`.
-    sites: Vec<Vec<Symbol>>,
+    /// Per construction site: where it is and which option fields were
+    /// `Some`.
+    sites: Vec<(Span, Vec<Symbol>)>,
 }
 
 pub struct OptionsAsEnum {
@@ -95,7 +96,7 @@ impl<'tcx> LateLintPass<'tcx> for OptionsAsEnum {
                         return;
                     }
                 }
-                facts.sites.push(somes);
+                facts.sites.push((expr.span, somes));
             }
             // A later `s.field = ...` write re-opens every combination; the
             // construction sites alone no longer prove anything.
@@ -120,13 +121,13 @@ impl<'tcx> LateLintPass<'tcx> for OptionsAsEnum {
             if facts.unprovable || facts.sites.len() < 2 {
                 continue;
             }
-            if facts.sites.iter().any(|s| s.len() > 1) {
+            if facts.sites.iter().any(|(_, s)| s.len() > 1) {
                 continue;
             }
             // At least two distinct fields must actually appear as Some;
             // otherwise this is one live field and dead siblings, not a state.
             let mut seen: Vec<Symbol> = Vec::new();
-            for site in &facts.sites {
+            for (_, site) in &facts.sites {
                 for f in site {
                     if !seen.contains(f) {
                         seen.push(*f);
@@ -137,17 +138,21 @@ impl<'tcx> LateLintPass<'tcx> for OptionsAsEnum {
                 continue;
             }
             let names: Vec<String> = seen.iter().map(|s| format!("`{s}`")).collect();
-            emit(
+            let names = names.join(", ");
+            emit_with_note(
                 cx,
                 OPTIONS_AS_ENUM,
                 cx.tcx.def_span(*did),
                 format!(
-                    "no construction of `{}` sets more than one of {} to `Some` ({} sites checked)",
-                    cx.tcx.def_path_str(*did),
-                    names.join(", "),
+                    "none of the {} places `{}` is constructed sets more than one of {names} to `Some`, so these fields are alternatives that the struct nevertheless lets be set together",
                     facts.sites.len(),
+                    cx.tcx.def_path_str(*did),
                 ),
-                "these fields encode one state; an enum with one variant per field represents it",
+                facts.sites[0].0,
+                "one of the constructions",
+                format!(
+                    "replace {names} with one enum field that has a variant per case; two `Some`s at once then cannot be written"
+                ),
             );
         }
     }

--- a/src/parallel_bools.rs
+++ b/src/parallel_bools.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
 
 use crate::adt_facts::{field_ty, private_local_struct, struct_field};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::assigned_field;
 use clippy_utils::get_enclosing_block;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, HirId};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
-use rustc_span::Symbol;
+use rustc_span::{Span, Symbol};
 
 rustc_session::declare_lint! {
-    /// Flags bool fields that are never assigned separately: every write to
+    /// Flags bool fields that are always assigned together: every write to
     /// one sits in the same block as a write to the other, across at least two
-    /// functions. Together the fields encode one state; an enum names it and
-    /// makes the unpaired combinations unrepresentable.
+    /// functions, so between them they hold one state that the struct lets
+    /// fall out of step. One enum field naming those states cannot.
     ///
     /// Only fires on structs private to the crate. One lone write to either
     /// field anywhere — `s.f = ..`, `s.f |= ..`, or either through a `Box`,
@@ -25,10 +25,18 @@ rustc_session::declare_lint! {
     "bool fields only ever assigned together"
 }
 
+/// One assignment to a bool field: the body and block it sits in, and the
+/// assignment itself.
+struct Write {
+    body: DefId,
+    block: HirId,
+    at: Span,
+}
+
 #[derive(Default)]
 pub struct ParallelBools {
-    /// (struct, field) -> the (body, block) sites that assign it.
-    writes: HashMap<(DefId, Symbol), Vec<(DefId, HirId)>>,
+    /// (struct, field) -> the sites that assign it.
+    writes: HashMap<(DefId, Symbol), Vec<Write>>,
 }
 
 rustc_session::impl_lint_pass!(ParallelBools => [PARALLEL_BOOLS]);
@@ -71,32 +79,42 @@ impl<'tcx> LateLintPass<'tcx> for ParallelBools {
         self.writes
             .entry((adt.did(), ident.name))
             .or_default()
-            .push((body, block.hir_id));
+            .push(Write {
+                body,
+                block: block.hir_id,
+                at: expr.span,
+            });
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
         // Group fields per struct, then find groups whose write-site sets are
         // identical. Sites are compared as sets of blocks.
         type Sites = std::collections::HashSet<(DefId, HirId)>;
-        let mut per_struct: HashMap<DefId, Vec<(Symbol, Sites)>> = HashMap::new();
-        for ((did, field), sites) in self.writes.drain() {
-            let sites: Sites = sites.into_iter().collect();
-            per_struct.entry(did).or_default().push((field, sites));
+        let mut per_struct: HashMap<DefId, Vec<(Symbol, Sites, Span)>> = HashMap::new();
+        for ((did, field), writes) in self.writes.drain() {
+            let Some(first) = writes.iter().map(|w| w.at).min() else {
+                continue;
+            };
+            let sites: Sites = writes.into_iter().map(|w| (w.body, w.block)).collect();
+            per_struct
+                .entry(did)
+                .or_default()
+                .push((field, sites, first));
         }
         for (did, mut fields) in per_struct {
             if fields.len() < 2 {
                 continue;
             }
-            fields.sort_by_key(|(f, _)| f.as_str().to_owned());
+            fields.sort_by_key(|(f, ..)| f.as_str().to_owned());
             // Partition by identical site-sets.
-            let mut groups: Vec<(&Sites, Vec<Symbol>)> = Vec::new();
-            for (field, sites) in &fields {
-                match groups.iter_mut().find(|(s, _)| *s == sites) {
-                    Some((_, members)) => members.push(*field),
-                    None => groups.push((sites, vec![*field])),
+            let mut groups: Vec<(&Sites, Vec<Symbol>, Span)> = Vec::new();
+            for (field, sites, first) in &fields {
+                match groups.iter_mut().find(|(s, ..)| *s == sites) {
+                    Some((_, members, _)) => members.push(*field),
+                    None => groups.push((sites, vec![*field], *first)),
                 }
             }
-            for (sites, members) in groups {
+            for (sites, members, first) in groups {
                 if members.len() < 2 || sites.len() < 2 {
                     continue;
                 }
@@ -106,18 +124,22 @@ impl<'tcx> LateLintPass<'tcx> for ParallelBools {
                     continue;
                 }
                 let names: Vec<String> = members.iter().map(|s| format!("`{s}`")).collect();
-                emit(
+                let names = names.join(", ");
+                emit_with_note(
                     cx,
                     PARALLEL_BOOLS,
                     cx.tcx.def_span(did),
                     format!(
-                        "the bool fields {} of `{}` are only ever assigned together ({} sites in {} functions)",
-                        names.join(", "),
+                        "the bool fields {names} of `{}` are always assigned together ({} blocks in {} functions), so between them they hold one state that the struct lets fall out of step",
                         cx.tcx.def_path_str(did),
                         sites.len(),
                         bodies.len(),
                     ),
-                    "together these fields encode one state; an enum makes the unpaired combinations unrepresentable",
+                    first,
+                    "one of the blocks that assigns them together",
+                    format!(
+                        "replace {names} with one enum field naming the states those blocks set; a combination no block writes then cannot exist"
+                    ),
                 );
             }
         }

--- a/src/parallel_bools.rs
+++ b/src/parallel_bools.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::adt_facts::{field_ty, private_local_struct, struct_field};
-use crate::baseline::emit_with_note;
+use crate::baseline::{emit_with_note, join};
 use crate::hir_shapes::assigned_field;
 use clippy_utils::get_enclosing_block;
 use rustc_hir::def_id::DefId;
@@ -13,8 +13,8 @@ use rustc_span::{Span, Symbol};
 rustc_session::declare_lint! {
     /// Flags bool fields that are always assigned together: every write to
     /// one sits in the same block as a write to the other, across at least two
-    /// functions, so between them they hold one state that the struct lets
-    /// fall out of step. One enum field naming those states cannot.
+    /// functions. Together they hold one state, and the struct lets them
+    /// drift apart. One enum field naming those states cannot.
     ///
     /// Only fires on structs private to the crate. One lone write to either
     /// field anywhere — `s.f = ..`, `s.f |= ..`, or either through a `Box`,
@@ -124,21 +124,22 @@ impl<'tcx> LateLintPass<'tcx> for ParallelBools {
                     continue;
                 }
                 let names: Vec<String> = members.iter().map(|s| format!("`{s}`")).collect();
+                let anded = join(&names, "and");
                 let names = names.join(", ");
                 emit_with_note(
                     cx,
                     PARALLEL_BOOLS,
                     cx.tcx.def_span(did),
                     format!(
-                        "the bool fields {names} of `{}` are always assigned together ({} blocks in {} functions), so between them they hold one state that the struct lets fall out of step",
+                        "{anded} of `{}` are always assigned together ({} blocks in {} functions). Together they hold one state, and the struct lets them drift apart",
                         cx.tcx.def_path_str(did),
                         sites.len(),
                         bodies.len(),
                     ),
                     first,
-                    "one of the blocks that assigns them together",
+                    "one of the blocks that sets both",
                     format!(
-                        "replace {names} with one enum field naming the states those blocks set; a combination no block writes then cannot exist"
+                        "replace {names} with one enum field whose variants are the states those blocks set"
                     ),
                 );
             }

--- a/src/parallel_params.rs
+++ b/src/parallel_params.rs
@@ -16,18 +16,17 @@ use rustc_span::symbol::kw;
 use rustc_span::{Span, Symbol};
 
 use crate::MordantConfig;
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
     /// Flags two or more plain-data parameters that `parallel-params-min-fns`
-    /// or more crate-private functions declare under the same names and
-    /// types and pass among themselves: every counted function hands the
-    /// group, unchanged and in one call, to another of them, or receives it
-    /// that way. The group arrives together, is checked together and leaves
-    /// together: it is one value, and the only place it has no name is the
-    /// type system, so nothing keeps a caller from passing half of it, or two
-    /// halves of different wholes.
+    /// or more crate-private functions declare alike (same names and types)
+    /// and hand each other unchanged: every counted function passes the
+    /// group in one call to another of them, or receives it that way. The
+    /// group is one value that only exists as loose parameters, so nothing
+    /// keeps a caller from mixing them up or passing half of it; a struct
+    /// with those fields does.
     ///
     /// Plain data is scalars, `&str`, shared slices, and structs and enums
     /// made only of those. `&mut` borrows, references and pointers to
@@ -336,7 +335,7 @@ impl<'tcx> LateLintPass<'tcx> for ParallelParams {
             }
             witnesses.extend(links[key].iter().copied());
         }
-        let mut findings: Vec<(Span, String)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, String, String)> = Vec::new();
         for (sig, (mut slots, mut witnesses)) in groups {
             let anchor = &self.fns[&sig[0]];
             // Slots in the anchor's declaration order, printed as written there.
@@ -373,27 +372,30 @@ impl<'tcx> LateLintPass<'tcx> for ParallelParams {
                 }
             };
             let names: Vec<String> = sig.iter().map(name).collect();
+            let fields: Vec<String> = slots.iter().map(|(n, _)| format!("`{n}`")).collect();
+            let fns = listed(&names);
             findings.push((
                 at,
                 format!(
-                    "parameters {} pass unchanged between {} ({} hands them to {} in one call): one value travelling as {} parameters",
+                    "{} are declared alike by {fns} and handed between them unchanged, so they are one value that only exists as {} loose parameters a caller can mix up or pass by halves",
                     join(&shown),
-                    listed(&names),
-                    name(&witness.from),
-                    name(&witness.to),
                     slots.len(),
+                ),
+                witness.span,
+                format!(
+                    "{} hands them to {} here",
+                    name(&witness.from),
+                    name(&witness.to)
+                ),
+                format!(
+                    "declare a struct with fields {} and make {fns} take it as one parameter",
+                    join(&fields),
                 ),
             ));
         }
-        findings.sort_by_key(|(span, _)| span.lo());
-        for (span, msg) in findings {
-            emit(
-                cx,
-                PARALLEL_PARAMS,
-                span,
-                msg,
-                "a struct with these fields names the value; each function then takes, checks and forwards one parameter",
-            );
+        findings.sort_by_key(|(span, ..)| span.lo());
+        for (span, msg, witness, note, help) in findings {
+            emit_with_note(cx, PARALLEL_PARAMS, span, msg, witness, note, help);
         }
     }
 }

--- a/src/parallel_params.rs
+++ b/src/parallel_params.rs
@@ -16,17 +16,17 @@ use rustc_span::symbol::kw;
 use rustc_span::{Span, Symbol};
 
 use crate::MordantConfig;
-use crate::baseline::emit_with_note;
+use crate::baseline::{emit_with_note, join};
 use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
     /// Flags two or more plain-data parameters that `parallel-params-min-fns`
     /// or more crate-private functions declare alike (same names and types)
-    /// and hand each other unchanged: every counted function passes the
+    /// and pass between them unchanged: every counted function passes the
     /// group in one call to another of them, or receives it that way. The
-    /// group is one value that only exists as loose parameters, so nothing
-    /// keeps a caller from mixing them up or passing half of it; a struct
-    /// with those fields does.
+    /// group is one value travelling as loose parameters, so nothing keeps a
+    /// caller from mixing them up or passing half of it. A struct with those
+    /// fields does.
     ///
     /// Plain data is scalars, `&str`, shared slices, and structs and enums
     /// made only of those. `&mut` borrows, references and pointers to
@@ -377,8 +377,8 @@ impl<'tcx> LateLintPass<'tcx> for ParallelParams {
             findings.push((
                 at,
                 format!(
-                    "{} are declared alike by {fns} and handed between them unchanged, so they are one value that only exists as {} loose parameters a caller can mix up or pass by halves",
-                    join(&shown),
+                    "{} are declared the same way by {fns} and passed between them unchanged. They are one value travelling as {} loose parameters",
+                    join(&shown, "and"),
                     slots.len(),
                 ),
                 witness.span,
@@ -387,10 +387,7 @@ impl<'tcx> LateLintPass<'tcx> for ParallelParams {
                     name(&witness.from),
                     name(&witness.to)
                 ),
-                format!(
-                    "declare a struct with fields {} and make {fns} take it as one parameter",
-                    join(&fields),
-                ),
+                format!("put {} in a struct and pass that", join(&fields, "and")),
             ));
         }
         findings.sort_by_key(|(span, ..)| span.lo());
@@ -400,20 +397,11 @@ impl<'tcx> LateLintPass<'tcx> for ParallelParams {
     }
 }
 
-/// `a`, `a and b`, `a, b and c`.
-fn join(items: &[String]) -> String {
-    match items {
-        [] => String::new(),
-        [one] => one.clone(),
-        [head @ .., last] => format!("{} and {last}", head.join(", ")),
-    }
-}
-
 /// Up to four names, then a count of the rest.
 fn listed(names: &[String]) -> String {
     const SHOWN: usize = 4;
     if names.len() <= SHOWN {
-        join(names)
+        join(names, "and")
     } else {
         format!(
             "{} and {} more functions",
@@ -425,7 +413,8 @@ fn listed(names: &[String]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{join, listed};
+    use super::listed;
+    use crate::baseline::join;
 
     fn owned(xs: &[&str]) -> Vec<String> {
         xs.iter().map(|s| (*s).to_owned()).collect()
@@ -433,9 +422,9 @@ mod tests {
 
     #[test]
     fn join_reads_as_prose() {
-        assert_eq!(join(&owned(&["a"])), "a");
-        assert_eq!(join(&owned(&["a", "b"])), "a and b");
-        assert_eq!(join(&owned(&["a", "b", "c"])), "a, b and c");
+        assert_eq!(join(&owned(&["a"]), "and"), "a");
+        assert_eq!(join(&owned(&["a", "b"]), "and"), "a and b");
+        assert_eq!(join(&owned(&["a", "b", "c"]), "or"), "a, b or c");
     }
 
     #[test]

--- a/src/parallel_vecs.rs
+++ b/src/parallel_vecs.rs
@@ -12,7 +12,7 @@ use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::{DesugaringKind, Ident, Span, Symbol, sym};
 
 use crate::adt_facts::field_ty;
-use crate::baseline::emit_with_note;
+use crate::baseline::{emit_with_note, join};
 use crate::hir_shapes::{assigned_field, field_method_call, indexed_field};
 
 rustc_session::declare_lint! {
@@ -24,10 +24,9 @@ rustc_session::declare_lint! {
     /// other, on the same value, and every struct literal starts both empty
     /// -- and that some function reads at one index (`s.a[i]` with `s.b[i]`,
     /// `s.a.get(i)` with `s.b.get(i)`) or zips together. Element `i` of each
-    /// is one record split across several vecs whose lengths the struct lets
-    /// differ; only the discipline of every writer keeps `a[i]` describing
-    /// the same thing as `b[i]`. One `Vec` whose element struct has a field
-    /// for each has one length and one push.
+    /// is one record split across several vecs, and only the discipline of
+    /// every writer keeps `a[i]` describing the same thing as `b[i]`. One
+    /// `Vec` of a struct with a field for each has one length and one push.
     ///
     /// Only fields nothing outside the crate can write are considered: the
     /// struct is private to the crate, or the field is. One mutable access
@@ -559,22 +558,20 @@ impl<'tcx> LateLintPass<'tcx> for ParallelVecs {
         findings.sort_by_key(|(adt, ..)| cx.tcx.def_span(*adt).lo());
         for (adt, members, sites, read) in findings {
             let names: Vec<String> = members.iter().map(|m| format!("`{m}`")).collect();
+            let names = join(&names, "and");
             let n = members.len();
             emit_with_note(
                 cx,
                 PARALLEL_VECS,
                 cx.tcx.def_span(adt),
                 format!(
-                    "{} of `{}` only ever change length together ({sites} {}) and are read at the same index, so element `i` of each is one record split across {n} vecs whose lengths the struct lets differ",
-                    names.join(", "),
+                    "{names} of `{}` only change length together ({sites} {}) and are read at the same index. Element `i` of each is one record split across {n} vecs",
                     cx.tcx.def_path_str(adt),
                     if sites == 1 { "block" } else { "blocks" },
                 ),
                 read,
                 "one of the reads at a shared index",
-                format!(
-                    "replace the {n} fields with one `Vec` whose element struct has a field for each; then there is one length and one push"
-                ),
+                "use one `Vec` of a struct with a field for each. One length, one push",
             );
         }
     }

--- a/src/parallel_vecs.rs
+++ b/src/parallel_vecs.rs
@@ -9,10 +9,10 @@ use rustc_hir::{
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_span::hygiene::{ExpnKind, MacroKind};
-use rustc_span::{DesugaringKind, Ident, Symbol, sym};
+use rustc_span::{DesugaringKind, Ident, Span, Symbol, sym};
 
 use crate::adt_facts::field_ty;
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{assigned_field, field_method_call, indexed_field};
 
 rustc_session::declare_lint! {
@@ -24,10 +24,10 @@ rustc_session::declare_lint! {
     /// other, on the same value, and every struct literal starts both empty
     /// -- and that some function reads at one index (`s.a[i]` with `s.b[i]`,
     /// `s.a.get(i)` with `s.b.get(i)`) or zips together. Element `i` of each
-    /// is one record kept in several places by hand: the type admits
-    /// sequences of different lengths, and only the discipline of every
-    /// writer keeps `a[i]` describing the same thing as `b[i]`. One `Vec` of
-    /// a struct with those fields holds the pairing in the type.
+    /// is one record split across several vecs whose lengths the struct lets
+    /// differ; only the discipline of every writer keeps `a[i]` describing
+    /// the same thing as `b[i]`. One `Vec` whose element struct has a field
+    /// for each has one length and one push.
     ///
     /// Only fields nothing outside the crate can write are considered: the
     /// struct is private to the crate, or the field is. One mutable access
@@ -132,8 +132,9 @@ pub struct ParallelVecs {
     candidates: HashMap<DefId, Vec<Symbol>>,
     /// (struct, field) -> the sites that change its length.
     writes: HashMap<(DefId, Symbol), HashSet<Site>>,
-    /// (struct, field, field), names ordered: read at one index somewhere.
-    in_step: HashSet<(DefId, Symbol, Symbol)>,
+    /// (struct, field, field), names ordered -> the first place the two are
+    /// read at one index.
+    in_step: HashMap<(DefId, Symbol, Symbol), Span>,
     reads: Vec<Read>,
 }
 
@@ -304,7 +305,9 @@ impl ParallelVecs {
             }
             let other = cx.tcx.hir_expect_expr(earlier.index);
             if SpanlessEq::new(cx).eq_expr(at.span.ctxt(), other, index) {
-                self.in_step.insert(ordered(adt, earlier.field, field));
+                self.in_step
+                    .entry(ordered(adt, earlier.field, field))
+                    .or_insert(at.span);
             }
         }
         self.reads.push(Read {
@@ -320,6 +323,7 @@ impl ParallelVecs {
     fn record_zip<'tcx>(
         &mut self,
         cx: &LateContext<'tcx>,
+        at: Span,
         l: &'tcx Expr<'tcx>,
         r: &'tcx Expr<'tcx>,
     ) {
@@ -333,7 +337,7 @@ impl ParallelVecs {
             return;
         };
         if adt == radt && lf != rf && lp == rp {
-            self.in_step.insert(ordered(adt, lf, rf));
+            self.in_step.entry(ordered(adt, lf, rf)).or_insert(at);
         }
     }
 }
@@ -436,7 +440,7 @@ impl<'tcx> LateLintPass<'tcx> for ParallelVecs {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         match expr.kind {
             ExprKind::MethodCall(seg, recv, [arg], _) if seg.ident.name.as_str() == "zip" => {
-                self.record_zip(cx, recv, arg);
+                self.record_zip(cx, expr.span, recv, arg);
             }
             ExprKind::Call(callee, [l, r])
                 if matches!(callee.kind, ExprKind::Path(ref qp)
@@ -444,7 +448,7 @@ impl<'tcx> LateLintPass<'tcx> for ParallelVecs {
                         .is_some_and(|d| cx.tcx.opt_item_name(d)
                             .is_some_and(|n| n.as_str() == "zip"))) =>
             {
-                self.record_zip(cx, l, r);
+                self.record_zip(cx, expr.span, l, r);
             }
             ExprKind::MethodCall(_, recv, ..) => {
                 let Some(call) = field_method_call(expr) else {
@@ -526,7 +530,7 @@ impl<'tcx> LateLintPass<'tcx> for ParallelVecs {
         for ((adt, field), sites) in self.writes.drain() {
             per_struct.entry(adt).or_default().push((field, sites));
         }
-        let mut findings: Vec<(DefId, Vec<Symbol>, usize)> = Vec::new();
+        let mut findings: Vec<(DefId, Vec<Symbol>, usize, Span)> = Vec::new();
         for (adt, mut fields) in per_struct {
             fields.sort_by_key(|(f, _)| f.as_str().to_owned());
             let mut groups: Vec<(&HashSet<Site>, Vec<Symbol>)> = Vec::new();
@@ -537,32 +541,40 @@ impl<'tcx> LateLintPass<'tcx> for ParallelVecs {
                 }
             }
             for (sites, members) in groups {
-                let read_in_step = members.iter().any(|a| {
-                    members
-                        .iter()
-                        .any(|b| self.in_step.contains(&ordered(adt, *a, *b)))
-                });
-                if members.len() >= 2 && read_in_step {
-                    findings.push((adt, members, sites.len()));
+                let read_in_step = members
+                    .iter()
+                    .flat_map(|a| {
+                        members
+                            .iter()
+                            .filter_map(|b| self.in_step.get(&ordered(adt, *a, *b)).copied())
+                    })
+                    .min_by_key(|span| span.lo());
+                if members.len() >= 2
+                    && let Some(read) = read_in_step
+                {
+                    findings.push((adt, members, sites.len(), read));
                 }
             }
         }
         findings.sort_by_key(|(adt, ..)| cx.tcx.def_span(*adt).lo());
-        for (adt, members, sites) in findings {
+        for (adt, members, sites, read) in findings {
             let names: Vec<String> = members.iter().map(|m| format!("`{m}`")).collect();
-            emit(
+            let n = members.len();
+            emit_with_note(
                 cx,
                 PARALLEL_VECS,
                 cx.tcx.def_span(adt),
                 format!(
-                    "parallel vecs: the fields {} of `{}` only change length together ({} {}) and are read at one index, so element `i` of each is one record kept in {} places",
+                    "{} of `{}` only ever change length together ({sites} {}) and are read at the same index, so element `i` of each is one record split across {n} vecs whose lengths the struct lets differ",
                     names.join(", "),
                     cx.tcx.def_path_str(adt),
-                    sites,
                     if sites == 1 { "block" } else { "blocks" },
-                    members.len(),
                 ),
-                "one `Vec` of a struct with these fields holds the pairing in the type and cannot let the lengths differ",
+                read,
+                "one of the reads at a shared index",
+                format!(
+                    "replace the {n} fields with one `Vec` whose element struct has a field for each; then there is one length and one push"
+                ),
             );
         }
     }

--- a/src/param_wider_than_callers.rs
+++ b/src/param_wider_than_callers.rs
@@ -11,19 +11,18 @@ use rustc_middle::ty;
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{Callee, callee_of};
 
 rustc_session::declare_lint! {
-    /// Flags a panicking match arm for an enum variant that no existing call
-    /// site can send: the function takes the full enum, panics on `E::C`, and
-    /// every call site in the crate provably passes a different variant
-    /// (constructor literals only — anything else makes the set unknowable
-    /// and the lint silent; a method's receiver is the value sent to `self`,
-    /// so `m.run()` makes `run`'s domain unknowable while `Mode::Off.run()`
-    /// passes `Off`). The parameter type is wider than the function's
-    /// real domain; narrowing it turns the panic into a compile error for
-    /// future callers.
+    /// Flags a match arm that panics on an enum variant no existing call
+    /// passes: the function takes the full enum, panics on `E::C`, and every
+    /// call in the crate provably passes a different variant (constructor
+    /// literals only — anything else makes the set unknowable and the lint
+    /// silent; a method's receiver is the value sent to `self`, so `m.run()`
+    /// makes `run`'s domain unknowable while `Mode::Off.run()` passes `Off`).
+    /// The panic guards a case the parameter type allows and no caller uses;
+    /// narrowing the type turns it into a compile error for future callers.
     pub PARAM_WIDER_THAN_CALLERS,
     Warn,
     "panicking arm for a variant no existing call site passes"
@@ -33,6 +32,8 @@ rustc_session::declare_lint! {
 struct CallFacts {
     passed: HashSet<DefId>,
     sites: usize,
+    /// The first argument recorded, for the note.
+    first: Option<Span>,
     unknown: bool,
 }
 
@@ -59,6 +60,7 @@ impl ParamWiderThanCallers {
         for (i, value) in values {
             let facts = self.calls.entry((def, i)).or_default();
             facts.sites += 1;
+            facts.first.get_or_insert(value.span);
             match crate::enum_facts::ctor_literal_variant(cx, value) {
                 Some(v) => {
                     facts.passed.insert(v);
@@ -174,7 +176,7 @@ impl<'tcx> LateLintPass<'tcx> for ParamWiderThanCallers {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut findings: Vec<(Span, String)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, String)> = Vec::new();
         for (key @ (fn_def, _), arms) in &self.panicking {
             if self.poisoned.contains(fn_def) {
                 continue;
@@ -183,7 +185,10 @@ impl<'tcx> LateLintPass<'tcx> for ParamWiderThanCallers {
                 // Never called: nothing provable about its domain.
                 continue;
             };
-            if calls.unknown || calls.sites == 0 {
+            let Some(first) = calls.first else {
+                continue;
+            };
+            if calls.unknown {
                 continue;
             }
             for (variant, span) in arms {
@@ -196,27 +201,33 @@ impl<'tcx> LateLintPass<'tcx> for ParamWiderThanCallers {
                     .map(|v| format!("`{}`", cx.tcx.item_name(*v)))
                     .collect();
                 passed.sort();
+                let fn_name = cx.tcx.item_name(*fn_def);
+                let variant = cx.tcx.item_name(*variant);
                 findings.push((
                     *span,
                     format!(
-                        "all {} call sites of `{}` pass {}; this arm panics on `{}`, which no existing caller sends",
+                        "this arm panics on `{variant}`, but all {} calls to `{fn_name}` pass only {}, so the panic guards a case the parameter type allows and no caller uses",
                         calls.sites,
-                        cx.tcx.item_name(*fn_def),
                         passed.join(", "),
-                        cx.tcx.item_name(*variant),
+                    ),
+                    first,
+                    format!(
+                        "narrow `{fn_name}`'s parameter to a type that cannot be `{variant}` (a smaller enum, or the payload itself); a future caller passing `{variant}` then fails to compile instead of panicking"
                     ),
                 ));
             }
         }
         // `panicking` is a HashMap; report in source order.
-        findings.sort_by_key(|(span, _)| span.lo());
-        for (span, msg) in findings {
-            emit(
+        findings.sort_by_key(|(span, ..)| span.lo());
+        for (span, msg, first, help) in findings {
+            emit_with_note(
                 cx,
                 PARAM_WIDER_THAN_CALLERS,
                 span,
                 msg,
-                "the parameter is wider than the function's domain; narrow the type and the panic becomes a compile error for future callers",
+                first,
+                "one of the calls",
+                help,
             );
         }
     }

--- a/src/param_wider_than_callers.rs
+++ b/src/param_wider_than_callers.rs
@@ -18,11 +18,11 @@ rustc_session::declare_lint! {
     /// Flags a match arm that panics on an enum variant no existing call
     /// passes: the function takes the full enum, panics on `E::C`, and every
     /// call in the crate provably passes a different variant (constructor
-    /// literals only — anything else makes the set unknowable and the lint
-    /// silent; a method's receiver is the value sent to `self`, so `m.run()`
+    /// literals only, anything else makes the set unknowable and the lint
+    /// silent. A method's receiver is the value sent to `self`, so `m.run()`
     /// makes `run`'s domain unknowable while `Mode::Off.run()` passes `Off`).
-    /// The panic guards a case the parameter type allows and no caller uses;
-    /// narrowing the type turns it into a compile error for future callers.
+    /// The parameter type allows a case no caller uses. Narrowing the type
+    /// turns it into a compile error for future callers.
     pub PARAM_WIDER_THAN_CALLERS,
     Warn,
     "panicking arm for a variant no existing call site passes"
@@ -206,13 +206,13 @@ impl<'tcx> LateLintPass<'tcx> for ParamWiderThanCallers {
                 findings.push((
                     *span,
                     format!(
-                        "this arm panics on `{variant}`, but all {} calls to `{fn_name}` pass only {}, so the panic guards a case the parameter type allows and no caller uses",
+                        "this arm panics on `{variant}`, but all {} calls to `{fn_name}` pass only {}. The parameter type allows a case no caller uses",
                         calls.sites,
                         passed.join(", "),
                     ),
                     first,
                     format!(
-                        "narrow `{fn_name}`'s parameter to a type that cannot be `{variant}` (a smaller enum, or the payload itself); a future caller passing `{variant}` then fails to compile instead of panicking"
+                        "narrow `{fn_name}`'s parameter to a type that cannot be `{variant}`, such as a smaller enum or the payload itself. A caller passing `{variant}` then fails to compile"
                     ),
                 ));
             }

--- a/src/reimplemented_helper.rs
+++ b/src/reimplemented_helper.rs
@@ -14,12 +14,12 @@ use crate::baseline::emit_with_note;
 use crate::hir_clone::{bodies_equal, body_hash, fn_sigs_equal};
 
 rustc_session::declare_lint! {
-    /// Flags a function whose signature and body are the same as another
-    /// function's in the crate: the same parameter and return types and
-    /// bounds, parameters destructured the same way, and the same
-    /// computation once parameters and locals are renamed. One helper
-    /// exists twice under two names, nothing ties the copies together, and a
-    /// fix made to one is silently missing from the other.
+    /// Flags a function with the same signature and, up to renamed locals,
+    /// the same body as another function in the crate: the same parameter
+    /// and return types and bounds, parameters destructured the same way,
+    /// and the same computation. One helper exists twice under two names,
+    /// nothing ties the copies together, and a fix to either silently misses
+    /// the other.
     ///
     /// Bodies smaller than `reimplemented-helper-min-nodes` expression nodes
     /// (default 12) are not compared, so one-line accessors and constructors
@@ -121,18 +121,22 @@ impl<'tcx> LateLintPass<'tcx> for ReimplementedHelper {
         }
         findings.sort_by_key(|(f, _)| f.span.lo());
         for (copy, original) in findings {
+            let (copy_name, original_name) = (
+                cx.tcx.def_path_str(copy.def),
+                cx.tcx.def_path_str(original.def),
+            );
             emit_with_note(
                 cx,
                 REIMPLEMENTED_HELPER,
                 cx.tcx.def_span(copy.def),
                 format!(
-                    "`{}` has the same signature and body as `{}`",
-                    cx.tcx.def_path_str(copy.def),
-                    cx.tcx.def_path_str(original.def),
+                    "`{copy_name}` has the same signature and, up to renamed locals, the same body as `{original_name}`, so one helper exists twice and a fix to either silently misses the other"
                 ),
                 cx.tcx.def_span(original.def),
-                "the same body is here",
-                "one helper written twice drifts apart at the first fix; keep one and call it from the other's callers",
+                format!("`{original_name}`, the other copy"),
+                format!(
+                    "delete `{copy_name}` and call `{original_name}` from its callers (or the reverse)"
+                ),
             );
         }
     }

--- a/src/reimplemented_helper.rs
+++ b/src/reimplemented_helper.rs
@@ -14,11 +14,11 @@ use crate::baseline::emit_with_note;
 use crate::hir_clone::{bodies_equal, body_hash, fn_sigs_equal};
 
 rustc_session::declare_lint! {
-    /// Flags a function with the same signature and, up to renamed locals,
-    /// the same body as another function in the crate: the same parameter
-    /// and return types and bounds, parameters destructured the same way,
-    /// and the same computation. One helper exists twice under two names,
-    /// nothing ties the copies together, and a fix to either silently misses
+    /// Flags a function with the same signature and the same body as
+    /// another function in the crate, apart from local names: the same
+    /// parameter and return types and bounds, parameters destructured the
+    /// same way, and the same computation. One helper exists twice under two
+    /// names, nothing ties the copies together, and a fix to one will miss
     /// the other.
     ///
     /// Bodies smaller than `reimplemented-helper-min-nodes` expression nodes
@@ -130,12 +130,12 @@ impl<'tcx> LateLintPass<'tcx> for ReimplementedHelper {
                 REIMPLEMENTED_HELPER,
                 cx.tcx.def_span(copy.def),
                 format!(
-                    "`{copy_name}` has the same signature and, up to renamed locals, the same body as `{original_name}`, so one helper exists twice and a fix to either silently misses the other"
+                    "`{copy_name}` has the same signature and the same body as `{original_name}`, apart from local names. A fix to one will miss the other"
                 ),
                 cx.tcx.def_span(original.def),
                 format!("`{original_name}`, the other copy"),
                 format!(
-                    "delete `{copy_name}` and call `{original_name}` from its callers (or the reverse)"
+                    "delete `{copy_name}` and call `{original_name}` instead, or the other way round"
                 ),
             );
         }

--- a/src/return_wider_than_body.rs
+++ b/src/return_wider_than_body.rs
@@ -9,17 +9,18 @@ use rustc_middle::ty;
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::enum_facts::{arm_variant, is_panic_arm};
 use crate::hir_shapes::{Callee, callee_of};
 use crate::variant_flow::returned_variants;
 
 rustc_session::declare_lint! {
-    /// Flags a panicking match arm for a variant the matched call can never
-    /// produce: the callee's return type is a crate-local enum, every value
+    /// Flags a match arm that panics on a variant the matched call never
+    /// returns: the callee's return type is a crate-local enum, every value
     /// its body returns is a constructor literal, and the panicked-on variant
-    /// is not among them. The return type promises more than the function
-    /// delivers; narrowing it deletes the caller's panic arm at compile time.
+    /// is not among them. The arm exists only because the return type is
+    /// wider than what the function produces; narrowing it deletes the arm
+    /// at compile time.
     ///
     /// The return set comes from MIR dataflow: constructor aggregates traced
     /// through plain copies between locals, so `let t = ...; t` and branches
@@ -112,17 +113,22 @@ impl<'tcx> LateLintPass<'tcx> for ReturnWiderThanBody {
                 .map(|v| format!("`{}`", adt.variant(*v).name))
                 .collect();
             names.sort();
-            emit(
+            let fn_name = cx.tcx.item_name(*callee);
+            let variant = cx.tcx.item_name(*variant);
+            let enum_name = cx.tcx.item_name(*enum_did);
+            emit_with_note(
                 cx,
                 RETURN_WIDER_THAN_BODY,
                 *span,
                 format!(
-                    "`{}` only ever returns {}; this arm panics on `{}`, which it never constructs",
-                    cx.tcx.item_name(*callee),
+                    "this arm panics on `{variant}`, but `{fn_name}` only ever returns {}, so the arm exists only because `{fn_name}`'s return type `{enum_name}` is wider than what it produces",
                     names.join(", "),
-                    cx.tcx.item_name(*variant),
                 ),
-                "the return type promises more than the function delivers; narrow it and this arm becomes unnecessary at compile time",
+                cx.tcx.def_span(*callee),
+                format!("`{fn_name}`, declared to return any `{enum_name}`"),
+                format!(
+                    "give `{fn_name}` a return type without `{variant}` (a smaller enum, or a struct for the one shape); this arm then cannot be written"
+                ),
             );
         }
     }

--- a/src/return_wider_than_body.rs
+++ b/src/return_wider_than_body.rs
@@ -18,9 +18,8 @@ rustc_session::declare_lint! {
     /// Flags a match arm that panics on a variant the matched call never
     /// returns: the callee's return type is a crate-local enum, every value
     /// its body returns is a constructor literal, and the panicked-on variant
-    /// is not among them. The arm exists only because the return type is
-    /// wider than what the function produces; narrowing it deletes the arm
-    /// at compile time.
+    /// is not among them. The return type is wider than what the function
+    /// produces. Narrowing it deletes the arm at compile time.
     ///
     /// The return set comes from MIR dataflow: constructor aggregates traced
     /// through plain copies between locals, so `let t = ...; t` and branches
@@ -121,13 +120,13 @@ impl<'tcx> LateLintPass<'tcx> for ReturnWiderThanBody {
                 RETURN_WIDER_THAN_BODY,
                 *span,
                 format!(
-                    "this arm panics on `{variant}`, but `{fn_name}` only ever returns {}, so the arm exists only because `{fn_name}`'s return type `{enum_name}` is wider than what it produces",
+                    "this arm panics on `{variant}`, but `{fn_name}` only ever returns {}. The return type `{enum_name}` is wider than what the function produces",
                     names.join(", "),
                 ),
                 cx.tcx.def_span(*callee),
-                format!("`{fn_name}`, declared to return any `{enum_name}`"),
+                format!("`{fn_name}`'s signature"),
                 format!(
-                    "give `{fn_name}` a return type without `{variant}` (a smaller enum, or a struct for the one shape); this arm then cannot be written"
+                    "give `{fn_name}` a return type without `{variant}`. This arm then cannot be written"
                 ),
             );
         }

--- a/src/runtime_typestate.rs
+++ b/src/runtime_typestate.rs
@@ -12,11 +12,11 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, Symbol};
 
 rustc_session::declare_lint! {
-    /// Flags a bool field that two or more methods start by checking and
+    /// Flags a bool field that two or more methods begin by testing and
     /// returning early on: `if self.flag { return ... }` as the first
-    /// statement. Whether those methods may be called is decided at runtime,
-    /// method by method, and only where someone remembered. A type per state
-    /// decides it at compile time everywhere.
+    /// statement. Whether those methods may be called yet is checked at
+    /// runtime, one method at a time, and only where someone remembered. A
+    /// type per state checks it at compile time everywhere.
     ///
     /// The field must also be written somewhere after construction: a flag
     /// that is only ever set in a literal (`is_server`, `minify`) is a role
@@ -24,7 +24,7 @@ rustc_session::declare_lint! {
     /// order.
     pub RUNTIME_TYPESTATE,
     Warn,
-    "bool field enforcing an ordering invariant at runtime"
+    "bool field tested at the top of several methods to order calls at runtime"
 }
 
 #[derive(Default)]
@@ -124,12 +124,12 @@ impl<'tcx> LateLintPass<'tcx> for RuntimeTypestate {
                 RUNTIME_TYPESTATE,
                 cx.tcx.def_span(fdef.did),
                 format!(
-                    "{count} methods of `{owner}` start by testing `{field}` and returning early, so whether they may be called yet is decided at runtime, method by method"
+                    "{count} methods of `{owner}` begin by testing `{field}` and returning early. Whether they may be called yet is checked at runtime, one method at a time"
                 ),
                 *first,
-                "the test at the top of one of those methods",
+                "the test at the top of one of them",
                 format!(
-                    "split `{owner}` into one type per state and put those {count} methods only on the type where `{field}` allows them; calling one too early is then a compile error"
+                    "split `{owner}` into a type per state and put those {count} methods only on the one `{field}` allows. Calling them too early becomes a compile error"
                 ),
             );
         }

--- a/src/runtime_typestate.rs
+++ b/src/runtime_typestate.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::adt_facts::{field_ty, struct_field};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{SelfField, assigned_adt_field, ends_in_return, peel_not, self_field};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::FnKind;
@@ -12,11 +12,11 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::{Span, Symbol};
 
 rustc_session::declare_lint! {
-    /// Flags a bool field that two or more methods test and bail on at entry:
-    /// `if self.flag { return ... }` as the first statement. The ordering
-    /// invariant ("call X before Y") is enforced at runtime, per method, and
-    /// only where someone remembered. A type per state enforces it at compile
-    /// time everywhere.
+    /// Flags a bool field that two or more methods start by checking and
+    /// returning early on: `if self.flag { return ... }` as the first
+    /// statement. Whether those methods may be called is decided at runtime,
+    /// method by method, and only where someone remembered. A type per state
+    /// decides it at compile time everywhere.
     ///
     /// The field must also be written somewhere after construction: a flag
     /// that is only ever set in a literal (`is_server`, `minify`) is a role
@@ -29,7 +29,9 @@ rustc_session::declare_lint! {
 
 #[derive(Default)]
 pub struct RuntimeTypestate {
-    guards: HashMap<(DefId, Symbol), usize>,
+    /// (struct, field) -> how many methods bail on it at entry, and the
+    /// first such test.
+    guards: HashMap<(DefId, Symbol), (usize, Span)>,
     /// Fields assigned, compound-assigned, or mutably borrowed anywhere in
     /// the crate: the ones whose value is a state rather than a setting.
     written: HashSet<(DefId, Symbol)>,
@@ -101,27 +103,34 @@ impl<'tcx> LateLintPass<'tcx> for RuntimeTypestate {
             return;
         };
         if ends_in_return(then) {
-            *self.guards.entry((adt.did(), field)).or_default() += 1;
+            self.guards
+                .entry((adt.did(), field))
+                .or_insert((0, cond.span))
+                .0 += 1;
         }
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        for ((did, field), count) in &self.guards {
+        for ((did, field), (count, first)) in &self.guards {
             if *count < 2 || !self.written.contains(&(*did, *field)) {
                 continue;
             }
             let Some(fdef) = struct_field(cx.tcx.adt_def(*did), *field) else {
                 continue;
             };
-            emit(
+            let owner = cx.tcx.def_path_str(*did);
+            emit_with_note(
                 cx,
                 RUNTIME_TYPESTATE,
                 cx.tcx.def_span(fdef.did),
                 format!(
-                    "`{field}` is tested and bailed on at the start of {count} methods of `{}`",
-                    cx.tcx.def_path_str(*did),
+                    "{count} methods of `{owner}` start by testing `{field}` and returning early, so whether they may be called yet is decided at runtime, method by method"
                 ),
-                "the ordering invariant lives at runtime; a separate type for the guarded state enforces it at compile time",
+                *first,
+                "the test at the top of one of those methods",
+                format!(
+                    "split `{owner}` into one type per state and put those {count} methods only on the type where `{field}` allows them; calling one too early is then a compile error"
+                ),
             );
         }
     }

--- a/src/same_match_twice.rs
+++ b/src/same_match_twice.rs
@@ -12,10 +12,10 @@ use crate::hir_clone::{expr_hash, exprs_equal};
 rustc_session::declare_lint! {
     /// Flags a `match` over an enum that repeats another one somewhere else
     /// in the crate arm for arm: same scrutinee type, same patterns, same arm
-    /// bodies up to the names of the locals they read. The same table from
-    /// variants to results exists twice, which is a method the enum does not
-    /// have; a change to one copy silently misses the other, and a variant
-    /// added later is handled in whichever copy the author remembers.
+    /// bodies up to the names of the locals they read. The mapping exists
+    /// twice, which is a method the enum does not have. A change to one copy
+    /// will miss the other, and a variant added later is handled in
+    /// whichever copy the author remembers.
     ///
     /// Only matches with at least two arms that name a pattern count (a
     /// `_`/binding catch-all plus one arm is a test, not a table), and only
@@ -124,7 +124,7 @@ impl<'tcx> LateLintPass<'tcx> for SameMatchTwice {
                 SAME_MATCH_TWICE,
                 span,
                 format!(
-                    "this `match` on `{name}` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other"
+                    "this `match` on `{name}` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other"
                 ),
                 earlier,
                 "the other copy",

--- a/src/same_match_twice.rs
+++ b/src/same_match_twice.rs
@@ -10,13 +10,12 @@ use crate::baseline::emit_with_note;
 use crate::hir_clone::{expr_hash, exprs_equal};
 
 rustc_session::declare_lint! {
-    /// Flags a `match` over an enum that is written out a second time, arm
-    /// for arm, somewhere else in the crate: same scrutinee type, same
-    /// patterns, same arm bodies up to the names of the locals they read. A
-    /// mapping from variants to values or actions that exists in two places
-    /// is a method the enum does not have; the two copies are kept in step by
-    /// hand, and a variant added later is handled in whichever copy the
-    /// author remembers.
+    /// Flags a `match` over an enum that repeats another one somewhere else
+    /// in the crate arm for arm: same scrutinee type, same patterns, same arm
+    /// bodies up to the names of the locals they read. The same table from
+    /// variants to results exists twice, which is a method the enum does not
+    /// have; a change to one copy silently misses the other, and a variant
+    /// added later is handled in whichever copy the author remembers.
     ///
     /// Only matches with at least two arms that name a pattern count (a
     /// `_`/binding catch-all plus one arm is a test, not a table), and only
@@ -119,17 +118,17 @@ impl<'tcx> LateLintPass<'tcx> for SameMatchTwice {
                 continue;
             }
             reported.push(span);
+            let name = cx.tcx.def_path_str(adt);
             emit_with_note(
                 cx,
                 SAME_MATCH_TWICE,
                 span,
                 format!(
-                    "this `match` on `{}` is written out arm for arm a second time",
-                    cx.tcx.def_path_str(adt),
+                    "this `match` on `{name}` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other"
                 ),
                 earlier,
-                "the same match is here",
-                "the mapping lives in two places kept in step by hand; a method on the enum states it once",
+                "the other copy",
+                format!("move the mapping into a method on `{name}` and call it from both places"),
             );
         }
     }

--- a/src/sentinel_integer.rs
+++ b/src/sentinel_integer.rs
@@ -14,19 +14,19 @@ use rustc_middle::ty::{self, Ty};
 use rustc_span::{Span, Symbol, sym};
 
 use crate::adt_facts::{field_ty, is_option_ty, struct_field};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{assigned_field, callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
-    /// Flags an integer struct field that the crate itself treats as
-    /// sometimes absent — some function compares it `==`/`!=` against
-    /// `T::MAX`, `-1`, or a constant named `INVALID`/`NONE`/`SENTINEL` — and
-    /// that another function indexes with (`v[x.f as usize]`, a slice range
-    /// end, `buf[off..off + len]`, `get_unchecked`) or offsets a pointer by,
-    /// with no test of the field anywhere in that function. One reader knows
-    /// the magic value means "none"; the other turns it into an out-of-bounds
-    /// index or a wild pointer. The type is `u32` when the value set is
-    /// `Option<u32>`, and only convention tells the readers apart.
+    /// Flags an integer struct field that can hold a sentinel — some
+    /// function compares it `==`/`!=` against `T::MAX`, `-1`, or a constant
+    /// named `INVALID`/`NONE`/`SENTINEL`, treating that value as "no value" —
+    /// and that another function indexes with (`v[x.f as usize]`, a slice
+    /// range end, `buf[off..off + len]`, `get_unchecked`) or offsets a pointer
+    /// by without any such test. One reader knows the magic value means
+    /// "none"; the other turns it into an out-of-range index or a wild
+    /// offset. The type is `u32` when the value set is `Option<u32>`, and only
+    /// convention tells the readers apart.
     ///
     /// Reported on the unchecked reader. A function counts as checking the
     /// field if it compares the field, or a local read off it, against
@@ -56,6 +56,8 @@ struct Evidence {
     /// How the first comparison seen spells the sentinel.
     spelling: String,
     compared: usize,
+    /// Where that first comparison is.
+    at: Option<Span>,
 }
 
 #[derive(Clone, Copy)]
@@ -325,10 +327,18 @@ impl SentinelInteger {
         }
     }
 
-    fn compared<'tcx>(&mut self, cx: &LateContext<'tcx>, field: Field, s: &Sentinel, ty: Ty<'tcx>) {
+    fn compared<'tcx>(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        field: Field,
+        s: &Sentinel,
+        ty: Ty<'tcx>,
+        at: Span,
+    ) {
         let ev = self.evidence.entry(field).or_default();
         if ev.compared == 0 {
             ev.spelling = spelling(cx, s, ty);
+            ev.at = Some(at);
         }
         ev.compared += 1;
     }
@@ -346,13 +356,19 @@ impl SentinelInteger {
     }
 
     /// `l == r` / `l != r`, spelled as an operator or an `assert_eq!`.
-    fn equated<'tcx>(&mut self, cx: &LateContext<'tcx>, l: &'tcx Expr<'tcx>, r: &'tcx Expr<'tcx>) {
+    fn equated<'tcx>(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        at: Span,
+        l: &'tcx Expr<'tcx>,
+        r: &'tcx Expr<'tcx>,
+    ) {
         for (a, b) in [(l, r), (r, l)] {
             let fields = self.tested(cx, a);
             if let Some(s) = sentinel_of(cx, b) {
                 let ty = cx.typeck_results().expr_ty(peel_blocks_unsafe(b));
                 for f in fields {
-                    self.compared(cx, f, &s, ty);
+                    self.compared(cx, f, &s, ty, at);
                 }
             }
         }
@@ -383,7 +399,7 @@ impl SentinelInteger {
             {
                 let ty = cx.typeck_results().node_type(leaf.hir_id);
                 for f in &fields {
-                    self.compared(cx, *f, &s, ty);
+                    self.compared(cx, *f, &s, ty, leaf.span);
                 }
             }
         }
@@ -521,7 +537,7 @@ impl<'tcx> LateLintPass<'tcx> for SentinelInteger {
         // `assert_eq!(a, b)` compares through match-arm bindings the operator
         // arm below cannot see back through; read its arguments directly.
         if let Some((l, r)) = Self::assert_eq_args(cx, expr) {
-            self.equated(cx, l, r);
+            self.equated(cx, expr.span, l, r);
         }
         match expr.kind {
             ExprKind::Struct(_, fields, _) => {
@@ -560,7 +576,7 @@ impl<'tcx> LateLintPass<'tcx> for SentinelInteger {
                 }
             }
             ExprKind::Binary(op, l, r) => match op.node {
-                BinOpKind::Eq | BinOpKind::Ne => self.equated(cx, l, r),
+                BinOpKind::Eq | BinOpKind::Ne => self.equated(cx, expr.span, l, r),
                 BinOpKind::Lt | BinOpKind::Le | BinOpKind::Gt | BinOpKind::Ge => {
                     self.tested(cx, l);
                     self.tested(cx, r);
@@ -602,14 +618,14 @@ impl<'tcx> LateLintPass<'tcx> for SentinelInteger {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut findings: Vec<(Span, String)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, String, String)> = Vec::new();
         for (field, reads) in &self.reads {
             let Some(ev) = self.evidence.get(field) else {
                 continue;
             };
-            if ev.compared == 0 {
+            let Some(evidence_at) = ev.at else {
                 continue;
-            }
+            };
             // One report per unchecked function, at its first use.
             let mut first: HashMap<DefId, &Read> = HashMap::new();
             for read in reads {
@@ -626,37 +642,35 @@ impl<'tcx> LateLintPass<'tcx> for SentinelInteger {
                 if self.checks(body, *field) || self.callers_check(body, *field) {
                     continue;
                 }
-                let how = match read.how {
-                    Use::Index => "indexes with",
-                    Use::Offset => "offsets a pointer by",
+                let (how, becomes) = match read.how {
+                    Use::Index => ("indexes with", "an out-of-range index"),
+                    Use::Offset => ("offsets a pointer by", "a wild offset"),
                 };
                 let reader = match cx.tcx.opt_item_name(body) {
                     Some(name) => format!("`{name}`"),
                     None => "this body".to_owned(),
                 };
+                let (owner, name, sentinel) = (cx.tcx.item_name(field.0), field.1, &ev.spelling);
                 findings.push((
                     read.span,
                     format!(
-                        "sentinel `{}` can reach this use: {reader} {how} `{}.{}` and nothing in it tests the field, which the crate compares against that sentinel at {} other site{}",
-                        ev.spelling,
-                        cx.tcx.item_name(field.0),
-                        field.1,
+                        "`{owner}.{name}` can be `{sentinel}`, which {} other place{} in the crate test{} for as \"no value\", but {reader} {how} it here without any such test, so the sentinel becomes {becomes}",
                         ev.compared,
                         if ev.compared == 1 { "" } else { "s" },
+                        if ev.compared == 1 { "s" } else { "" },
+                    ),
+                    evidence_at,
+                    format!("one of the places that treats `{sentinel}` as \"no value\""),
+                    format!(
+                        "store `{name}` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so {reader} has to decide the empty case before it can use the number"
                     ),
                 ));
             }
         }
-        findings.sort_by_key(|(span, _)| span.lo());
-        findings.dedup_by_key(|(span, _)| *span);
-        for (span, msg) in findings {
-            emit(
-                cx,
-                SENTINEL_INTEGER,
-                span,
-                msg,
-                "the field's value set is `Option<int>`; store that (a `NonZero`/`NonMax` niche keeps the size) and no reader can index without deciding the empty case",
-            );
+        findings.sort_by_key(|(span, ..)| span.lo());
+        findings.dedup_by_key(|(span, ..)| *span);
+        for (span, msg, evidence_at, note, help) in findings {
+            emit_with_note(cx, SENTINEL_INTEGER, span, msg, evidence_at, note, help);
         }
     }
 }

--- a/src/sentinel_integer.rs
+++ b/src/sentinel_integer.rs
@@ -18,15 +18,15 @@ use crate::baseline::emit_with_note;
 use crate::hir_shapes::{assigned_field, callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
-    /// Flags an integer struct field that can hold a sentinel — some
+    /// Flags an integer struct field that can hold a sentinel (some
     /// function compares it `==`/`!=` against `T::MAX`, `-1`, or a constant
-    /// named `INVALID`/`NONE`/`SENTINEL`, treating that value as "no value" —
+    /// named `INVALID`/`NONE`/`SENTINEL`, treating that value as "no value")
     /// and that another function indexes with (`v[x.f as usize]`, a slice
     /// range end, `buf[off..off + len]`, `get_unchecked`) or offsets a pointer
-    /// by without any such test. One reader knows the magic value means
-    /// "none"; the other turns it into an out-of-range index or a wild
-    /// offset. The type is `u32` when the value set is `Option<u32>`, and only
-    /// convention tells the readers apart.
+    /// by without checking. One reader knows the magic value means "none".
+    /// The other turns it into an out-of-range index or a wild offset. The
+    /// type is `u32` when the value set is `Option<u32>`, and only convention
+    /// tells the readers apart.
     ///
     /// Reported on the unchecked reader. A function counts as checking the
     /// field if it compares the field, or a local read off it, against
@@ -642,27 +642,27 @@ impl<'tcx> LateLintPass<'tcx> for SentinelInteger {
                 if self.checks(body, *field) || self.callers_check(body, *field) {
                     continue;
                 }
-                let (how, becomes) = match read.how {
-                    Use::Index => ("indexes with", "an out-of-range index"),
-                    Use::Offset => ("offsets a pointer by", "a wild offset"),
+                let (how, becomes, use_it) = match read.how {
+                    Use::Index => ("indexes with", "an out-of-range index", "index"),
+                    Use::Offset => ("offsets a pointer by", "a wild offset", "offset"),
                 };
                 let reader = match cx.tcx.opt_item_name(body) {
                     Some(name) => format!("`{name}`"),
-                    None => "this body".to_owned(),
+                    None => "This body".to_owned(),
                 };
                 let (owner, name, sentinel) = (cx.tcx.item_name(field.0), field.1, &ev.spelling);
                 findings.push((
                     read.span,
                     format!(
-                        "`{owner}.{name}` can be `{sentinel}`, which {} other place{} in the crate test{} for as \"no value\", but {reader} {how} it here without any such test, so the sentinel becomes {becomes}",
+                        "`{owner}.{name}` can be `{sentinel}`, which {} other place{} treat{} as \"no value\". {reader} {how} it here without checking, so the sentinel becomes {becomes}",
                         ev.compared,
                         if ev.compared == 1 { "" } else { "s" },
                         if ev.compared == 1 { "s" } else { "" },
                     ),
                     evidence_at,
-                    format!("one of the places that treats `{sentinel}` as \"no value\""),
+                    format!("one of the places that checks for `{sentinel}`"),
                     format!(
-                        "store `{name}` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so {reader} has to decide the empty case before it can use the number"
+                        "store `{name}` as an `Option` (over `NonZero` or `NonMax` to keep the size). {reader} then has to handle the empty case before it can {use_it}"
                     ),
                 ));
             }

--- a/src/some_still_unchecked.rs
+++ b/src/some_still_unchecked.rs
@@ -16,13 +16,13 @@ use crate::hir_shapes::sole_expr;
 rustc_session::declare_lint! {
     /// Flags a `match` or `if let` over an `Option` or `Result` whose
     /// present case is only taken under a further condition on the value,
-    /// with the value that fails it handled exactly as the absent case is:
+    /// with the value that fails it treated exactly like the absent case:
     /// `Some(x) if x.ready() => go(x), _ => wait()`, `if let Some(x) = next
     /// && x.ready() { .. } else { .. }`, or the same with the condition as an
     /// inner `if` whose `else` repeats the outer one. A `Some` that fails
-    /// the condition is handled exactly like `None`, so at this point `Some`
+    /// the condition is treated exactly like `None`, so at this point `Some`
     /// alone does not mean usable, and the condition saying which is written
-    /// here, at a consumer, rather than where the value is produced; every
+    /// here, at a consumer, rather than where the value is produced. Every
     /// other consumer has to repeat it or takes the unwanted `Some` as a
     /// valid one. Filtering at the source, or a payload type that cannot
     /// hold the unwanted value, makes `Some` mean present.
@@ -97,32 +97,27 @@ impl Wrapper {
             Wrapper::Result => "an",
         };
         format!(
-            "{article} `{present}` that fails `{cond}` is handled exactly like `{absent}` here, so `{present}` alone does not mean usable and every other consumer of this value has to repeat the check"
+            "{article} `{present}` that fails `{cond}` is treated exactly like `{absent}` here. `{present}` alone does not mean usable, and every consumer has to repeat the check"
         )
     }
 
     fn note(self) -> String {
         format!(
-            "the failing `{}` lands here, together with `{}`",
+            "the failing `{}` ends up here, with `{}`",
             self.present_name(),
             self.absent_name()
         )
     }
 
     fn help(self, scrut: &str, cond: &str) -> String {
-        let (present, means) = match self {
-            Wrapper::Option => (
-                "a `Some`",
-                "a `.filter(..)`, or a payload type that cannot fail it",
+        match self {
+            Wrapper::Option => format!(
+                "filter where `{scrut}` is produced, with `.filter(..)` or a payload type that cannot fail `{cond}`"
             ),
-            Wrapper::Result => (
-                "an `Ok`",
-                "an error for that case, or a payload type that cannot fail it",
+            Wrapper::Result => format!(
+                "reject that case where `{scrut}` is produced, with an error for it or a payload type that cannot fail `{cond}`"
             ),
-        };
-        format!(
-            "make whatever produces `{scrut}` reject values failing `{cond}` ({means}), so {present} reaching here needs no second check"
-        )
+        }
     }
 }
 

--- a/src/some_still_unchecked.rs
+++ b/src/some_still_unchecked.rs
@@ -19,12 +19,13 @@ rustc_session::declare_lint! {
     /// with the value that fails it handled exactly as the absent case is:
     /// `Some(x) if x.ready() => go(x), _ => wait()`, `if let Some(x) = next
     /// && x.ready() { .. } else { .. }`, or the same with the condition as an
-    /// inner `if` whose `else` repeats the outer one. The `Option` at this
-    /// point admits a `Some` the code does not want, and the condition that
-    /// says which is written here, at a consumer, rather than where the
-    /// value is produced; every other consumer has to repeat it or gets the
-    /// unwanted `Some` as a valid one. Filtering at the source, or a payload
-    /// type that cannot hold the unwanted value, makes `Some` mean present.
+    /// inner `if` whose `else` repeats the outer one. A `Some` that fails
+    /// the condition is handled exactly like `None`, so at this point `Some`
+    /// alone does not mean usable, and the condition saying which is written
+    /// here, at a consumer, rather than where the value is produced; every
+    /// other consumer has to repeat it or takes the unwanted `Some` as a
+    /// valid one. Filtering at the source, or a payload type that cannot
+    /// hold the unwanted value, makes `Some` mean present.
     ///
     /// Stays quiet when the condition never reads what the pattern bound (a
     /// guard on unrelated state is a different shape), when the failing
@@ -74,33 +75,54 @@ impl Wrapper {
         }
     }
 
+    /// How the present variant is spelled in a message.
+    fn present_name(self) -> &'static str {
+        match self {
+            Wrapper::Option => "Some",
+            Wrapper::Result => "Ok",
+        }
+    }
+
+    fn absent_name(self) -> &'static str {
+        match self {
+            Wrapper::Option => "None",
+            Wrapper::Result => "Err",
+        }
+    }
+
     fn message(self, cond: &str) -> String {
-        match self {
-            Wrapper::Option => {
-                format!("a `Some` that fails `{cond}` is handled as if it were `None`")
-            }
-            Wrapper::Result => {
-                format!("an `Ok` that fails `{cond}` is handled as if it were `Err`")
-            }
-        }
+        let (present, absent) = (self.present_name(), self.absent_name());
+        let article = match self {
+            Wrapper::Option => "a",
+            Wrapper::Result => "an",
+        };
+        format!(
+            "{article} `{present}` that fails `{cond}` is handled exactly like `{absent}` here, so `{present}` alone does not mean usable and every other consumer of this value has to repeat the check"
+        )
     }
 
-    fn note(self) -> &'static str {
-        match self {
-            Wrapper::Option => "the failing `Some` lands here, handled like `None`",
-            Wrapper::Result => "the failing `Ok` lands here, handled like `Err`",
-        }
+    fn note(self) -> String {
+        format!(
+            "the failing `{}` lands here, together with `{}`",
+            self.present_name(),
+            self.absent_name()
+        )
     }
 
-    fn help(self) -> &'static str {
-        match self {
-            Wrapper::Option => {
-                "filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here"
-            }
-            Wrapper::Result => {
-                "reject where the value is produced (an error for this case, or a type whose `Ok` is always valid) so `Ok` needs no second check here"
-            }
-        }
+    fn help(self, scrut: &str, cond: &str) -> String {
+        let (present, means) = match self {
+            Wrapper::Option => (
+                "a `Some`",
+                "a `.filter(..)`, or a payload type that cannot fail it",
+            ),
+            Wrapper::Result => (
+                "an `Ok`",
+                "an error for that case, or a payload type that cannot fail it",
+            ),
+        };
+        format!(
+            "make whatever produces `{scrut}` reject values failing `{cond}` ({means}), so {present} reaching here needs no second check"
+        )
     }
 }
 
@@ -195,12 +217,15 @@ fn has_let(operands: &[&Expr<'_>]) -> bool {
 struct Finding {
     w: Wrapper,
     span: Span,
+    /// The `Option`/`Result` being matched, for the help.
+    scrut: Span,
     cond: Span,
     lands: Span,
 }
 
 fn report(cx: &LateContext<'_>, f: Finding) {
     let cond = snippet(cx, f.cond, "..");
+    let scrut = snippet(cx, f.scrut, "..");
     emit_with_note(
         cx,
         SOME_STILL_UNCHECKED,
@@ -208,7 +233,7 @@ fn report(cx: &LateContext<'_>, f: Finding) {
         f.w.message(&cond),
         f.lands,
         f.w.note(),
-        f.w.help(),
+        f.w.help(&scrut, &cond),
     );
 }
 
@@ -255,19 +280,23 @@ fn check_match<'tcx>(
     Some(Finding {
         w,
         span: arm.pat.span.to(cond.span),
+        scrut: scrut.span,
         cond: cond.span,
         lands: lands.pat.span,
     })
 }
 
-/// `let Some(x) = init` at the head of a condition: the wrapper it opens
-/// and the locals it binds.
-fn present_let<'tcx>(cx: &LateContext<'tcx>, e: &Expr<'tcx>) -> Option<(Wrapper, Vec<HirId>)> {
+/// `let Some(x) = init` at the head of a condition: the wrapper it opens,
+/// the locals it binds, and where `init` is.
+fn present_let<'tcx>(
+    cx: &LateContext<'tcx>,
+    e: &Expr<'tcx>,
+) -> Option<(Wrapper, Vec<HirId>, Span)> {
     let ExprKind::Let(LetExpr { pat, init, .. }) = e.kind else {
         return None;
     };
     let w = Wrapper::of(cx, cx.typeck_results().expr_ty(init))?;
-    Some((w, present_bindings(cx, pat, w)?))
+    Some((w, present_bindings(cx, pat, w)?, init.span))
 }
 
 fn check_if<'tcx>(
@@ -282,7 +311,7 @@ fn check_if<'tcx>(
     let mut parts = Vec::new();
     and_operands(cond, &mut parts);
     let (head, tail) = parts.split_first()?;
-    let (w, ids) = present_let(cx, head)?;
+    let (w, ids, scrut) = present_let(cx, head)?;
     if let (Some(first), Some(last)) = (tail.first(), tail.last()) {
         // `if let Some(x) = v && COND { A } else { B }`
         if has_let(tail) || !tail.iter().any(|e| reads_any(cx, e, &ids)) {
@@ -291,6 +320,7 @@ fn check_if<'tcx>(
         return Some(Finding {
             w,
             span: cond.span,
+            scrut,
             cond: first.span.to(last.span),
             lands: els.span,
         });
@@ -313,6 +343,7 @@ fn check_if<'tcx>(
     Some(Finding {
         w,
         span: head.span,
+        scrut,
         cond: inner_cond.span,
         lands: inner_els.span,
     })

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -20,14 +20,14 @@ use crate::hir_shapes::{
 };
 
 rustc_session::declare_lint! {
-    /// A fact read off a field of `self` (`let n = self.items.len()`, `let p =
-    /// self.buf.as_ptr()`, `let had = self.cb.is_some()`), then a statement
-    /// that hands control to code this function cannot see, then a later
-    /// statement that acts on the same field as if the fact still held:
+    /// Flags a value read off a field of `self` (`let n = self.items.len()`,
+    /// `let p = self.buf.as_ptr()`, `let had = self.cb.is_some()`), then a
+    /// call that can run code with access to `self`, then a later statement
+    /// that uses the value as if the field could not have changed in between:
     /// indexing or removing at `n`, unwrapping under `had`, or touching `p`
-    /// at all. Whatever ran in between had `self` available and may have
-    /// pushed, popped, taken, or reallocated; the panic or dangling access
-    /// only shows up on the re-entrant path, which is the one tests skip.
+    /// at all. Whatever ran in between may have pushed, popped, taken, or
+    /// reallocated; the panic or dangling access only shows up on the
+    /// re-entrant path, which is the one tests skip.
     ///
     /// The re-entrant statements are calls through a closure or fn-pointer
     /// parameter or field, calls on a `dyn Trait` receiver, `.await`, and
@@ -192,14 +192,14 @@ impl Fact {
         }
     }
 
-    fn help(self) -> &'static str {
+    fn help(self, name: Symbol, place: &str) -> String {
         match self {
-            Fact::Count | Fact::Flag => {
-                "re-read the field after the call, or hold the item itself rather than its position"
-            }
-            Fact::Pointer => {
-                "take the pointer after the call, or keep what it points at alive across it by value"
-            }
+            Fact::Count | Fact::Flag => format!(
+                "re-read `{place}` after that call instead of reusing `{name}`, or hold the element itself rather than its position across the call"
+            ),
+            Fact::Pointer => format!(
+                "take the pointer from `{place}` again after that call, or keep the data alive across it by value"
+            ),
         }
     }
 }
@@ -753,10 +753,10 @@ impl<'tcx> LateLintPass<'tcx> for StaleAcrossReentry {
                             let name = t.name;
                             let msg = match t.fact {
                                 Fact::Count | Fact::Flag => format!(
-                                    "`{name}` describes `{place}` as it stood before a call that can re-enter and change it"
+                                    "`{name}` was read off `{place}` before a call that can run code with access to `self`, and is used here as if `{place}` could not have changed in between"
                                 ),
                                 Fact::Pointer => format!(
-                                    "`{name}` points into `{place}` as it stood before a call that can re-enter and move or free it"
+                                    "`{name}` points into `{place}` as it was before a call that can run code with access to `self`, which may have moved or freed that buffer by the time `{name}` is used here"
                                 ),
                             };
                             emit_with_note(
@@ -765,8 +765,10 @@ impl<'tcx> LateLintPass<'tcx> for StaleAcrossReentry {
                                 at,
                                 msg,
                                 call,
-                                "control leaves this function here, with `self` reachable from whatever runs",
-                                t.fact.help(),
+                                format!(
+                                    "control leaves this function here, and whatever runs can reach `{place}`"
+                                ),
+                                t.fact.help(name, &place),
                             );
                             break;
                         }

--- a/src/stale_across_reentry.rs
+++ b/src/stale_across_reentry.rs
@@ -20,13 +20,13 @@ use crate::hir_shapes::{
 };
 
 rustc_session::declare_lint! {
-    /// Flags a value read off a field of `self` (`let n = self.items.len()`,
+    /// Flags a value read from a field of `self` (`let n = self.items.len()`,
     /// `let p = self.buf.as_ptr()`, `let had = self.cb.is_some()`), then a
-    /// call that can run code with access to `self`, then a later statement
-    /// that uses the value as if the field could not have changed in between:
+    /// call that can run other code with access to `self`, then a later
+    /// statement that uses the value as if the field had not changed:
     /// indexing or removing at `n`, unwrapping under `had`, or touching `p`
     /// at all. Whatever ran in between may have pushed, popped, taken, or
-    /// reallocated; the panic or dangling access only shows up on the
+    /// reallocated. The panic or dangling access only shows up on the
     /// re-entrant path, which is the one tests skip.
     ///
     /// The re-entrant statements are calls through a closure or fn-pointer
@@ -195,10 +195,10 @@ impl Fact {
     fn help(self, name: Symbol, place: &str) -> String {
         match self {
             Fact::Count | Fact::Flag => format!(
-                "re-read `{place}` after that call instead of reusing `{name}`, or hold the element itself rather than its position across the call"
+                "read `{place}` again after the call instead of reusing `{name}`, or hold the element itself across the call"
             ),
             Fact::Pointer => format!(
-                "take the pointer from `{place}` again after that call, or keep the data alive across it by value"
+                "take the pointer from `{place}` again after the call, or keep the data alive across it by value"
             ),
         }
     }
@@ -753,10 +753,10 @@ impl<'tcx> LateLintPass<'tcx> for StaleAcrossReentry {
                             let name = t.name;
                             let msg = match t.fact {
                                 Fact::Count | Fact::Flag => format!(
-                                    "`{name}` was read off `{place}` before a call that can run code with access to `self`, and is used here as if `{place}` could not have changed in between"
+                                    "`{name}` was read from `{place}` before a call that can run other code with access to `self`. It is used here as if `{place}` had not changed"
                                 ),
                                 Fact::Pointer => format!(
-                                    "`{name}` points into `{place}` as it was before a call that can run code with access to `self`, which may have moved or freed that buffer by the time `{name}` is used here"
+                                    "`{name}` points into `{place}` as it was before a call that can run other code with access to `self`. That code may have moved or freed the buffer by the time `{name}` is used here"
                                 ),
                             };
                             emit_with_note(
@@ -766,7 +766,7 @@ impl<'tcx> LateLintPass<'tcx> for StaleAcrossReentry {
                                 msg,
                                 call,
                                 format!(
-                                    "control leaves this function here, and whatever runs can reach `{place}`"
+                                    "control leaves this function here, and what runs can reach `{place}`"
                                 ),
                                 t.fact.help(name, &place),
                             );

--- a/src/stale_panic_message.rs
+++ b/src/stale_panic_message.rs
@@ -7,10 +7,10 @@ use crate::claims::{self, DefNames};
 
 rustc_session::declare_lint! {
     /// Flags a panic-family message (`panic!`, `unreachable!`, `assert!`,
-    /// `expect`) whose backticked identifiers no longer exist in the file's
-    /// code or among the definitions of this crate or any crate it links. A
-    /// crash message that explains the invariant in terms of a guard a
-    /// refactor renamed actively misleads whoever reads the backtrace.
+    /// `expect`) that mentions a backticked identifier nothing by that name
+    /// exists for any more, in the file's code or among the definitions of
+    /// this crate or any crate it links. Whoever hits the panic is sent
+    /// looking for something that is gone.
     pub STALE_PANIC_MESSAGE,
     Warn,
     "panic or assert message names an identifier that no longer exists"
@@ -50,9 +50,9 @@ impl StalePanicMessage {
                     STALE_PANIC_MESSAGE,
                     at,
                     format!(
-                        "this message names `{ident}`, which appears nowhere in this file's code, this crate, or any crate it links"
+                        "this message mentions `{ident}`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so whoever hits this panic is sent looking for something that is gone"
                     ),
-                    "whoever reads this at a crash site will search for a name that no longer exists; update the message",
+                    format!("rewrite the message in terms of whatever replaced `{ident}`"),
                 );
             }
         }

--- a/src/stale_panic_message.rs
+++ b/src/stale_panic_message.rs
@@ -7,10 +7,9 @@ use crate::claims::{self, DefNames};
 
 rustc_session::declare_lint! {
     /// Flags a panic-family message (`panic!`, `unreachable!`, `assert!`,
-    /// `expect`) that mentions a backticked identifier nothing by that name
-    /// exists for any more, in the file's code or among the definitions of
-    /// this crate or any crate it links. Whoever hits the panic is sent
-    /// looking for something that is gone.
+    /// `expect`) that mentions a backticked identifier when nothing with
+    /// that name exists in the file, this crate, or any crate it links.
+    /// Whoever hits the panic is sent looking for something that is gone.
     pub STALE_PANIC_MESSAGE,
     Warn,
     "panic or assert message names an identifier that no longer exists"
@@ -50,9 +49,9 @@ impl StalePanicMessage {
                     STALE_PANIC_MESSAGE,
                     at,
                     format!(
-                        "this message mentions `{ident}`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so whoever hits this panic is sent looking for something that is gone"
+                        "this message mentions `{ident}`, but nothing with that name exists in this file, this crate, or any crate it links. Whoever hits the panic is sent looking for something that is gone"
                     ),
-                    format!("rewrite the message in terms of whatever replaced `{ident}`"),
+                    format!("rewrite the message in terms of what replaced `{ident}`"),
                 );
             }
         }

--- a/src/stale_safety_comment.rs
+++ b/src/stale_safety_comment.rs
@@ -5,11 +5,11 @@ use crate::baseline::emit;
 use crate::claims::{self, DefNames};
 
 rustc_session::declare_lint! {
-    /// Flags a `// SAFETY:` comment whose backticked identifiers no longer
-    /// exist: not in the file's code, and not the name of any definition in
-    /// this crate or a crate it links. A safety justification that names a
-    /// guard which a refactor has since removed is documentation asserting an
-    /// invariant nothing provides.
+    /// Flags a `// SAFETY:` comment that relies on a backticked identifier
+    /// nothing by that name exists for any more: not in the file's code, and
+    /// not among the definitions of this crate or a crate it links. The
+    /// justification describes code that is gone, so it asserts an invariant
+    /// nothing provides.
     ///
     /// Runs only with `stale-safety-comment-enabled = true` in `dylint.toml`.
     /// The crate cannot see names defined in C++, in scripts, or in crates
@@ -66,9 +66,11 @@ impl<'tcx> LateLintPass<'tcx> for StaleSafetyComment {
                     STALE_SAFETY_COMMENT,
                     comment_span,
                     format!(
-                        "this SAFETY comment names `{ident}`, which appears nowhere in this file's code, this crate, or any crate it links"
+                        "this SAFETY comment relies on `{ident}`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so the justification describes code that is gone"
                     ),
-                    "the guard this justification described has moved or gone; update the comment or restore the guard",
+                    format!(
+                        "find what replaced `{ident}` and restate the comment in its terms; if nothing did, this `unsafe` block has lost the guard it depended on and needs one"
+                    ),
                 );
             }
         }

--- a/src/stale_safety_comment.rs
+++ b/src/stale_safety_comment.rs
@@ -6,10 +6,8 @@ use crate::claims::{self, DefNames};
 
 rustc_session::declare_lint! {
     /// Flags a `// SAFETY:` comment that relies on a backticked identifier
-    /// nothing by that name exists for any more: not in the file's code, and
-    /// not among the definitions of this crate or a crate it links. The
-    /// justification describes code that is gone, so it asserts an invariant
-    /// nothing provides.
+    /// when nothing with that name exists in the file, this crate, or any
+    /// crate it links. The justification describes code that is gone.
     ///
     /// Runs only with `stale-safety-comment-enabled = true` in `dylint.toml`.
     /// The crate cannot see names defined in C++, in scripts, or in crates
@@ -66,10 +64,10 @@ impl<'tcx> LateLintPass<'tcx> for StaleSafetyComment {
                     STALE_SAFETY_COMMENT,
                     comment_span,
                     format!(
-                        "this SAFETY comment relies on `{ident}`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so the justification describes code that is gone"
+                        "this SAFETY comment relies on `{ident}`, but nothing with that name exists in this file, this crate, or any crate it links. The justification describes code that is gone"
                     ),
                     format!(
-                        "find what replaced `{ident}` and restate the comment in its terms; if nothing did, this `unsafe` block has lost the guard it depended on and needs one"
+                        "restate the comment in terms of what replaced `{ident}`. If nothing did, this `unsafe` block has lost its guard and needs one"
                     ),
                 );
             }

--- a/src/stringified_error.rs
+++ b/src/stringified_error.rs
@@ -6,10 +6,10 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 
 rustc_session::declare_lint! {
-    /// Flags the site where a typed error is collapsed into a string:
-    /// `.map_err(|e| e.to_string())` on a `Result` whose error type is not
-    /// already a string. `stringly_error` flags the signature that demands
-    /// this; this lint flags the expression that performs the destruction.
+    /// Flags a `.map_err(|e| e.to_string())` that turns a typed error into a
+    /// `String`, after which callers cannot match on which failure it was.
+    /// `stringly_error` flags the signature that demands this; this lint
+    /// flags the expression that does it.
     pub STRINGIFIED_ERROR,
     Warn,
     "typed error collapsed into a string"
@@ -61,8 +61,12 @@ impl<'tcx> LateLintPass<'tcx> for StringifiedError {
                 cx,
                 STRINGIFIED_ERROR,
                 expr.span,
-                format!("typed error `{err_ty}` collapsed into a string"),
-                "return the error type, or an error enum with a variant that wraps it",
+                format!(
+                    "this `map_err` turns `{err_ty}` into `String`, so from here on callers cannot match on which failure it was"
+                ),
+                format!(
+                    "return `{err_ty}` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed"
+                ),
             );
         }
     }

--- a/src/stringified_error.rs
+++ b/src/stringified_error.rs
@@ -7,9 +7,9 @@ use rustc_middle::ty;
 
 rustc_session::declare_lint! {
     /// Flags a `.map_err(|e| e.to_string())` that turns a typed error into a
-    /// `String`, after which callers cannot match on which failure it was.
-    /// `stringly_error` flags the signature that demands this; this lint
-    /// flags the expression that does it.
+    /// `String`. From there on, callers cannot match on which failure it
+    /// was. `stringly_error` flags the signature that demands this, and this
+    /// lint flags the expression that does it.
     pub STRINGIFIED_ERROR,
     Warn,
     "typed error collapsed into a string"
@@ -62,10 +62,10 @@ impl<'tcx> LateLintPass<'tcx> for StringifiedError {
                 STRINGIFIED_ERROR,
                 expr.span,
                 format!(
-                    "this `map_err` turns `{err_ty}` into `String`, so from here on callers cannot match on which failure it was"
+                    "this `map_err` turns a `{err_ty}` into a `String`. From here on, callers cannot match on which failure it was"
                 ),
                 format!(
-                    "return `{err_ty}` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed"
+                    "return `{err_ty}` itself, or an error enum that wraps it, and turn it into text only where it is shown"
                 ),
             );
         }

--- a/src/stringly_error.rs
+++ b/src/stringly_error.rs
@@ -12,8 +12,8 @@ use crate::MordantConfig;
 
 rustc_session::declare_lint! {
     /// Flags a public function whose error type is `String` (or `&str`,
-    /// `Cow<str>`): its callers can only tell failures apart by reading the
-    /// message text. An error enum gives them variants to match on.
+    /// `Cow<str>`): callers can only tell failures apart by reading the
+    /// message. An error enum gives them variants to match on.
     pub STRINGLY_ERROR,
     Warn,
     "public signature returns a Result with a string error type"
@@ -44,11 +44,9 @@ impl StringlyError {
                 STRINGLY_ERROR,
                 ret_hir_ty.span,
                 format!(
-                    "`{name}` is public and returns `Result<_, {desc}>`, so its callers can only tell failures apart by reading the message text"
+                    "`{name}` is public and returns `Result<_, {desc}>`. Callers can only tell failures apart by reading the message"
                 ),
-                format!(
-                    "define an error enum with a variant per way `{name}` can fail and return that; keep the text in its `Display` impl"
-                ),
+                "return an error enum with a variant per failure, and keep the text in its `Display` impl",
             );
         }
     }

--- a/src/stringly_error.rs
+++ b/src/stringly_error.rs
@@ -11,9 +11,9 @@ use rustc_span::{Span, Symbol, sym};
 use crate::MordantConfig;
 
 rustc_session::declare_lint! {
-    /// Flags `Result<_, String>` (and `&str`, `Cow<str>`) in public signatures.
-    /// A string error has no variants to match on; callers cannot distinguish
-    /// failure cases without parsing prose.
+    /// Flags a public function whose error type is `String` (or `&str`,
+    /// `Cow<str>`): its callers can only tell failures apart by reading the
+    /// message text. An error enum gives them variants to match on.
     pub STRINGLY_ERROR,
     Warn,
     "public signature returns a Result with a string error type"
@@ -38,12 +38,17 @@ impl StringlyError {
             return;
         };
         if let Some(desc) = self.stringy_desc(cx, err_ty) {
+            let name = cx.tcx.item_name(def_id.to_def_id());
             emit(
                 cx,
                 STRINGLY_ERROR,
                 ret_hir_ty.span,
-                format!("public signature returns `Result<_, {desc}>`"),
-                "a string error has no variants to match on; define an error enum and return it",
+                format!(
+                    "`{name}` is public and returns `Result<_, {desc}>`, so its callers can only tell failures apart by reading the message text"
+                ),
+                format!(
+                    "define an error enum with a variant per way `{name}` can fail and return that; keep the text in its `Display` impl"
+                ),
             );
         }
     }

--- a/src/stringly_state.rs
+++ b/src/stringly_state.rs
@@ -14,13 +14,13 @@ use rustc_middle::ty::{self, Ty, TypeckResults};
 use rustc_span::{Span, Symbol, sym};
 
 use crate::adt_facts::{field_ty, has_fixed_repr, has_positional_fields, struct_field};
-use crate::baseline::emit_with_note;
+use crate::baseline::{emit_with_note, join};
 use crate::hir_shapes::{Callee, callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
     /// Flags a string or byte-string field or local that only ever holds one
-    /// of a fixed set of literals and is read by comparing against literals:
-    /// an enum spelled as a string, so a misspelt state on either side still
+    /// of a fixed set of literals and is read by comparing against literals.
+    /// It is an enum written as a string, so a typo on either side still
     /// compiles, a new state needs every comparison found by hand, and
     /// nothing says which strings are possible.
     ///
@@ -410,15 +410,12 @@ impl StringlyState {
         slot: Slot,
         facts: &Facts,
     ) -> Option<(Span, String, String)> {
-        let (span, name, scope) = match slot {
+        let (span, name) = match slot {
             Slot::Field(did, name) => {
                 let field = struct_field(cx.tcx.adt_def(did), name)?;
-                (cx.tcx.def_span(field.did), name, " across the crate")
+                (cx.tcx.def_span(field.did), name)
             }
-            Slot::Local(id) => {
-                let &(span, name) = self.locals.get(&id)?;
-                (span, name, "")
-            }
+            Slot::Local(id) => *self.locals.get(&id)?,
         };
         const SHOWN: usize = 6;
         let mut list: Vec<String> = facts
@@ -431,20 +428,18 @@ impl StringlyState {
         if more > 0 {
             list.push(format!("{more} more"));
         }
+        let values = join(&list, "or");
         Some((
             span,
             format!(
-                "`{name}` only ever holds one of {} ({} {}{}) and is read by comparing against \
-                 literals, so it is an enum spelled as a string and a misspelt state still \
-                 compiles",
-                list.join(", "),
+                "`{name}` only ever holds {values} ({} {}) and is read by comparing against \
+                 literals. It is an enum written as a string, and a typo still compiles",
                 facts.stores,
                 if facts.stores == 1 { "store" } else { "stores" },
-                scope,
             ),
             format!(
-                "declare an enum with a variant per string and store that in `{name}`; keep the \
-                 text in an `as_str` method for wherever it is printed"
+                "declare an enum with a variant per string and store that in `{name}`. Keep the \
+                 text in an `as_str` method for printing"
             ),
         ))
     }
@@ -573,7 +568,7 @@ impl<'tcx> LateLintPass<'tcx> for StringlyState {
                 span,
                 msg,
                 compared,
-                "one of the comparisons against a literal",
+                "one of the comparisons",
                 help,
             );
         }

--- a/src/stringly_state.rs
+++ b/src/stringly_state.rs
@@ -14,16 +14,15 @@ use rustc_middle::ty::{self, Ty, TypeckResults};
 use rustc_span::{Span, Symbol, sym};
 
 use crate::adt_facts::{field_ty, has_fixed_repr, has_positional_fields, struct_field};
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{Callee, callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
-    /// Flags a string or byte-string field or local whose every value the
-    /// code ever stores is one of a fixed set of literals, and which is then
-    /// compared against literals to decide what to do. The set is an enum
-    /// the type does not declare: a misspelt literal on either side compiles,
-    /// a new state needs every comparison found by hand, and nothing says
-    /// which strings are possible.
+    /// Flags a string or byte-string field or local that only ever holds one
+    /// of a fixed set of literals and is read by comparing against literals:
+    /// an enum spelled as a string, so a misspelt state on either side still
+    /// compiles, a new state needs every comparison found by hand, and
+    /// nothing says which strings are possible.
     ///
     /// Only fires where every store is visible: a local, or a field no other
     /// crate can name (the struct or the field is private to this one). Every
@@ -51,7 +50,8 @@ struct Facts {
     open: bool,
     stores: usize,
     values: BTreeSet<String>,
-    compared: bool,
+    /// The first comparison against a literal.
+    compared: Option<Span>,
 }
 
 #[derive(Default)]
@@ -332,10 +332,15 @@ impl StringlyState {
         }
     }
 
+    fn compared(&mut self, slot: Slot, at: Span) {
+        self.facts(slot).compared.get_or_insert(at);
+    }
+
     /// `a == "lit"`, `a != b"lit"`, either way round.
     fn note_comparison<'tcx>(
         &mut self,
         cx: &LateContext<'tcx>,
+        at: Span,
         l: &'tcx Expr<'tcx>,
         r: &'tcx Expr<'tcx>,
     ) {
@@ -343,7 +348,7 @@ impl StringlyState {
             if is_literal_expr(other)
                 && let Some(slot) = read_slot(cx, place)
             {
-                self.facts(slot).compared = true;
+                self.compared(slot, at);
             }
         }
     }
@@ -379,7 +384,7 @@ impl StringlyState {
         }
         for o in operands {
             if let Some(slot) = read_slot(cx, o) {
-                self.facts(slot).compared = true;
+                self.compared(slot, e.span);
             }
         }
     }
@@ -387,17 +392,24 @@ impl StringlyState {
     fn note_match<'tcx>(
         &mut self,
         cx: &LateContext<'tcx>,
+        at: Span,
         scrut: &'tcx Expr<'tcx>,
         arms: &'tcx [Arm<'tcx>],
     ) {
         if let Some(slot) = read_slot(cx, scrut)
             && arms.iter().any(|a| pat_has_literal(a.pat))
         {
-            self.facts(slot).compared = true;
+            self.compared(slot, at);
         }
     }
 
-    fn message(&self, cx: &LateContext<'_>, slot: Slot, facts: &Facts) -> Option<(Span, String)> {
+    /// Where to report, the message, and the help.
+    fn message(
+        &self,
+        cx: &LateContext<'_>,
+        slot: Slot,
+        facts: &Facts,
+    ) -> Option<(Span, String, String)> {
         let (span, name, scope) = match slot {
             Slot::Field(did, name) => {
                 let field = struct_field(cx.tcx.adt_def(did), name)?;
@@ -422,13 +434,17 @@ impl StringlyState {
         Some((
             span,
             format!(
-                "every value stored in `{}` is one of {} ({} {}{}), and it is read by comparing \
-                 against literals",
-                name,
+                "`{name}` only ever holds one of {} ({} {}{}) and is read by comparing against \
+                 literals, so it is an enum spelled as a string and a misspelt state still \
+                 compiles",
                 list.join(", "),
                 facts.stores,
                 if facts.stores == 1 { "store" } else { "stores" },
                 scope,
+            ),
+            format!(
+                "declare an enum with a variant per string and store that in `{name}`; keep the \
+                 text in an `as_str` method for wherever it is printed"
             ),
         ))
     }
@@ -528,10 +544,10 @@ impl<'tcx> LateLintPass<'tcx> for StringlyState {
                 }
             }
             ExprKind::Binary(op, l, r) if matches!(op.node, BinOpKind::Eq | BinOpKind::Ne) => {
-                self.note_comparison(cx, l, r);
+                self.note_comparison(cx, expr.span, l, r);
             }
             ExprKind::Match(scrut, arms, MatchSource::Normal | MatchSource::Postfix) => {
-                self.note_match(cx, scrut, arms);
+                self.note_match(cx, scrut.span, scrut, arms);
             }
             ExprKind::Call(..) | ExprKind::MethodCall(..) => self.note_comparing_call(cx, expr),
             _ => {}
@@ -539,21 +555,26 @@ impl<'tcx> LateLintPass<'tcx> for StringlyState {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut findings: Vec<(Span, String)> = self
+        let mut findings: Vec<(Span, String, Span, String)> = self
             .slots
             .iter()
-            .filter(|(_, f)| !f.open && f.compared && f.values.len() >= 2)
-            .filter_map(|(slot, f)| self.message(cx, *slot, f))
+            .filter(|(_, f)| !f.open && f.values.len() >= 2)
+            .filter_map(|(slot, f)| {
+                let compared = f.compared?;
+                let (span, msg, help) = self.message(cx, *slot, f)?;
+                Some((span, msg, compared, help))
+            })
             .collect();
-        findings.sort_by_key(|(span, _)| span.lo());
-        for (span, msg) in findings {
-            emit(
+        findings.sort_by_key(|(span, ..)| span.lo());
+        for (span, msg, compared, help) in findings {
+            emit_with_note(
                 cx,
                 STRINGLY_STATE,
                 span,
                 msg,
-                "these strings are the variants of an enum; store the enum and keep the text in an \
-                 `as_str` method, so a misspelt state is a compile error",
+                compared,
+                "one of the comparisons against a literal",
+                help,
             );
         }
     }

--- a/src/tuple_wants_struct.rs
+++ b/src/tuple_wants_struct.rs
@@ -14,21 +14,20 @@ use rustc_middle::ty::{self, AssocContainer, Ty, TyCtxt};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Ident, Span, Symbol, sym};
 
-use crate::baseline::{emit, emit_with_note};
+use crate::baseline::emit_with_note;
 use crate::hir_shapes::{callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
     /// Flags a crate-private function returning a tuple (bare, or inside an
-    /// `Option`/`Result`) with two members of one type, when every call site
-    /// in the crate destructures it on the spot (`let (a, b) = f()`, an
+    /// `Option`/`Result`) with two members of one type, when every call in
+    /// the crate unpacks it on the spot (`let (a, b) = f()`, an
     /// `if let`/`match` arm, or `(a, self.b) = f()`) and all of them, across
-    /// at least two functions, give the members the same names. Those names
-    /// are the members' real names: written at every use, missing only from
-    /// the type, which is the one place the compiler could keep them attached.
-    /// As a tuple, `(r, g, b)` and `(r, b, g)` are the same type, so a
-    /// transposed pattern or return value goes through; when the function's
-    /// own body already returns the members under those names in another
-    /// order, the finding says where.
+    /// at least two functions, give the members the same names. Those are the
+    /// members' names everywhere but in the type, and since the members share
+    /// a type a swapped pair still compiles; when the function's own body
+    /// already returns them under those names in another order, the finding
+    /// says where. A struct with those fields puts the names in the
+    /// signature.
     ///
     /// Silent when the member types all differ (the compiler already rejects
     /// a transposition), when any caller keeps the tuple whole (stores,
@@ -64,6 +63,8 @@ struct Sites {
     /// The items the destructuring sites sit in.
     owners: HashSet<LocalDefId>,
     count: usize,
+    /// The first destructuring call, for the note.
+    first: Option<Span>,
     /// A site kept the tuple whole, left a member unnamed, or disagreed.
     opaque: bool,
 }
@@ -402,6 +403,7 @@ impl TupleWantsStruct {
             Use::Opaque => sites.opaque = true,
             Use::Names(names) => {
                 sites.count += 1;
+                sites.first.get_or_insert(site.span);
                 sites
                     .owners
                     .insert(cx.tcx.hir_get_parent_item(site.hir_id).def_id);
@@ -493,7 +495,7 @@ impl<'tcx> LateLintPass<'tcx> for TupleWantsStruct {
     }
 
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
-        let mut findings: Vec<(Span, String, Option<Span>)> = Vec::new();
+        let mut findings: Vec<(Span, String, Span, &str, String)> = Vec::new();
         for (def, cand) in &self.candidates {
             if self.poisoned.contains(def) {
                 continue;
@@ -501,14 +503,14 @@ impl<'tcx> LateLintPass<'tcx> for TupleWantsStruct {
             let Some(sites) = self.sites.get(def) else {
                 continue;
             };
-            let Some(names) = &sites.names else {
+            let (Some(names), Some(first)) = (&sites.names, sites.first) else {
                 continue;
             };
             if sites.opaque || sites.count < 2 || sites.owners.len() < 2 {
                 continue;
             }
             let lead = format!(
-                "all {} call sites of `{}`, in {} functions, destructure this as `{}`",
+                "every one of the {} calls to `{}` (in {} functions) unpacks this as `{}`",
                 sites.count,
                 cand.name,
                 sites.owners.len(),
@@ -524,41 +526,36 @@ impl<'tcx> LateLintPass<'tcx> for TupleWantsStruct {
                     a == b
                 }
             });
-            let (msg, note) = match transposed {
+            let (msg, at, note) = match transposed {
                 Some(r) => (
                     format!(
-                        "{lead}, but the body returns them as `{}`; {}, so both orders type-check and one of them is wrong",
+                        "{lead}, but the body returns them as `{}`, and since {} both orders compile and one of them is wrong",
                         tuple_of(&r.names),
                         cand.same,
                     ),
-                    Some(r.span),
+                    r.span,
+                    "the body returns them in the other order here",
                 ),
                 None => (
                     format!(
-                        "{lead}: the members are named everywhere except in the type; {}, so transposing them still type-checks",
+                        "{lead}, so those are the members' names everywhere but in the type, and since {} a swapped pair still compiles",
                         cand.same,
                     ),
-                    None,
+                    first,
+                    "one of the calls that names them",
                 ),
             };
-            findings.push((cand.ret_span, msg, note));
+            let fields: Vec<String> = names.iter().map(|n| format!("`{n}`")).collect();
+            let help = format!(
+                "return a struct with fields {} instead of the tuple; the names then live in the signature and same-typed members cannot trade places",
+                fields.join(", "),
+            );
+            findings.push((cand.ret_span, msg, at, note, help));
         }
         // `candidates` is a HashMap; report in source order.
         findings.sort_by_key(|(span, ..)| span.lo());
-        let help = "return a struct with these fields: the names move into the signature, and members of one type can no longer trade places";
-        for (span, msg, note) in findings {
-            match note {
-                Some(note) => emit_with_note(
-                    cx,
-                    TUPLE_WANTS_STRUCT,
-                    span,
-                    msg,
-                    note,
-                    "returned in this order here",
-                    help,
-                ),
-                None => emit(cx, TUPLE_WANTS_STRUCT, span, msg, help),
-            }
+        for (span, msg, at, note, help) in findings {
+            emit_with_note(cx, TUPLE_WANTS_STRUCT, span, msg, at, note, help);
         }
     }
 }

--- a/src/tuple_wants_struct.rs
+++ b/src/tuple_wants_struct.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty::{self, AssocContainer, Ty, TyCtxt};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Ident, Span, Symbol, sym};
 
-use crate::baseline::emit_with_note;
+use crate::baseline::{emit_with_note, join};
 use crate::hir_shapes::{callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
@@ -22,12 +22,11 @@ rustc_session::declare_lint! {
     /// `Option`/`Result`) with two members of one type, when every call in
     /// the crate unpacks it on the spot (`let (a, b) = f()`, an
     /// `if let`/`match` arm, or `(a, self.b) = f()`) and all of them, across
-    /// at least two functions, give the members the same names. Those are the
-    /// members' names everywhere but in the type, and since the members share
-    /// a type a swapped pair still compiles; when the function's own body
-    /// already returns them under those names in another order, the finding
-    /// says where. A struct with those fields puts the names in the
-    /// signature.
+    /// at least two functions, give the members the same names. The names
+    /// exist everywhere except in the type, and since the members share a
+    /// type a swapped pair compiles. When the function's own body already
+    /// returns them under those names in another order, the finding says
+    /// where. A struct with those fields puts the names in the signature.
     ///
     /// Silent when the member types all differ (the compiler already rejects
     /// a transposition), when any caller keeps the tuple whole (stores,
@@ -123,11 +122,16 @@ fn tuple_return(tcx: TyCtxt<'_>, def: DefId) -> Option<TupleReturn<'_>> {
     }
 }
 
-/// The first two members of one type, as "`.i` and `.j` are both `T`".
+/// The first two members of one type, as "both members are `T`" for a pair
+/// and "`.i` and `.j` are both `T`" for anything longer.
 fn same_typed_pair(members: &[Ty<'_>]) -> Option<String> {
     members.iter().enumerate().find_map(|(i, a)| {
         let j = i + 1 + members[i + 1..].iter().position(|b| a == b)?;
-        Some(format!("`.{i}` and `.{j}` are both `{a}`"))
+        Some(if members.len() == 2 {
+            format!("both members are `{a}`")
+        } else {
+            format!("`.{i}` and `.{j}` are both `{a}`")
+        })
     })
 }
 
@@ -510,10 +514,14 @@ impl<'tcx> LateLintPass<'tcx> for TupleWantsStruct {
                 continue;
             }
             let lead = format!(
-                "every one of the {} calls to `{}` (in {} functions) unpacks this as `{}`",
+                "{} {} calls to `{}` unpack the result as `{}`",
+                if sites.count == 2 {
+                    "both of the"
+                } else {
+                    "all"
+                },
                 sites.count,
                 cand.name,
-                sites.owners.len(),
                 tuple_of(names),
             );
             // The body spelling the same names in another order is the
@@ -529,7 +537,7 @@ impl<'tcx> LateLintPass<'tcx> for TupleWantsStruct {
             let (msg, at, note) = match transposed {
                 Some(r) => (
                     format!(
-                        "{lead}, but the body returns them as `{}`, and since {} both orders compile and one of them is wrong",
+                        "{lead}, but the body returns them as `{}`. Since {} both orders compile, and one of them is wrong",
                         tuple_of(&r.names),
                         cand.same,
                     ),
@@ -538,18 +546,15 @@ impl<'tcx> LateLintPass<'tcx> for TupleWantsStruct {
                 ),
                 None => (
                     format!(
-                        "{lead}, so those are the members' names everywhere but in the type, and since {} a swapped pair still compiles",
+                        "{lead}. The names exist everywhere except in the type, and since {} a swapped pair compiles",
                         cand.same,
                     ),
                     first,
-                    "one of the calls that names them",
+                    "one of the calls",
                 ),
             };
             let fields: Vec<String> = names.iter().map(|n| format!("`{n}`")).collect();
-            let help = format!(
-                "return a struct with fields {} instead of the tuple; the names then live in the signature and same-typed members cannot trade places",
-                fields.join(", "),
-            );
+            let help = format!("return a struct with fields {}", join(&fields, "and"));
             findings.push((cand.ret_span, msg, at, note, help));
         }
         // `candidates` is a HashMap; report in source order.

--- a/src/unchecked_construction.rs
+++ b/src/unchecked_construction.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty;
 use rustc_span::{Span, Symbol, sym};
 
 rustc_session::declare_lint! {
-    /// Flags a value of a validated type made or changed by hand, skipping
+    /// Flags a value of a validated type built or changed by hand, skipping
     /// the check its validating constructor makes. A validating constructor
     /// is a receiver-less inherent function returning `Result<Self, _>` or
     /// `Option<Self>` whose body rejects some value it then stores in a field
@@ -24,8 +24,8 @@ rustc_session::declare_lint! {
     /// * a struct literal, `S(x)` on a tuple struct included -- one with a
     ///   `..base` tail only when it names a field some validator checks,
     ///   since the fields it takes from `base` were checked when `base` was
-    ///   made;
-    /// * an assignment, plain or compound, to a checked field;
+    ///   made,
+    /// * an assignment, plain or compound, to a checked field,
     /// * `mem::zeroed`, `mem::transmute` or `MaybeUninit::assume_init`
     ///   producing the type.
     ///
@@ -317,12 +317,12 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedConstruction {
                     let (ctor, checked) = (by.ctor, checked(by));
                     (
                         format!(
-                            "`{path}` is constructed by hand here, skipping the check on {checked} that `{ty}::{ctor}` makes before it will construct one"
+                            "`{path}` is built by hand here, skipping the check on {checked} that `{ty}::{ctor}` makes"
                         ),
                         check.check,
-                        format!("the check in `{ty}::{ctor}` that this literal skips"),
+                        format!("the check in `{ty}::{ctor}`"),
                         format!(
-                            "construct it with `{ty}::{ctor}(..)`, or make {checked} private so a literal like this only compiles inside `{ty}`'s own module"
+                            "build it with `{ty}::{ctor}(..)`, or make {checked} private so a literal like this only compiles inside `{ty}`'s module"
                         ),
                     )
                 }
@@ -333,12 +333,12 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedConstruction {
                     let (ctor, checked) = (by.ctor, checked(by));
                     (
                         format!(
-                            "`{path}` is produced with `{what}` here, skipping the check on {checked} that `{ty}::{ctor}` makes before it will construct one"
+                            "`{path}` is produced with `{what}` here, skipping the check on {checked} that `{ty}::{ctor}` makes"
                         ),
                         by.first.check,
-                        format!("the check in `{ty}::{ctor}` that this value never went through"),
+                        format!("the check in `{ty}::{ctor}`"),
                         format!(
-                            "construct it with `{ty}::{ctor}(..)`, or add an explicitly unchecked constructor beside `{ty}::{ctor}` and call that, so the bypass is visible where the check lives"
+                            "build it with `{ty}::{ctor}(..)`. If this path must skip the check, add an unchecked constructor next to `{ty}::{ctor}` and call that"
                         ),
                     )
                 }
@@ -350,12 +350,12 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedConstruction {
                     let ctor = by.ctor;
                     (
                         format!(
-                            "`{path}::{name}` is assigned directly here, skipping the check that `{ty}::{ctor}` runs on `{name}` before storing it"
+                            "`{path}::{name}` is assigned directly here, skipping the check on `{name}` that `{ty}::{ctor}` makes"
                         ),
                         check.check,
-                        format!("the check in `{ty}::{ctor}` that this write skips"),
+                        format!("the check in `{ty}::{ctor}`"),
                         format!(
-                            "change `{name}` through a method of `{ty}` that repeats the check, or make `{name}` private so this write only compiles inside `{ty}`'s own module"
+                            "change `{name}` through a method of `{ty}` that repeats the check, or make `{name}` private so this write only compiles inside `{ty}`'s module"
                         ),
                     )
                 }

--- a/src/unchecked_construction.rs
+++ b/src/unchecked_construction.rs
@@ -14,9 +14,9 @@ use rustc_middle::ty;
 use rustc_span::{Span, Symbol, sym};
 
 rustc_session::declare_lint! {
-    /// Flags a value of a validated type made or changed without its
-    /// validating constructor running. A validating constructor is a
-    /// receiver-less inherent function returning `Result<Self, _>` or
+    /// Flags a value of a validated type made or changed by hand, skipping
+    /// the check its validating constructor makes. A validating constructor
+    /// is a receiver-less inherent function returning `Result<Self, _>` or
     /// `Option<Self>` whose body rejects some value it then stores in a field
     /// (see `ctor_flow`). Outside the type's own module and impls, each of
     /// these skips that check:
@@ -303,6 +303,8 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedConstruction {
                     .iter()
                     .find_map(|v| v.checks().find(|c| is_hit(c.field)).map(|c| (v, c)))
             };
+            let path = cx.tcx.def_path_str(site.adt);
+            let ty = cx.tcx.item_name(site.adt);
             let (msg, check, note, help) = match &site.kind {
                 SiteKind::Literal(literal) => {
                     let by = match literal {
@@ -312,34 +314,32 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedConstruction {
                     let Some((by, check)) = by else {
                         continue;
                     };
+                    let (ctor, checked) = (by.ctor, checked(by));
                     (
                         format!(
-                            "`{}` is constructed by literal here, but `{}::{}` checks {} before constructing one",
-                            cx.tcx.def_path_str(site.adt),
-                            cx.tcx.item_name(site.adt),
-                            by.ctor,
-                            checked(by),
+                            "`{path}` is constructed by hand here, skipping the check on {checked} that `{ty}::{ctor}` makes before it will construct one"
                         ),
                         check.check,
-                        "the check this literal never runs",
-                        "construct through the validating function, or move this literal into the type's module",
+                        format!("the check in `{ty}::{ctor}` that this literal skips"),
+                        format!(
+                            "construct it with `{ty}::{ctor}(..)`, or make {checked} private so a literal like this only compiles inside `{ty}`'s own module"
+                        ),
                     )
                 }
                 SiteKind::Conjured(what) => {
                     let Some(by) = ctors.first() else {
                         continue;
                     };
+                    let (ctor, checked) = (by.ctor, checked(by));
                     (
                         format!(
-                            "`{}` is produced by `{what}` here, but `{}::{}` checks {} before constructing one",
-                            cx.tcx.def_path_str(site.adt),
-                            cx.tcx.item_name(site.adt),
-                            by.ctor,
-                            checked(by),
+                            "`{path}` is produced with `{what}` here, skipping the check on {checked} that `{ty}::{ctor}` makes before it will construct one"
                         ),
                         by.first.check,
-                        "the check this value never went through",
-                        "construct through the validating function",
+                        format!("the check in `{ty}::{ctor}` that this value never went through"),
+                        format!(
+                            "construct it with `{ty}::{ctor}(..)`, or add an explicitly unchecked constructor beside `{ty}::{ctor}` and call that, so the bypass is visible where the check lives"
+                        ),
                     )
                 }
                 SiteKind::Write(field) => {
@@ -347,16 +347,16 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedConstruction {
                         continue;
                     };
                     let name = fields[*field].name;
+                    let ctor = by.ctor;
                     (
                         format!(
-                            "`{}::{name}` is written directly here, but `{}::{}` rejects some values of `{name}` before storing one",
-                            cx.tcx.def_path_str(site.adt),
-                            cx.tcx.item_name(site.adt),
-                            by.ctor,
+                            "`{path}::{name}` is assigned directly here, skipping the check that `{ty}::{ctor}` runs on `{name}` before storing it"
                         ),
                         check.check,
-                        "the check this write never runs",
-                        "change the value through the validating function, or make the field private and move this write into the type's module",
+                        format!("the check in `{ty}::{ctor}` that this write skips"),
+                        format!(
+                            "change `{name}` through a method of `{ty}` that repeats the check, or make `{name}` private so this write only compiles inside `{ty}`'s own module"
+                        ),
                     )
                 }
             };

--- a/src/unchecked_input_len.rs
+++ b/src/unchecked_input_len.rs
@@ -63,14 +63,15 @@ use crate::baseline::emit_with_note;
 use crate::mir_flow::mir_for;
 
 rustc_session::declare_lint! {
-    /// Flags an integer the function received (a parameter other than
-    /// `self`, or a field reached from one) handed to `split_at`,
+    /// Flags an integer that comes from the caller (a parameter other than
+    /// `self`, or a field reached from one) passed to `split_at`,
     /// `get_unchecked`, `with_capacity`, `reserve`, `set_len`,
     /// `from_raw_parts`, `copy_nonoverlapping` or a raw-pointer
-    /// `add`/`offset` on a path that has not compared it, when some other
-    /// branch of the same function bounds it (`<`, `<=`, `>`, `>=`, also via
-    /// arithmetic on it): the author knew it needed a bound and this path
-    /// skips it. Reported at the use; the note points at the bound.
+    /// `add`/`offset` on a path where nothing has checked it, although the
+    /// same function does bound it (`<`, `<=`, `>`, `>=`, also via
+    /// arithmetic on it) on another path: the author knew it needed a bound
+    /// and this path skips it. Reported at the use; the note points at the
+    /// bound.
     ///
     /// Silent when every such use is dominated by a branch that tests the
     /// value (a clamp, an early return, an equality test, a `debug_assert!`,
@@ -1008,11 +1009,13 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedInputLen {
                 UNCHECKED_INPUT_LEN,
                 span,
                 format!(
-                    "`{name}` reaches `{callee}` here without having been checked, though this function bounds it elsewhere"
+                    "`{name}` comes from the caller and is passed to `{callee}` here on a path where nothing has checked it, although this function does bound `{name}` on another path"
                 ),
                 bound,
-                "the bound that does not cover this use",
-                "check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes",
+                format!("the bound on `{name}` that does not cover this path"),
+                format!(
+                    "check `{name}` before this call on every path (or once, before the paths split), or make the checked value the only thing `{callee}` can be given here"
+                ),
             );
         }
     }

--- a/src/unchecked_input_len.rs
+++ b/src/unchecked_input_len.rs
@@ -67,11 +67,10 @@ rustc_session::declare_lint! {
     /// `self`, or a field reached from one) passed to `split_at`,
     /// `get_unchecked`, `with_capacity`, `reserve`, `set_len`,
     /// `from_raw_parts`, `copy_nonoverlapping` or a raw-pointer
-    /// `add`/`offset` on a path where nothing has checked it, although the
-    /// same function does bound it (`<`, `<=`, `>`, `>=`, also via
-    /// arithmetic on it) on another path: the author knew it needed a bound
-    /// and this path skips it. Reported at the use; the note points at the
-    /// bound.
+    /// `add`/`offset` with no check on that path, although the same
+    /// function does bound it (`<`, `<=`, `>`, `>=`, also via arithmetic on
+    /// it) on another path: the author knew it needed a bound and this path
+    /// skips it. Reported at the use, and the note points at the bound.
     ///
     /// Silent when every such use is dominated by a branch that tests the
     /// value (a clamp, an early return, an equality test, a `debug_assert!`,
@@ -1009,12 +1008,12 @@ impl<'tcx> LateLintPass<'tcx> for UncheckedInputLen {
                 UNCHECKED_INPUT_LEN,
                 span,
                 format!(
-                    "`{name}` comes from the caller and is passed to `{callee}` here on a path where nothing has checked it, although this function does bound `{name}` on another path"
+                    "`{name}` comes from the caller and reaches `{callee}` here with no check on this path. The function does bound `{name}` on another path"
                 ),
                 bound,
-                format!("the bound on `{name}` that does not cover this path"),
+                "the bound that does not cover this path",
                 format!(
-                    "check `{name}` before this call on every path (or once, before the paths split), or make the checked value the only thing `{callee}` can be given here"
+                    "check `{name}` on every path before this call, or once before the paths split"
                 ),
             );
         }

--- a/src/unit_mismatch.rs
+++ b/src/unit_mismatch.rs
@@ -6,9 +6,10 @@ use crate::hir_shapes::value_name;
 
 rustc_session::declare_lint! {
     /// Flags addition, subtraction, and comparison between values whose names
-    /// claim different units: `timeout_ms + deadline_ns` compiles and is
-    /// always wrong. Multiplication and division stay silent, since they are
-    /// how units legitimately convert.
+    /// say they are in different units: `timeout_ms + deadline_ns` uses them
+    /// as if they were the same unit, compiles, and is always wrong.
+    /// Multiplication and division stay silent, since they are how units
+    /// legitimately convert.
     pub UNIT_MISMATCH,
     Warn,
     "arithmetic between values whose names claim different units"
@@ -68,19 +69,21 @@ impl<'tcx> LateLintPass<'tcx> for UnitMismatch {
             return;
         };
         if lc != rc {
+            let op = if matches!(op.node, BinOpKind::Add | BinOpKind::Sub) {
+                "arithmetic"
+            } else {
+                "comparison"
+            };
             emit(
                 cx,
                 UNIT_MISMATCH,
                 expr.span,
                 format!(
-                    "`{ln}` claims {lc} and `{rn}` claims {rc}; {} between them mixes units",
-                    if matches!(op.node, BinOpKind::Add | BinOpKind::Sub) {
-                        "arithmetic"
-                    } else {
-                        "comparison"
-                    }
+                    "`{ln}` says it is in {lc} and `{rn}` says {rc}, and this {op} uses them as if they were the same unit"
                 ),
-                "convert one side, or rename whichever name is lying about its unit",
+                format!(
+                    "convert one side to the other's unit first, or if `{ln}` or `{rn}` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one"
+                ),
             );
         }
     }

--- a/src/unit_mismatch.rs
+++ b/src/unit_mismatch.rs
@@ -6,8 +6,8 @@ use crate::hir_shapes::value_name;
 
 rustc_session::declare_lint! {
     /// Flags addition, subtraction, and comparison between values whose names
-    /// say they are in different units: `timeout_ms + deadline_ns` uses them
-    /// as if they were the same unit, compiles, and is always wrong.
+    /// say they are in different units: `timeout_ms + deadline_ns` mixes
+    /// them, compiles, and is always wrong.
     /// Multiplication and division stay silent, since they are how units
     /// legitimately convert.
     pub UNIT_MISMATCH,
@@ -21,15 +21,15 @@ rustc_session::declare_lint_pass!(UnitMismatch => [UNIT_MISMATCH]);
 /// operands from different classes.
 fn unit_class(suffix: &str) -> Option<&'static str> {
     Some(match suffix {
-        "ns" | "nanos" => "ns",
-        "us" | "micros" => "us",
-        "ms" | "millis" => "ms",
-        "sec" | "secs" | "seconds" => "s",
-        "mins" | "minutes" => "min",
+        "ns" | "nanos" => "nanoseconds",
+        "us" | "micros" => "microseconds",
+        "ms" | "millis" => "milliseconds",
+        "sec" | "secs" | "seconds" => "seconds",
+        "mins" | "minutes" => "minutes",
         "bytes" => "bytes",
-        "kb" | "kib" => "kb",
-        "mb" | "mib" => "mb",
-        "gb" | "gib" => "gb",
+        "kb" | "kib" => "kilobytes",
+        "mb" | "mib" => "megabytes",
+        "gb" | "gib" => "gigabytes",
         "tenths" => "tenths",
         _ => return None,
     })
@@ -78,12 +78,8 @@ impl<'tcx> LateLintPass<'tcx> for UnitMismatch {
                 cx,
                 UNIT_MISMATCH,
                 expr.span,
-                format!(
-                    "`{ln}` says it is in {lc} and `{rn}` says {rc}, and this {op} uses them as if they were the same unit"
-                ),
-                format!(
-                    "convert one side to the other's unit first, or if `{ln}` or `{rn}` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one"
-                ),
+                format!("`{ln}` says {lc} and `{rn}` says {rc}, and this {op} mixes them"),
+                "convert one side first. If a name is wrong about its unit, rename it. A `Duration` or a unit newtype would catch the next one",
             );
         }
     }

--- a/src/unread_error_variant.rs
+++ b/src/unread_error_variant.rs
@@ -6,12 +6,14 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 
 use crate::adt_facts::inside_own_trait_impl;
-use crate::baseline::emit;
+use crate::baseline::emit_with_note;
 use crate::enum_facts::{arm_variant, private_enum_of};
 
 rustc_session::declare_lint! {
-    /// Flags a crate-private enum variant that is constructed somewhere but
-    /// never named by a pattern outside the enum's own trait impls. Trait
+    /// Flags a crate-private enum variant that is built somewhere but never
+    /// singled out by a `match` arm or other pattern outside the enum's own
+    /// trait impls, so whatever it carries is never read and it is only ever
+    /// handled by a catch-all. Trait
     /// impls (`Display`, `Debug`, `From`, derives) must match every variant to
     /// exist, so they prove nothing; a pattern anywhere else, including the
     /// enum's own inherent methods, is the crate reading the structure. An
@@ -146,16 +148,20 @@ impl<'tcx> LateLintPass<'tcx> for UnreadErrorVariant {
         }
         unread.sort_by_key(|(span, ..)| span.lo());
         for (span, variant, enum_did) in unread {
-            emit(
+            let path = cx.tcx.def_path_str(variant);
+            let owner = cx.tcx.item_name(enum_did);
+            emit_with_note(
                 cx,
                 UNREAD_ERROR_VARIANT,
                 span,
                 format!(
-                    "`{}` is constructed here, but no pattern outside `{}`'s trait impls ever names it",
-                    cx.tcx.def_path_str(variant),
-                    cx.tcx.item_name(enum_did),
+                    "`{path}` is constructed here, but no `match` arm or pattern anywhere (outside `{owner}`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all"
                 ),
-                "the variant's structure is never read; handle it distinctly or collapse it into another variant",
+                cx.tcx.def_span(variant),
+                "the variant, which nothing matches on",
+                format!(
+                    "add an arm for `{path}` where `{owner}` is matched, or fold it into the variant it is currently lumped with"
+                ),
             );
         }
     }

--- a/src/unread_error_variant.rs
+++ b/src/unread_error_variant.rs
@@ -10,12 +10,12 @@ use crate::baseline::emit_with_note;
 use crate::enum_facts::{arm_variant, private_enum_of};
 
 rustc_session::declare_lint! {
-    /// Flags a crate-private enum variant that is built somewhere but never
-    /// singled out by a `match` arm or other pattern outside the enum's own
-    /// trait impls, so whatever it carries is never read and it is only ever
-    /// handled by a catch-all. Trait
+    /// Flags a crate-private enum variant that is constructed somewhere but
+    /// no pattern anywhere singles it out (its own trait impls aside), so
+    /// what it carries is never read and it is only ever caught by a
+    /// catch-all. Trait
     /// impls (`Display`, `Debug`, `From`, derives) must match every variant to
-    /// exist, so they prove nothing; a pattern anywhere else, including the
+    /// exist, so they prove nothing. A pattern anywhere else, including the
     /// enum's own inherent methods, is the crate reading the structure. An
     /// `==` / `!=` against a variant names it as a pattern would, and an `as`
     /// cast of the enum reads every variant, since the discriminant is all the
@@ -155,12 +155,12 @@ impl<'tcx> LateLintPass<'tcx> for UnreadErrorVariant {
                 UNREAD_ERROR_VARIANT,
                 span,
                 format!(
-                    "`{path}` is constructed here, but no `match` arm or pattern anywhere (outside `{owner}`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all"
+                    "`{path}` is constructed here, but no pattern anywhere singles it out (its own trait impls aside). What it carries is never read, and it is only ever caught by a catch-all"
                 ),
                 cx.tcx.def_span(variant),
-                "the variant, which nothing matches on",
+                "the variant",
                 format!(
-                    "add an arm for `{path}` where `{owner}` is matched, or fold it into the variant it is currently lumped with"
+                    "add an arm for `{path}` where `{owner}` is matched, or fold it into the variant it is lumped with"
                 ),
             );
         }

--- a/src/wildcard_over_own_enum.rs
+++ b/src/wildcard_over_own_enum.rs
@@ -15,9 +15,9 @@ use crate::hir_shapes::{callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
     /// Flags `_` (or a catch-all binding) matching over a small crate-local
-    /// enum. The catch-all also matches any variant added to the enum later,
-    /// so a new variant lands in it silently instead of failing to compile.
-    /// Spelling out the remaining variants keeps exhaustiveness checking
+    /// enum. The catch-all will also match any variant added to the enum
+    /// later, so a new variant lands in it silently instead of failing to
+    /// compile. Listing the remaining variants keeps exhaustiveness checking
     /// alive.
     ///
     /// Silent on an arm that answers "not this shape" (`None`, `false`, an
@@ -233,19 +233,18 @@ impl<'tcx> LateLintPass<'tcx> for WildcardOverOwnEnum {
                 arm.hir_id,
                 arm.pat.span,
                 format!(
-                    "this catch-all also matches any variant added to `{name}` later ({n} today), so a new variant lands here silently instead of failing to compile"
+                    "this catch-all will also match any variant added to `{name}` later ({n} today). A new variant lands here silently instead of failing to compile"
                 ),
                 |diag| {
                     diag.span_note(
                         cx.tcx.def_span(adt.did()),
-                        format!("`{name}`, whose new variants would fall into this arm"),
+                        format!("`{name}` is defined here"),
                     );
-                    let msg = format!(
-                        "spell out the remaining variants instead; the compiler then points at this `match` whenever `{name}` grows"
-                    );
+                    let wildcard = snippet_opt(cx, arm.pat.span).unwrap_or_else(|| "_".into());
+                    let msg = format!("list the remaining variants instead of `{wildcard}`");
                     match &fix {
                         Some(sugg) => {
-                            diag.span_suggestion(
+                            diag.span_suggestion_verbose(
                                 arm.pat.span,
                                 msg,
                                 sugg,

--- a/src/wildcard_over_own_enum.rs
+++ b/src/wildcard_over_own_enum.rs
@@ -15,9 +15,10 @@ use crate::hir_shapes::{callee_of, peel_blocks_unsafe};
 
 rustc_session::declare_lint! {
     /// Flags `_` (or a catch-all binding) matching over a small crate-local
-    /// enum. The wildcard absorbs every future variant: adding one compiles
-    /// without a whisper, and this match silently routes it to the old
-    /// behavior. Listing the variants keeps exhaustiveness checking alive.
+    /// enum. The catch-all also matches any variant added to the enum later,
+    /// so a new variant lands in it silently instead of failing to compile.
+    /// Spelling out the remaining variants keeps exhaustiveness checking
+    /// alive.
     ///
     /// Silent on an arm that answers "not this shape" (`None`, `false`, an
     /// empty slice, string or collection, or a `return` of one of those, with
@@ -225,18 +226,23 @@ impl<'tcx> LateLintPass<'tcx> for WildcardOverOwnEnum {
             // Emitted against the ARM's hir id, so an #[allow] placed on the
             // arm itself is honored; a plain span emission would only see the
             // enclosing match's lint level.
+            let name = cx.tcx.def_path_str(adt.did());
             emit_hir_then(
                 cx,
                 WILDCARD_OVER_OWN_ENUM,
                 arm.hir_id,
                 arm.pat.span,
                 format!(
-                    "this arm absorbs every future variant of `{}` ({n} variants today)",
-                    cx.tcx.def_path_str(adt.did()),
+                    "this catch-all also matches any variant added to `{name}` later ({n} today), so a new variant lands here silently instead of failing to compile"
                 ),
                 |diag| {
-                    let msg =
-                        "list the remaining variants; the compiler then flags every new one added";
+                    diag.span_note(
+                        cx.tcx.def_span(adt.did()),
+                        format!("`{name}`, whose new variants would fall into this arm"),
+                    );
+                    let msg = format!(
+                        "spell out the remaining variants instead; the compiler then points at this `match` whenever `{name}` grows"
+                    );
                     match &fix {
                         Some(sugg) => {
                             diag.span_suggestion(

--- a/ui/always_unwrapped_option.stderr
+++ b/ui/always_unwrapped_option.stderr
@@ -1,4 +1,4 @@
-warning: `Conn.sock` is unwrapped at every one of its 2 reads and nothing ever handles `None`, so `None` only exists to crash on
+warning: `Conn.sock` is unwrapped at all 2 of its reads and `None` is never handled, so `None` can only crash
   --> $DIR/always_unwrapped_option.rs:5:5
    |
 LL |     sock: Option<u32>,
@@ -9,7 +9,7 @@ note: one of the reads
    |
 LL |         self.sock.unwrap()
    |         ^^^^^^^^^
-   = help: store the `sock` value directly and construct `Conn` once you have it, or split `Conn` into a type without `sock` and a later one with it
+   = help: store the `sock` value itself and b$DIRld `Conn` once you have it. Or split `Conn` into a type without `sock` and one with it
    = note: `#[warn(always_unwrapped_option)]` on by default
 
 warning: 1 warning emitted

--- a/ui/always_unwrapped_option.stderr
+++ b/ui/always_unwrapped_option.stderr
@@ -1,10 +1,15 @@
-warning: every read of `Conn.sock` assumes `Some` (2 unwraps, 0 sites handle `None`)
+warning: `Conn.sock` is unwrapped at every one of its 2 reads and nothing ever handles `None`, so `None` only exists to crash on
   --> $DIR/always_unwrapped_option.rs:5:5
    |
 LL |     sock: Option<u32>,
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: `None` is a state no reader survives; split the phases into types, or store `T` directly
+note: one of the reads
+  --> $DIR/always_unwrapped_option.rs:20:9
+   |
+LL |         self.sock.unwrap()
+   |         ^^^^^^^^^
+   = help: store the `sock` value directly and construct `Conn` once you have it, or split `Conn` into a type without `sock` and a later one with it
    = note: `#[warn(always_unwrapped_option)]` on by default
 
 warning: 1 warning emitted

--- a/ui/arg_named_like_other_param.stderr
+++ b/ui/arg_named_like_other_param.stderr
@@ -1,59 +1,94 @@
-warning: arguments `height` and `width` are bound to `resize`'s parameters `width` and `height`; all are `u32`, so the transposition type-checks
+warning: `height` and `width` are passed where `resize` expects `width` and `height`, in that order, and since all are `u32` the compiler cannot tell they are swapped
   --> $DIR/arg_named_like_other_param.rs:71:5
    |
 LL |     resize(height, width)
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error
+note: `resize`'s parameters, in the order it declares them
+  --> $DIR/arg_named_like_other_param.rs:3:1
+   |
+LL | fn resize(width: u32, height: u32) -> u32 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `width` and `height` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
    = note: `#[warn(arg_named_like_other_param)]` on by default
 
-warning: arguments `inherit_stderr` and `inherit_stdout` are bound to `spawn`'s parameters `inherit_stdout` and `inherit_stderr`; all are `bool`, so the transposition type-checks
+warning: `inherit_stderr` and `inherit_stdout` are passed where `spawn` expects `inherit_stdout` and `inherit_stderr`, in that order, and since all are `bool` the compiler cannot tell they are swapped
   --> $DIR/arg_named_like_other_param.rs:76:5
    |
 LL |     spawn(opts.inherit_stderr, opts.inherit_stdout)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error
+note: `spawn`'s parameters, in the order it declares them
+  --> $DIR/arg_named_like_other_param.rs:16:1
+   |
+LL | fn spawn(inherit_stdout: bool, inherit_stderr: bool) -> bool {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `inherit_stdout` and `inherit_stderr` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
 
-warning: argument `column` is bound to `place`'s parameter `line`, but `place` also takes a parameter `column` of the same type `u32`
+warning: `column` is passed as `place`'s `line` parameter, though `place` also has a `column` parameter of the same type `u32`, so this looks like an argument in the wrong position and the compiler cannot tell
   --> $DIR/arg_named_like_other_param.rs:81:11
    |
 LL |     place(column, extra, 0)
    |           ^^^^^^
    |
-   = help: give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error
+note: `place`'s parameters, in the order it declares them
+  --> $DIR/arg_named_like_other_param.rs:20:1
+   |
+LL | fn place(line: u32, column: u32, offset: u32) -> u32 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: move `column` to the `column` position, or if it really is the `line` here, rename it; then give `line` and `column` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
 
-warning: arguments `dst` and `src` are bound to `blit`'s parameters `src` and `dst`; all are `usize`, so the transposition type-checks
+warning: `dst` and `src` are passed where `blit` expects `src` and `dst`, in that order, and since all are `usize` the compiler cannot tell they are swapped
   --> $DIR/arg_named_like_other_param.rs:86:5
    |
 LL |     c.blit(dst, src)
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error
+note: `blit`'s parameters, in the order it declares them
+  --> $DIR/arg_named_like_other_param.rs:43:5
+   |
+LL |     fn blit(&self, src: usize, dst: usize) -> usize {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `src` and `dst` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
 
-warning: arguments `registry` and `url` are bound to `under`'s parameters `url` and `registry`; all are `&str`, so the transposition type-checks
+warning: `registry` and `url` are passed where `under` expects `url` and `registry`, in that order, and since all are `&str` the compiler cannot tell they are swapped
   --> $DIR/arg_named_like_other_param.rs:91:5
    |
 LL |     under(registry, url)
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error
+note: `under`'s parameters, in the order it declares them
+  --> $DIR/arg_named_like_other_param.rs:48:1
+   |
+LL | fn under(url: &str, registry: &str) -> bool {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `url` and `registry` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
 
-warning: argument `inherit_stdout` is bound to `spawn`'s parameter `inherit_stderr`, but `spawn` also takes a parameter `inherit_stdout` of the same type `bool`
+warning: `inherit_stdout` is passed as `spawn`'s `inherit_stderr` parameter, though `spawn` also has a `inherit_stdout` parameter of the same type `bool`, so this looks like an argument in the wrong position and the compiler cannot tell
   --> $DIR/arg_named_like_other_param.rs:97:25
    |
 LL |     let _ = spawn(true, opts.inherit_stdout);
    |                         ^^^^^^^^^^^^^^^^^^^
    |
-   = help: give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error
+note: `spawn`'s parameters, in the order it declares them
+  --> $DIR/arg_named_like_other_param.rs:16:1
+   |
+LL | fn spawn(inherit_stdout: bool, inherit_stderr: bool) -> bool {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: move `inherit_stdout` to the `inherit_stdout` position, or if it really is the `inherit_stderr` here, rename it; then give `inherit_stderr` and `inherit_stdout` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
 
-warning: argument `height` is bound to `resize`'s parameter `width`, but `resize` also takes a parameter `height` of the same type `u32`
+warning: `height` is passed as `resize`'s `width` parameter, though `resize` also has a `height` parameter of the same type `u32`, so this looks like an argument in the wrong position and the compiler cannot tell
   --> $DIR/arg_named_like_other_param.rs:98:12
    |
 LL |     resize(height, 0)
    |            ^^^^^^
    |
-   = help: give the two parameters distinct types (a newtype per quantity, an enum per flag) so a swap is a type error
+note: `resize`'s parameters, in the order it declares them
+  --> $DIR/arg_named_like_other_param.rs:3:1
+   |
+LL | fn resize(width: u32, height: u32) -> u32 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: move `height` to the `height` position, or if it really is the `width` here, rename it; then give `width` and `height` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
 
 warning: 7 warnings emitted
 

--- a/ui/arg_named_like_other_param.stderr
+++ b/ui/arg_named_like_other_param.stderr
@@ -1,94 +1,94 @@
-warning: `height` and `width` are passed where `resize` expects `width` and `height`, in that order, and since all are `u32` the compiler cannot tell they are swapped
+warning: `height` and `width` are passed where `resize` expects `width` then `height`. All are `u32`, so the swap compiles
   --> $DIR/arg_named_like_other_param.rs:71:5
    |
 LL |     resize(height, width)
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: `resize`'s parameters, in the order it declares them
+note: `resize` declares them in this order
   --> $DIR/arg_named_like_other_param.rs:3:1
    |
 LL | fn resize(width: u32, height: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `width` and `height` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
+   = help: swap the arguments. If the call is right, rename the values to match. Distinct types for `width` and `height` would make the next swap a compile error
    = note: `#[warn(arg_named_like_other_param)]` on by default
 
-warning: `inherit_stderr` and `inherit_stdout` are passed where `spawn` expects `inherit_stdout` and `inherit_stderr`, in that order, and since all are `bool` the compiler cannot tell they are swapped
+warning: `inherit_stderr` and `inherit_stdout` are passed where `spawn` expects `inherit_stdout` then `inherit_stderr`. All are `bool`, so the swap compiles
   --> $DIR/arg_named_like_other_param.rs:76:5
    |
 LL |     spawn(opts.inherit_stderr, opts.inherit_stdout)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `spawn`'s parameters, in the order it declares them
+note: `spawn` declares them in this order
   --> $DIR/arg_named_like_other_param.rs:16:1
    |
 LL | fn spawn(inherit_stdout: bool, inherit_stderr: bool) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `inherit_stdout` and `inherit_stderr` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
+   = help: swap the arguments. If the call is right, rename the values to match. Distinct types for `inherit_stdout` and `inherit_stderr` would make the next swap a compile error
 
-warning: `column` is passed as `place`'s `line` parameter, though `place` also has a `column` parameter of the same type `u32`, so this looks like an argument in the wrong position and the compiler cannot tell
+warning: `column` is passed as `place`'s `line` parameter, but `place` also has a parameter named `column` and both are `u32`. This looks like an argument in the wrong position
   --> $DIR/arg_named_like_other_param.rs:81:11
    |
 LL |     place(column, extra, 0)
    |           ^^^^^^
    |
-note: `place`'s parameters, in the order it declares them
+note: `place` declares them in this order
   --> $DIR/arg_named_like_other_param.rs:20:1
    |
 LL | fn place(line: u32, column: u32, offset: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: move `column` to the `column` position, or if it really is the `line` here, rename it; then give `line` and `column` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
+   = help: move `column` to the `column` position. If it really is the `line` here, rename it. Distinct types for `line` and `column` would make the next swap a compile error
 
-warning: `dst` and `src` are passed where `blit` expects `src` and `dst`, in that order, and since all are `usize` the compiler cannot tell they are swapped
+warning: `dst` and `src` are passed where `blit` expects `src` then `dst`. All are `usize`, so the swap compiles
   --> $DIR/arg_named_like_other_param.rs:86:5
    |
 LL |     c.blit(dst, src)
    |     ^^^^^^^^^^^^^^^^
    |
-note: `blit`'s parameters, in the order it declares them
+note: `blit` declares them in this order
   --> $DIR/arg_named_like_other_param.rs:43:5
    |
 LL |     fn blit(&self, src: usize, dst: usize) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `src` and `dst` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
+   = help: swap the arguments. If the call is right, rename the values to match. Distinct types for `src` and `dst` would make the next swap a compile error
 
-warning: `registry` and `url` are passed where `under` expects `url` and `registry`, in that order, and since all are `&str` the compiler cannot tell they are swapped
+warning: `registry` and `url` are passed where `under` expects `url` then `registry`. All are `&str`, so the swap compiles
   --> $DIR/arg_named_like_other_param.rs:91:5
    |
 LL |     under(registry, url)
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-note: `under`'s parameters, in the order it declares them
+note: `under` declares them in this order
   --> $DIR/arg_named_like_other_param.rs:48:1
    |
 LL | fn under(url: &str, registry: &str) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: swap them, or if the call is right as written, rename the values so they stop contradicting the parameters; then give `url` and `registry` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
+   = help: swap the arguments. If the call is right, rename the values to match. Distinct types for `url` and `registry` would make the next swap a compile error
 
-warning: `inherit_stdout` is passed as `spawn`'s `inherit_stderr` parameter, though `spawn` also has a `inherit_stdout` parameter of the same type `bool`, so this looks like an argument in the wrong position and the compiler cannot tell
+warning: `inherit_stdout` is passed as `spawn`'s `inherit_stderr` parameter, but `spawn` also has a parameter named `inherit_stdout` and both are `bool`. This looks like an argument in the wrong position
   --> $DIR/arg_named_like_other_param.rs:97:25
    |
 LL |     let _ = spawn(true, opts.inherit_stdout);
    |                         ^^^^^^^^^^^^^^^^^^^
    |
-note: `spawn`'s parameters, in the order it declares them
+note: `spawn` declares them in this order
   --> $DIR/arg_named_like_other_param.rs:16:1
    |
 LL | fn spawn(inherit_stdout: bool, inherit_stderr: bool) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: move `inherit_stdout` to the `inherit_stdout` position, or if it really is the `inherit_stderr` here, rename it; then give `inherit_stderr` and `inherit_stdout` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
+   = help: move `inherit_stdout` to the `inherit_stdout` position. If it really is the `inherit_stderr` here, rename it. Distinct types for `inherit_stderr` and `inherit_stdout` would make the next swap a compile error
 
-warning: `height` is passed as `resize`'s `width` parameter, though `resize` also has a `height` parameter of the same type `u32`, so this looks like an argument in the wrong position and the compiler cannot tell
+warning: `height` is passed as `resize`'s `width` parameter, but `resize` also has a parameter named `height` and both are `u32`. This looks like an argument in the wrong position
   --> $DIR/arg_named_like_other_param.rs:98:12
    |
 LL |     resize(height, 0)
    |            ^^^^^^
    |
-note: `resize`'s parameters, in the order it declares them
+note: `resize` declares them in this order
   --> $DIR/arg_named_like_other_param.rs:3:1
    |
 LL | fn resize(width: u32, height: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: move `height` to the `height` position, or if it really is the `width` here, rename it; then give `width` and `height` distinct types (a newtype per quantity, an enum per flag) so the next mix-up is a type error
+   = help: move `height` to the `height` position. If it really is the `width` here, rename it. Distinct types for `width` and `height` would make the next swap a compile error
 
 warning: 7 warnings emitted
 

--- a/ui/bare_bool_args.stderr
+++ b/ui/bare_bool_args.stderr
@@ -1,29 +1,29 @@
-warning: `render` takes `bool` parameters `wrap` and `color`, and 2 of its 3 call sites pass bare `true`/`false` for both: nothing at `render(.., true, false)` says which flag each one sets
+warning: `render` takes `bool` parameters `wrap` and `color`, and 2 of its 3 calls pass bare `true`/`false` for both, so at `render(.., true, false)` nothing says which flag is which and the swapped call compiles too
   --> $DIR/bare_bool_args.rs:5:4
    |
 LL | fn render(text: &str, wrap: bool, color: bool) -> usize {
    |    ^^^^^^
    |
-note: one such call
+note: one of those calls
   --> $DIR/bare_bool_args.rs:62:13
    |
 LL |     let _ = render("a", true, false);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: a two-variant enum per flag, or one options struct, names every argument at the call site and turns a swapped pair into a type error
+   = help: give `wrap` and `color` each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error
    = note: `#[warn(bare_bool_args)]` on by default
 
-warning: `open` takes `bool` parameters `create`, `truncate` and `append`, and 2 of its 2 call sites pass bare `true`/`false` for at least two of them: nothing at `open(true, false, ..)` says which flag each one sets
+warning: `open` takes `bool` parameters `create`, `truncate` and `append`, and 2 of its 2 calls pass bare `true`/`false` for at least two of them, so at `open(true, false, ..)` nothing says which flag is which and the swapped call compiles too
   --> $DIR/bare_bool_args.rs:16:8
    |
 LL |     fn open(&mut self, create: bool, truncate: bool, append: bool) -> usize {
    |        ^^^^
    |
-note: one such call
+note: one of those calls
   --> $DIR/bare_bool_args.rs:68:13
    |
 LL |     let _ = f.open(true, false, append);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: a two-variant enum per flag, or one options struct, names every argument at the call site and turns a swapped pair into a type error
+   = help: give `create`, `truncate` and `append` each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error
 
 warning: 2 warnings emitted
 

--- a/ui/bare_bool_args.stderr
+++ b/ui/bare_bool_args.stderr
@@ -1,4 +1,4 @@
-warning: `render` takes `bool` parameters `wrap` and `color`, and 2 of its 3 calls pass bare `true`/`false` for both, so at `render(.., true, false)` nothing says which flag is which and the swapped call compiles too
+warning: `render` takes bools `wrap` and `color`, and 2 of its 3 calls pass bare `true`/`false` for both. At `render(.., true, false)` nothing says which is which
   --> $DIR/bare_bool_args.rs:5:4
    |
 LL | fn render(text: &str, wrap: bool, color: bool) -> usize {
@@ -9,10 +9,10 @@ note: one of those calls
    |
 LL |     let _ = render("a", true, false);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: give `wrap` and `color` each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error
+   = help: give `wrap` and `color` a two-variant enum each, or an options struct, so every call names what it sets
    = note: `#[warn(bare_bool_args)]` on by default
 
-warning: `open` takes `bool` parameters `create`, `truncate` and `append`, and 2 of its 2 calls pass bare `true`/`false` for at least two of them, so at `open(true, false, ..)` nothing says which flag is which and the swapped call compiles too
+warning: `open` takes bools `create`, `truncate` and `append`, and 2 of its 2 calls pass bare `true`/`false` for at least two of them. At `open(true, false, ..)` nothing says which is which
   --> $DIR/bare_bool_args.rs:16:8
    |
 LL |     fn open(&mut self, create: bool, truncate: bool, append: bool) -> usize {
@@ -23,7 +23,7 @@ note: one of those calls
    |
 LL |     let _ = f.open(true, false, append);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: give `create`, `truncate` and `append` each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error
+   = help: give `create`, `truncate` and `append` a two-variant enum each, or an options struct, so every call names what it sets
 
 warning: 2 warnings emitted
 

--- a/ui/bool_beside_option.stderr
+++ b/ui/bool_beside_option.stderr
@@ -1,42 +1,42 @@
-warning: `connected` of `Conn` is written only together with `peer` in all 3 places, `true` with `Some(..)` and `false` with `None`, so it is `peer.is_some()` stored a second time and kept equal only by habit
+warning: `Conn.connected` is only ever written next to `peer`, `true` with `Some` and `false` with `None`, in all 3 places. It is `peer.is_some()` stored twice
   --> $DIR/bool_beside_option.rs:7:5
    |
 LL |     connected: bool,
    |     ^^^^^^^^^^^^^^^
    |
-note: one of the writes that pairs them
+note: one of the paired writes
   --> $DIR/bool_beside_option.rs:15:13
    |
 LL |             connected: false,
    |             ^^^^^^^^^^^^^^^^
-   = help: delete `connected` and ask `peer.is_some()` where it was read; the two then cannot disagree
+   = help: delete `connected` and call `peer.is_some()` where it was read
    = note: `#[warn(bool_beside_option)]` on by default
 
-warning: `stale` of `Cache` is written only together with `fresh` in all 2 places, `true` with `None` and `false` with `Some(..)`, so it is `fresh.is_none()` stored a second time and kept equal only by habit
+warning: `Cache.stale` is only ever written next to `fresh`, `true` with `None` and `false` with `Some`, in all 2 places. It is `fresh.is_none()` stored twice
   --> $DIR/bool_beside_option.rs:44:5
    |
 LL |     stale: bool,
    |     ^^^^^^^^^^^
    |
-note: one of the writes that pairs them
+note: one of the paired writes
   --> $DIR/bool_beside_option.rs:51:13
    |
 LL |             stale: false,
    |             ^^^^^^^^^^^^
-   = help: delete `stale` and ask `fresh.is_none()` where it was read; the two then cannot disagree
+   = help: delete `stale` and call `fresh.is_none()` where it was read
 
-warning: `linked` of `Link` is written only together with `up` in all 3 places, `true` with `Some(..)` and `false` with `None`, so it is `up.is_some()` stored a second time and kept equal only by habit
+warning: `Link.linked` is only ever written next to `up`, `true` with `Some` and `false` with `None`, in all 3 places. It is `up.is_some()` stored twice
   --> $DIR/bool_beside_option.rs:73:5
    |
 LL |     linked: bool,
    |     ^^^^^^^^^^^^
    |
-note: one of the writes that pairs them
+note: one of the paired writes
   --> $DIR/bool_beside_option.rs:84:9
    |
 LL |         self.linked = true;
    |         ^^^^^^^^^^^^^^^^^^
-   = help: delete `linked` and ask `up.is_some()` where it was read; the two then cannot disagree
+   = help: delete `linked` and call `up.is_some()` where it was read
 
 warning: 3 warnings emitted
 

--- a/ui/bool_beside_option.stderr
+++ b/ui/bool_beside_option.stderr
@@ -1,27 +1,42 @@
-warning: `connected` is only ever written beside `peer` of `Conn`, `true` with `Some(..)` and `false` with `None` (3 sites): it stores `peer.is_some()` a second time
+warning: `connected` of `Conn` is written only together with `peer` in all 3 places, `true` with `Some(..)` and `false` with `None`, so it is `peer.is_some()` stored a second time and kept equal only by habit
   --> $DIR/bool_beside_option.rs:7:5
    |
 LL |     connected: bool,
    |     ^^^^^^^^^^^^^^^
    |
-   = help: the `Option` already carries this state; drop the flag and ask the `Option`, so the two cannot disagree
+note: one of the writes that pairs them
+  --> $DIR/bool_beside_option.rs:15:13
+   |
+LL |             connected: false,
+   |             ^^^^^^^^^^^^^^^^
+   = help: delete `connected` and ask `peer.is_some()` where it was read; the two then cannot disagree
    = note: `#[warn(bool_beside_option)]` on by default
 
-warning: `stale` is only ever written beside `fresh` of `Cache`, `true` with `None` and `false` with `Some(..)` (2 sites): it stores `fresh.is_none()` a second time
+warning: `stale` of `Cache` is written only together with `fresh` in all 2 places, `true` with `None` and `false` with `Some(..)`, so it is `fresh.is_none()` stored a second time and kept equal only by habit
   --> $DIR/bool_beside_option.rs:44:5
    |
 LL |     stale: bool,
    |     ^^^^^^^^^^^
    |
-   = help: the `Option` already carries this state; drop the flag and ask the `Option`, so the two cannot disagree
+note: one of the writes that pairs them
+  --> $DIR/bool_beside_option.rs:51:13
+   |
+LL |             stale: false,
+   |             ^^^^^^^^^^^^
+   = help: delete `stale` and ask `fresh.is_none()` where it was read; the two then cannot disagree
 
-warning: `linked` is only ever written beside `up` of `Link`, `true` with `Some(..)` and `false` with `None` (3 sites): it stores `up.is_some()` a second time
+warning: `linked` of `Link` is written only together with `up` in all 3 places, `true` with `Some(..)` and `false` with `None`, so it is `up.is_some()` stored a second time and kept equal only by habit
   --> $DIR/bool_beside_option.rs:73:5
    |
 LL |     linked: bool,
    |     ^^^^^^^^^^^^
    |
-   = help: the `Option` already carries this state; drop the flag and ask the `Option`, so the two cannot disagree
+note: one of the writes that pairs them
+  --> $DIR/bool_beside_option.rs:84:9
+   |
+LL |         self.linked = true;
+   |         ^^^^^^^^^^^^^^^^^^
+   = help: delete `linked` and ask `up.is_some()` where it was read; the two then cannot disagree
 
 warning: 3 warnings emitted
 

--- a/ui/bool_cluster.stderr
+++ b/ui/bool_cluster.stderr
@@ -1,19 +1,19 @@
-warning: the 5 bool fields `fair`, `rr`, `census`, `stacks`, `counters` of `ShareVerdict` are 32 representable states
+warning: `ShareVerdict` has 5 bool fields (`fair`, `rr`, `census`, `stacks`, `counters`), which allows 32 combinations whether or not all 32 mean something
   --> $DIR/bool_cluster.rs:4:1
    |
 LL | struct ShareVerdict {
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: if fewer are legal, name them in an enum; if the layout is fixed elsewhere, give it a repr
+   = help: if only some of the 32 are legal, replace these bools with an enum of the legal ones; if the layout is fixed from outside, say so with a `repr` on `ShareVerdict`
    = note: `#[warn(bool_cluster)]` on by default
 
-warning: the 3 bool fields `too_big`, `exhausted`, `fragmented` of `Refusals` are 8 representable states
+warning: `Refusals` has 3 bool fields (`too_big`, `exhausted`, `fragmented`), which allows 8 combinations whether or not all 8 mean something
   --> $DIR/bool_cluster.rs:14:1
    |
 LL | struct Refusals {
    | ^^^^^^^^^^^^^^^
    |
-   = help: if fewer are legal, name them in an enum; if the layout is fixed elsewhere, give it a repr
+   = help: if only some of the 8 are legal, replace these bools with an enum of the legal ones; if the layout is fixed from outside, say so with a `repr` on `Refusals`
 
 warning: 2 warnings emitted
 

--- a/ui/bool_cluster.stderr
+++ b/ui/bool_cluster.stderr
@@ -1,19 +1,19 @@
-warning: `ShareVerdict` has 5 bool fields (`fair`, `rr`, `census`, `stacks`, `counters`), which allows 32 combinations whether or not all 32 mean something
+warning: `ShareVerdict` has 5 bool fields (`fair`, `rr`, `census`, `stacks`, `counters`). That is 32 possible combinations
   --> $DIR/bool_cluster.rs:4:1
    |
 LL | struct ShareVerdict {
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: if only some of the 32 are legal, replace these bools with an enum of the legal ones; if the layout is fixed from outside, say so with a `repr` on `ShareVerdict`
+   = help: if only some combinations are valid, replace the bools with an enum of those. If the layout is fixed from outside, add a `repr` to `ShareVerdict` to say so
    = note: `#[warn(bool_cluster)]` on by default
 
-warning: `Refusals` has 3 bool fields (`too_big`, `exhausted`, `fragmented`), which allows 8 combinations whether or not all 8 mean something
+warning: `Refusals` has 3 bool fields (`too_big`, `exhausted`, `fragmented`). That is 8 possible combinations
   --> $DIR/bool_cluster.rs:14:1
    |
 LL | struct Refusals {
    | ^^^^^^^^^^^^^^^
    |
-   = help: if only some of the 8 are legal, replace these bools with an enum of the legal ones; if the layout is fixed from outside, say so with a `repr` on `Refusals`
+   = help: if only some combinations are valid, replace the bools with an enum of those. If the layout is fixed from outside, add a `repr` to `Refusals` to say so
 
 warning: 2 warnings emitted
 

--- a/ui/cast_bypasses_from.stderr
+++ b/ui/cast_bypasses_from.stderr
@@ -1,198 +1,198 @@
-warning: `u8` is reinterpreted as `level::Level` by `mem::transmute` here, but `Level::try_from` converts `u8` to `level::Level` and can refuse a value; this site accepts any bit pattern
+warning: `u8` is reinterpreted as `level::Level` by `mem::transmute` here, which accepts any bit pattern, including values `Level::try_from` (the crate's checked `u8` to `level::Level` conversion) would refuse
   --> $DIR/cast_bypasses_from.rs:195:14
    |
 LL |     unsafe { core::mem::transmute::<u8, Level>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Level::try_from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:16:9
    |
 LL |         fn try_from(n: u8) -> Result<Self, u8> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Level::try_from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Level::try_from` so both sit beside the layout they depend on
    = note: `#[warn(cast_bypasses_from)]` on by default
 
-warning: `u16` is reinterpreted as `code::Code` by `mem::transmute` here, but `Code::from_raw` converts `u32` to `code::Code` and can refuse a value; this site accepts any bit pattern
+warning: `u16` is reinterpreted as `code::Code` by `mem::transmute` here, which accepts any bit pattern, including values `Code::from_raw` (the crate's checked `u32` to `code::Code` conversion) would refuse
   --> $DIR/cast_bypasses_from.rs:200:14
    |
 LL |     unsafe { core::mem::transmute::<u16, Code>(n as u16) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Code::from_raw`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:41:9
    |
 LL |         pub fn from_raw(n: u32) -> Option<Code> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Code::from_raw` instead; if this path must skip it, add an explicitly unchecked constructor next to `Code::from_raw` so both sit beside the layout they depend on
 
-warning: `u16` is reinterpreted as `code::Code` by `mem::transmute_copy` here, but `Code::from_raw` converts `u32` to `code::Code` and can refuse a value; this site accepts any bit pattern
+warning: `u16` is reinterpreted as `code::Code` by `mem::transmute_copy` here, which accepts any bit pattern, including values `Code::from_raw` (the crate's checked `u32` to `code::Code` conversion) would refuse
   --> $DIR/cast_bypasses_from.rs:205:14
    |
 LL |     unsafe { core::mem::transmute_copy::<u16, Code>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Code::from_raw`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:41:9
    |
 LL |         pub fn from_raw(n: u32) -> Option<Code> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Code::from_raw` instead; if this path must skip it, add an explicitly unchecked constructor next to `Code::from_raw` so both sit beside the layout they depend on
 
-warning: `i32` is reinterpreted as `fd::Fd` by `mem::transmute` here, but `Fd::new` is how `i32` becomes `fd::Fd`; this site goes around it
+warning: `i32` is reinterpreted as `fd::Fd` by `mem::transmute` here, going around `Fd::new`, which is where the crate says how `i32` becomes `fd::Fd`
   --> $DIR/cast_bypasses_from.rs:210:14
    |
 LL |     unsafe { core::mem::transmute::<i32, Fd>(raw) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Fd::new`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:57:9
    |
 LL |         pub fn new(raw: i32) -> Fd {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Fd::new` instead; if this path must skip it, add an explicitly unchecked constructor next to `Fd::new` so both sit beside the layout they depend on
 
-warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, but `Meters::from` is how `u32` becomes `meters::Meters`; this site goes around it
+warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:215:15
    |
 LL |     unsafe { *(n as *const u32 as *const Meters) }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Meters::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
 
-warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, but `Meters::from` is how `u32` becomes `meters::Meters`; this site goes around it
+warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:220:14
    |
 LL |     unsafe { p.cast::<Meters>().read() }
    |              ^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Meters::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
 
-warning: `u32` is reinterpreted as `meters::Meters` by `mem::transmute` here, but `Meters::from` is how `u32` becomes `meters::Meters`; this site goes around it
+warning: `u32` is reinterpreted as `meters::Meters` by `mem::transmute` here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:225:14
    |
 LL |     unsafe { core::mem::transmute::<&u32, &Meters>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Meters::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
 
-warning: `u32` is reinterpreted as `meters::Meters` by `mem::transmute` here, but `Meters::from` is how `u32` becomes `meters::Meters`; this site goes around it
+warning: `u32` is reinterpreted as `meters::Meters` by `mem::transmute` here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:230:14
    |
 LL |     unsafe { core::mem::transmute::<&u32, &Meters>(v) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Meters::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
 
-warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, but `Meters::from` is how `u32` becomes `meters::Meters`; this site goes around it
+warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:237:25
    |
 LL |         sum += unsafe { p.cast::<Meters>().read() }.0;
    |                         ^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Meters::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
 
-warning: `f32` is reinterpreted as `px::Px<px::Screen>` by `mem::transmute` here, but `Px::from` is how `f32` becomes `px::Px<px::Screen>`; this site goes around it
+warning: `f32` is reinterpreted as `px::Px<px::Screen>` by `mem::transmute` here, going around `Px::from`, which is where the crate says how `f32` becomes `px::Px<px::Screen>`
   --> $DIR/cast_bypasses_from.rs:244:14
    |
 LL |     unsafe { core::mem::transmute::<f32, Px<Screen>>(v) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Px::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:122:9
    |
 LL |         fn from(v: f32) -> Px<Screen> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Px::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Px::from` so both sit beside the layout they depend on
 
-warning: `[u8; 4]` is reinterpreted as `hdr::Hdr` by `mem::transmute` here, but `Hdr::from` is how `&[u8; 4]` becomes `hdr::Hdr`; this site goes around it
+warning: `[u8; 4]` is reinterpreted as `hdr::Hdr` by `mem::transmute` here, going around `Hdr::from`, which is where the crate says how `&[u8; 4]` becomes `hdr::Hdr`
   --> $DIR/cast_bypasses_from.rs:254:14
    |
 LL |     unsafe { core::mem::transmute::<[u8; 4], Hdr>(*b) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Hdr::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:134:9
    |
 LL |         fn from(b: &'a [u8; 4]) -> Hdr {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Hdr::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Hdr::from` so both sit beside the layout they depend on
 
-warning: `[u8; 4]` is reinterpreted as `hdr::Hdr` by a pointer cast here, but `Hdr::from` is how `&[u8; 4]` becomes `hdr::Hdr`; this site goes around it
+warning: `[u8; 4]` is reinterpreted as `hdr::Hdr` by a pointer cast here, going around `Hdr::from`, which is where the crate says how `&[u8; 4]` becomes `hdr::Hdr`
   --> $DIR/cast_bypasses_from.rs:259:16
    |
 LL |     unsafe { &*(b as *const [u8; 4] as *const Hdr) }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Hdr::from`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:134:9
    |
 LL |         fn from(b: &'a [u8; 4]) -> Hdr {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Hdr::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Hdr::from` so both sit beside the layout they depend on
 
-warning: `[u8]` is reinterpreted as `name::NameRef` by a pointer cast here, but `NameRef::new` converts `&[u8]` to `name::NameRef` and can refuse a value; this site accepts any bit pattern
+warning: `[u8]` is reinterpreted as `name::NameRef` by a pointer cast here, which accepts any bit pattern, including values `NameRef::new` (the crate's checked `&[u8]` to `name::NameRef` conversion) would refuse
   --> $DIR/cast_bypasses_from.rs:264:16
    |
 LL |     unsafe { &*(b as *const [u8] as *const NameRef) }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `NameRef::new`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:146:9
    |
 LL |         pub fn new(b: &[u8]) -> Option<&NameRef> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `NameRef::new` instead; if this path must skip it, add an explicitly unchecked constructor next to `NameRef::new` so both sit beside the layout they depend on
 
-warning: `&[u8]` is reinterpreted as `name::Str<'_>` by `mem::transmute` here, but `Str::new` converts `&[u8]` to `name::Str<'_>` and can refuse a value; this site accepts any bit pattern
+warning: `&[u8]` is reinterpreted as `name::Str<'_>` by `mem::transmute` here, which accepts any bit pattern, including values `Str::new` (the crate's checked `&[u8]` to `name::Str<'_>` conversion) would refuse
   --> $DIR/cast_bypasses_from.rs:269:14
    |
 LL |     unsafe { core::mem::transmute::<&[u8], Str<'_>>(b) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the conversion this site skips
+note: `Str::new`, the conversion this cast goes around
   --> $DIR/cast_bypasses_from.rs:160:9
    |
 LL |         pub fn new(b: &[u8]) -> Option<Str<'_>> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: convert through that function, or put an unchecked constructor beside it so both sit with the layout they depend on
+   = help: call `Str::new` instead; if this path must skip it, add an explicitly unchecked constructor next to `Str::new` so both sit beside the layout they depend on
 
-warning: `gate::Gate` is produced by `mem::transmute` here, but `Gate::new` checks `v` before constructing one
+warning: `gate::Gate` is produced with `mem::transmute` here, skipping the check on `v` that `Gate::new` makes before it will construct one
   --> $DIR/cast_bypasses_from.rs:274:14
    |
 LL |     unsafe { core::mem::transmute::<u8, Gate>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this value never went through
+note: the check in `Gate::new` that this value never went through
   --> $DIR/cast_bypasses_from.rs:176:16
    |
 LL |             if v < 2 { Some(Gate { v }) } else { None }
    |                ^^^^^
-   = help: construct through the validating function
+   = help: construct it with `Gate::new(..)`, or add an explicitly unchecked constructor beside `Gate::new` and call that, so the bypass is visible where the check lives
    = note: `#[warn(unchecked_construction)]` on by default
 
 warning: 15 warnings emitted

--- a/ui/cast_bypasses_from.stderr
+++ b/ui/cast_bypasses_from.stderr
@@ -1,198 +1,198 @@
-warning: `u8` is reinterpreted as `level::Level` by `mem::transmute` here, which accepts any bit pattern, including values `Level::try_from` (the crate's checked `u8` to `level::Level` conversion) would refuse
+warning: `mem::transmute` turns `u8` into `level::Level` here and accepts any bit pattern. `Level::try_from` is the checked conversion from `u8` and would reject some of them
   --> $DIR/cast_bypasses_from.rs:195:14
    |
 LL |     unsafe { core::mem::transmute::<u8, Level>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Level::try_from`, the conversion this cast goes around
+note: `Level::try_from`, the checked conversion
   --> $DIR/cast_bypasses_from.rs:16:9
    |
 LL |         fn try_from(n: u8) -> Result<Self, u8> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Level::try_from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Level::try_from` so both sit beside the layout they depend on
+   = help: call `Level::try_from` instead. If this path must skip the check, add an unchecked constructor next to it so both live beside the layout
    = note: `#[warn(cast_bypasses_from)]` on by default
 
-warning: `u16` is reinterpreted as `code::Code` by `mem::transmute` here, which accepts any bit pattern, including values `Code::from_raw` (the crate's checked `u32` to `code::Code` conversion) would refuse
+warning: `mem::transmute` turns `u16` into `code::Code` here and accepts any bit pattern. `Code::from_raw` is the checked conversion from `u32` and would reject some of them
   --> $DIR/cast_bypasses_from.rs:200:14
    |
 LL |     unsafe { core::mem::transmute::<u16, Code>(n as u16) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Code::from_raw`, the conversion this cast goes around
+note: `Code::from_raw`, the checked conversion
   --> $DIR/cast_bypasses_from.rs:41:9
    |
 LL |         pub fn from_raw(n: u32) -> Option<Code> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Code::from_raw` instead; if this path must skip it, add an explicitly unchecked constructor next to `Code::from_raw` so both sit beside the layout they depend on
+   = help: call `Code::from_raw` instead. If this path must skip the check, add an unchecked constructor next to it so both live beside the layout
 
-warning: `u16` is reinterpreted as `code::Code` by `mem::transmute_copy` here, which accepts any bit pattern, including values `Code::from_raw` (the crate's checked `u32` to `code::Code` conversion) would refuse
+warning: `mem::transmute_copy` turns `u16` into `code::Code` here and accepts any bit pattern. `Code::from_raw` is the checked conversion from `u32` and would reject some of them
   --> $DIR/cast_bypasses_from.rs:205:14
    |
 LL |     unsafe { core::mem::transmute_copy::<u16, Code>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Code::from_raw`, the conversion this cast goes around
+note: `Code::from_raw`, the checked conversion
   --> $DIR/cast_bypasses_from.rs:41:9
    |
 LL |         pub fn from_raw(n: u32) -> Option<Code> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Code::from_raw` instead; if this path must skip it, add an explicitly unchecked constructor next to `Code::from_raw` so both sit beside the layout they depend on
+   = help: call `Code::from_raw` instead. If this path must skip the check, add an unchecked constructor next to it so both live beside the layout
 
-warning: `i32` is reinterpreted as `fd::Fd` by `mem::transmute` here, going around `Fd::new`, which is where the crate says how `i32` becomes `fd::Fd`
+warning: `mem::transmute` turns `i32` into `fd::Fd` here and accepts any bit pattern. `Fd::new` is where the crate says how `i32` becomes `fd::Fd`
   --> $DIR/cast_bypasses_from.rs:210:14
    |
 LL |     unsafe { core::mem::transmute::<i32, Fd>(raw) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Fd::new`, the conversion this cast goes around
+note: `Fd::new`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:57:9
    |
 LL |         pub fn new(raw: i32) -> Fd {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Fd::new` instead; if this path must skip it, add an explicitly unchecked constructor next to `Fd::new` so both sit beside the layout they depend on
+   = help: call `Fd::new` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
+warning: a pointer cast turns `u32` into `meters::Meters` here and accepts any bit pattern. `Meters::from` is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:215:15
    |
 LL |     unsafe { *(n as *const u32 as *const Meters) }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Meters::from`, the conversion this cast goes around
+note: `Meters::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
+   = help: call `Meters::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
+warning: a pointer cast turns `u32` into `meters::Meters` here and accepts any bit pattern. `Meters::from` is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:220:14
    |
 LL |     unsafe { p.cast::<Meters>().read() }
    |              ^^^^^^^^^^^^^^^^^^
    |
-note: `Meters::from`, the conversion this cast goes around
+note: `Meters::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
+   = help: call `Meters::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `u32` is reinterpreted as `meters::Meters` by `mem::transmute` here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
+warning: `mem::transmute` turns `u32` into `meters::Meters` here and accepts any bit pattern. `Meters::from` is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:225:14
    |
 LL |     unsafe { core::mem::transmute::<&u32, &Meters>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Meters::from`, the conversion this cast goes around
+note: `Meters::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
+   = help: call `Meters::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `u32` is reinterpreted as `meters::Meters` by `mem::transmute` here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
+warning: `mem::transmute` turns `u32` into `meters::Meters` here and accepts any bit pattern. `Meters::from` is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:230:14
    |
 LL |     unsafe { core::mem::transmute::<&u32, &Meters>(v) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Meters::from`, the conversion this cast goes around
+note: `Meters::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
+   = help: call `Meters::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `u32` is reinterpreted as `meters::Meters` by a pointer cast here, going around `Meters::from`, which is where the crate says how `u32` becomes `meters::Meters`
+warning: a pointer cast turns `u32` into `meters::Meters` here and accepts any bit pattern. `Meters::from` is where the crate says how `u32` becomes `meters::Meters`
   --> $DIR/cast_bypasses_from.rs:237:25
    |
 LL |         sum += unsafe { p.cast::<Meters>().read() }.0;
    |                         ^^^^^^^^^^^^^^^^^^
    |
-note: `Meters::from`, the conversion this cast goes around
+note: `Meters::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:74:9
    |
 LL |         fn from(n: u32) -> Meters {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Meters::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Meters::from` so both sit beside the layout they depend on
+   = help: call `Meters::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `f32` is reinterpreted as `px::Px<px::Screen>` by `mem::transmute` here, going around `Px::from`, which is where the crate says how `f32` becomes `px::Px<px::Screen>`
+warning: `mem::transmute` turns `f32` into `px::Px<px::Screen>` here and accepts any bit pattern. `Px::from` is where the crate says how `f32` becomes `px::Px<px::Screen>`
   --> $DIR/cast_bypasses_from.rs:244:14
    |
 LL |     unsafe { core::mem::transmute::<f32, Px<Screen>>(v) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Px::from`, the conversion this cast goes around
+note: `Px::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:122:9
    |
 LL |         fn from(v: f32) -> Px<Screen> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Px::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Px::from` so both sit beside the layout they depend on
+   = help: call `Px::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `[u8; 4]` is reinterpreted as `hdr::Hdr` by `mem::transmute` here, going around `Hdr::from`, which is where the crate says how `&[u8; 4]` becomes `hdr::Hdr`
+warning: `mem::transmute` turns `[u8; 4]` into `hdr::Hdr` here and accepts any bit pattern. `Hdr::from` is where the crate says how `&[u8; 4]` becomes `hdr::Hdr`
   --> $DIR/cast_bypasses_from.rs:254:14
    |
 LL |     unsafe { core::mem::transmute::<[u8; 4], Hdr>(*b) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Hdr::from`, the conversion this cast goes around
+note: `Hdr::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:134:9
    |
 LL |         fn from(b: &'a [u8; 4]) -> Hdr {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Hdr::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Hdr::from` so both sit beside the layout they depend on
+   = help: call `Hdr::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `[u8; 4]` is reinterpreted as `hdr::Hdr` by a pointer cast here, going around `Hdr::from`, which is where the crate says how `&[u8; 4]` becomes `hdr::Hdr`
+warning: a pointer cast turns `[u8; 4]` into `hdr::Hdr` here and accepts any bit pattern. `Hdr::from` is where the crate says how `&[u8; 4]` becomes `hdr::Hdr`
   --> $DIR/cast_bypasses_from.rs:259:16
    |
 LL |     unsafe { &*(b as *const [u8; 4] as *const Hdr) }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Hdr::from`, the conversion this cast goes around
+note: `Hdr::from`, the conversion this skips
   --> $DIR/cast_bypasses_from.rs:134:9
    |
 LL |         fn from(b: &'a [u8; 4]) -> Hdr {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Hdr::from` instead; if this path must skip it, add an explicitly unchecked constructor next to `Hdr::from` so both sit beside the layout they depend on
+   = help: call `Hdr::from` instead. If this path must skip it, add an unchecked constructor next to it so both live beside the layout
 
-warning: `[u8]` is reinterpreted as `name::NameRef` by a pointer cast here, which accepts any bit pattern, including values `NameRef::new` (the crate's checked `&[u8]` to `name::NameRef` conversion) would refuse
+warning: a pointer cast turns `[u8]` into `name::NameRef` here and accepts any bit pattern. `NameRef::new` is the checked conversion from `&[u8]` and would reject some of them
   --> $DIR/cast_bypasses_from.rs:264:16
    |
 LL |     unsafe { &*(b as *const [u8] as *const NameRef) }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `NameRef::new`, the conversion this cast goes around
+note: `NameRef::new`, the checked conversion
   --> $DIR/cast_bypasses_from.rs:146:9
    |
 LL |         pub fn new(b: &[u8]) -> Option<&NameRef> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `NameRef::new` instead; if this path must skip it, add an explicitly unchecked constructor next to `NameRef::new` so both sit beside the layout they depend on
+   = help: call `NameRef::new` instead. If this path must skip the check, add an unchecked constructor next to it so both live beside the layout
 
-warning: `&[u8]` is reinterpreted as `name::Str<'_>` by `mem::transmute` here, which accepts any bit pattern, including values `Str::new` (the crate's checked `&[u8]` to `name::Str<'_>` conversion) would refuse
+warning: `mem::transmute` turns `&[u8]` into `name::Str<'_>` here and accepts any bit pattern. `Str::new` is the checked conversion from `&[u8]` and would reject some of them
   --> $DIR/cast_bypasses_from.rs:269:14
    |
 LL |     unsafe { core::mem::transmute::<&[u8], Str<'_>>(b) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `Str::new`, the conversion this cast goes around
+note: `Str::new`, the checked conversion
   --> $DIR/cast_bypasses_from.rs:160:9
    |
 LL |         pub fn new(b: &[u8]) -> Option<Str<'_>> {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: call `Str::new` instead; if this path must skip it, add an explicitly unchecked constructor next to `Str::new` so both sit beside the layout they depend on
+   = help: call `Str::new` instead. If this path must skip the check, add an unchecked constructor next to it so both live beside the layout
 
-warning: `gate::Gate` is produced with `mem::transmute` here, skipping the check on `v` that `Gate::new` makes before it will construct one
+warning: `gate::Gate` is produced with `mem::transmute` here, skipping the check on `v` that `Gate::new` makes
   --> $DIR/cast_bypasses_from.rs:274:14
    |
 LL |     unsafe { core::mem::transmute::<u8, Gate>(n) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Gate::new` that this value never went through
+note: the check in `Gate::new`
   --> $DIR/cast_bypasses_from.rs:176:16
    |
 LL |             if v < 2 { Some(Gate { v }) } else { None }
    |                ^^^^^
-   = help: construct it with `Gate::new(..)`, or add an explicitly unchecked constructor beside `Gate::new` and call that, so the bypass is visible where the check lives
+   = help: b$DIRld it with `Gate::new(..)`. If this path must skip the check, add an unchecked constructor next to `Gate::new` and call that
    = note: `#[warn(unchecked_construction)]` on by default
 
 warning: 15 warnings emitted

--- a/ui/defaulted_failure.stderr
+++ b/ui/defaulted_failure.stderr
@@ -1,109 +1,109 @@
-warning: `parse_port` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+warning: `parse_port` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:156:5
    |
 LL |     parse_port(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
    = note: `#[warn(defaulted_failure)]` on by default
 
-warning: `parse_port` rejects some of what it is handed, and `unwrap_or_default` carries on with a fixed value in place of the rejection
+warning: `parse_port` can reject its input, and `.unwrap_or_default` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:160:5
    |
 LL |     parse_port(s).unwrap_or_default()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `parse_port` rejects some of what it is handed, and `unwrap_or_else` carries on with a fixed value in place of the rejection
+warning: `parse_port` can reject its input, and `.unwrap_or_else` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:164:5
    |
 LL |     parse_port(s).unwrap_or_else(|_| u16::MAX)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `parse_port` rejects some of what it is handed, and `unwrap_or_else` carries on with a fixed value in place of the rejection
+warning: `parse_port` can reject its input, and `.unwrap_or_else` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:168:5
    |
 LL |     parse_port(s).unwrap_or_else(|_| Default::default())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `parse_port` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+warning: `parse_port` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:172:5
    |
 LL |     parse_port(s).ok().unwrap_or(80)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `Header::is_open` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+warning: `Header::is_open` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `Header::is_open` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:176:5
    |
 LL |     h.is_open(s).unwrap_or(true)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `Header::is_open` whose failure is replaced
   --> $DIR/defaulted_failure.rs:71:12
    |
 LL |         if s.is_empty() {
    |            ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `Header::is_open`'s reason is still attached
 
-warning: `parse_pair` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+warning: `parse_pair` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `parse_pair` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:180:5
    |
 LL |     parse_pair(s).unwrap_or((0, 0))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_pair` whose failure is replaced
   --> $DIR/defaulted_failure.rs:41:18
    |
 LL |     let (a, b) = s.split_once(':').ok_or(ParseError::Empty)?;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_pair`'s reason is still attached
 
-warning: `Header::parse_limit` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+warning: `Header::parse_limit` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `Header::parse_limit` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:184:5
    |
 LL |     h.parse_limit(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `Header::parse_limit` whose failure is replaced
   --> $DIR/defaulted_failure.rs:54:12
    |
 LL |         if n > self.limit {
    |            ^^^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `Header::parse_limit`'s reason is still attached
 
-warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
   --> $DIR/defaulted_failure.rs:188:5
    |
 LL | /     let Ok(port) = parse_port(s) else {
@@ -111,27 +111,27 @@ LL | |         return Ok(());
 LL | |     };
    | |______^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
   --> $DIR/defaulted_failure.rs:196:5
    |
 LL |     let Ok(port) = parse_port(s) else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
   --> $DIR/defaulted_failure.rs:201:5
    |
 LL | /     let Some(port) = parse_port(s).ok() else {
@@ -139,94 +139,94 @@ LL | |         return Ok(());
 LL | |     };
    | |______^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `parse_port` rejects some of what it is handed, and the `else` returns success in place of the rejection
+warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
   --> $DIR/defaulted_failure.rs:209:5
    |
 LL |     let Some(port) = parse_port(s).ok() else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `parse_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
 
-warning: `Header::send_checked` rejects some of what it is handed, and `unwrap_or` carries on with a fixed value in place of the rejection
+warning: `Header::send_checked` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `Header::send_checked` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:214:5
    |
 LL |     h.send_checked(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `Header::send_checked` whose failure is replaced
   --> $DIR/defaulted_failure.rs:93:16
    |
 LL |             if s.is_empty() {
    |                ^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `Header::send_checked`'s reason is still attached
 
-warning: `check_port` rejects some of what it is handed, and `unwrap_or_default` carries on with a fixed value in place of the rejection
+warning: `check_port` can reject its input, and `.unwrap_or_default` here swaps that rejection for a fixed value, so input `check_port` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:218:5
    |
 LL |     check_port(s).unwrap_or_default()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check whose failure is replaced
+note: the check in `check_port` whose failure is replaced
   --> $DIR/defaulted_failure.rs:103:5
    |
 LL |     parse_port(s)?;
    |     ^^^^^^^^^^^^^^
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `check_port`'s reason is still attached
 
-warning: `listed_by_config` is listed in `defaulted-failure-callees`, and `unwrap_or` carries on with a fixed value in place of its failure
+warning: `listed_by_config` is listed in `defaulted-failure-callees` as able to reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `listed_by_config` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:222:5
    |
 LL |     listed_by_config(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `listed_by_config`'s reason is still attached
 
-warning: `core::num::<impl u32>::from_str_radix` is listed in `defaulted-failure-callees`, and `unwrap_or` carries on with a fixed value in place of its failure
+warning: `core::num::<impl u32>::from_str_radix` is listed in `defaulted-failure-callees` as able to reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `core::num::<impl u32>::from_str_radix` refused is processed as if it had passed
   --> $DIR/defaulted_failure.rs:226:5
    |
 LL |     u32::from_str_radix(s, 16).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: propagate the failure, or handle the failing arm where its cause is still visible
+   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `core::num::<impl u32>::from_str_radix`'s reason is still attached
 
-warning: `let_else_reporting_failure_is_fine` reports `ParseError` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `let_else_reporting_failure_is_fine` turns its `ParseError` into `false`, and this call ignores the `false`, so a failure inside `let_else_reporting_failure_is_fine` is silently treated as success
   --> $DIR/defaulted_failure.rs:393:13
    |
 LL |     let _ = let_else_reporting_failure_is_fine("a", &mut ports);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/defaulted_failure.rs:328:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `let_else_reporting_failure_is_fine` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
    = note: `#[warn(error_collapsed_to_bool)]` on by default
 
-warning: `let_else_returning_none_is_fine` reports `ParseError` only as `None`, and this call drops the `None`: the failure can no longer be observed anywhere
+warning: `let_else_returning_none_is_fine` turns its `ParseError` into `None`, and this call ignores the `None`, so a failure inside `let_else_returning_none_is_fine` is silently treated as success
   --> $DIR/defaulted_failure.rs:394:13
    |
 LL |     let _ = let_else_returning_none_is_fine("a");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the error becomes `None` here, and nothing else is done with it
+note: the error becomes `None` here
   --> $DIR/defaulted_failure.rs:336:9
    |
 LL |         return None;
    |         ^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `let_else_returning_none_is_fine` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
 warning: 18 warnings emitted
 

--- a/ui/defaulted_failure.stderr
+++ b/ui/defaulted_failure.stderr
@@ -1,109 +1,109 @@
-warning: `parse_port` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
+warning: `parse_port` can reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:156:5
    |
 LL |     parse_port(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
    = note: `#[warn(defaulted_failure)]` on by default
 
-warning: `parse_port` can reject its input, and `.unwrap_or_default` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
+warning: `parse_port` can reject its input, and `.unwrap_or_default` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:160:5
    |
 LL |     parse_port(s).unwrap_or_default()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_port` can reject its input, and `.unwrap_or_else` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
+warning: `parse_port` can reject its input, and `.unwrap_or_else` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:164:5
    |
 LL |     parse_port(s).unwrap_or_else(|_| u16::MAX)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_port` can reject its input, and `.unwrap_or_else` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
+warning: `parse_port` can reject its input, and `.unwrap_or_else` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:168:5
    |
 LL |     parse_port(s).unwrap_or_else(|_| Default::default())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_port` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `parse_port` refused is processed as if it had passed
+warning: `parse_port` can reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:172:5
    |
 LL |     parse_port(s).ok().unwrap_or(80)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `Header::is_open` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `Header::is_open` refused is processed as if it had passed
+warning: `Header::is_open` can reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:176:5
    |
 LL |     h.is_open(s).unwrap_or(true)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Header::is_open` whose failure is replaced
+note: the check in `Header::is_open` that gets overridden
   --> $DIR/defaulted_failure.rs:71:12
    |
 LL |         if s.is_empty() {
    |            ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `Header::is_open`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_pair` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `parse_pair` refused is processed as if it had passed
+warning: `parse_pair` can reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:180:5
    |
 LL |     parse_pair(s).unwrap_or((0, 0))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_pair` whose failure is replaced
+note: the check in `parse_pair` that gets overridden
   --> $DIR/defaulted_failure.rs:41:18
    |
 LL |     let (a, b) = s.split_once(':').ok_or(ParseError::Empty)?;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_pair`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `Header::parse_limit` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `Header::parse_limit` refused is processed as if it had passed
+warning: `Header::parse_limit` can reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:184:5
    |
 LL |     h.parse_limit(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Header::parse_limit` whose failure is replaced
+note: the check in `Header::parse_limit` that gets overridden
   --> $DIR/defaulted_failure.rs:54:12
    |
 LL |         if n > self.limit {
    |            ^^^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `Header::parse_limit`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
+warning: `parse_port` can reject its input, and the `else` here returns success when that happens. Rejected input is reported as handled
   --> $DIR/defaulted_failure.rs:188:5
    |
 LL | /     let Ok(port) = parse_port(s) else {
@@ -111,27 +111,27 @@ LL | |         return Ok(());
 LL | |     };
    | |______^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
+warning: `parse_port` can reject its input, and the `else` here returns success when that happens. Rejected input is reported as handled
   --> $DIR/defaulted_failure.rs:196:5
    |
 LL |     let Ok(port) = parse_port(s) else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
+warning: `parse_port` can reject its input, and the `else` here returns success when that happens. Rejected input is reported as handled
   --> $DIR/defaulted_failure.rs:201:5
    |
 LL | /     let Some(port) = parse_port(s).ok() else {
@@ -139,69 +139,69 @@ LL | |         return Ok(());
 LL | |     };
    | |______^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `parse_port` can reject its input, and the `else` here returns success when it does, so input `parse_port` refused is reported as handled
+warning: `parse_port` can reject its input, and the `else` here returns success when that happens. Rejected input is reported as handled
   --> $DIR/defaulted_failure.rs:209:5
    |
 LL |     let Some(port) = parse_port(s).ok() else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `parse_port` whose failure is replaced
+note: the check in `parse_port` that gets overridden
   --> $DIR/defaulted_failure.rs:20:8
    |
 LL |     if s.is_empty() {
    |        ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `parse_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `Header::send_checked` can reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `Header::send_checked` refused is processed as if it had passed
+warning: `Header::send_checked` can reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:214:5
    |
 LL |     h.send_checked(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Header::send_checked` whose failure is replaced
+note: the check in `Header::send_checked` that gets overridden
   --> $DIR/defaulted_failure.rs:93:16
    |
 LL |             if s.is_empty() {
    |                ^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `Header::send_checked`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `check_port` can reject its input, and `.unwrap_or_default` here swaps that rejection for a fixed value, so input `check_port` refused is processed as if it had passed
+warning: `check_port` can reject its input, and `.unwrap_or_default` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:218:5
    |
 LL |     check_port(s).unwrap_or_default()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `check_port` whose failure is replaced
+note: the check in `check_port` that gets overridden
   --> $DIR/defaulted_failure.rs:103:5
    |
 LL |     parse_port(s)?;
    |     ^^^^^^^^^^^^^^
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `check_port`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `listed_by_config` is listed in `defaulted-failure-callees` as able to reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `listed_by_config` refused is processed as if it had passed
+warning: `listed_by_config` is listed in `defaulted-failure-callees` as able to reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:222:5
    |
 LL |     listed_by_config(s).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `listed_by_config`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `core::num::<impl u32>::from_str_radix` is listed in `defaulted-failure-callees` as able to reject its input, and `.unwrap_or` here swaps that rejection for a fixed value, so input `core::num::<impl u32>::from_str_radix` refused is processed as if it had passed
+warning: `core::num::<impl u32>::from_str_radix` is listed in `defaulted-failure-callees` as able to reject its input, and `.unwrap_or` here replaces the rejection with a fixed value. Rejected input carries on as if it were fine
   --> $DIR/defaulted_failure.rs:226:5
    |
 LL |     u32::from_str_radix(s, 16).unwrap_or(0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: propagate the error with `?` or `return Err(..)`, or match on it here while `core::num::<impl u32>::from_str_radix`'s reason is still attached
+   = help: pass the error on with `?`, or match on it here while the reason is still attached
 
-warning: `let_else_reporting_failure_is_fine` turns its `ParseError` into `false`, and this call ignores the `false`, so a failure inside `let_else_reporting_failure_is_fine` is silently treated as success
+warning: `let_else_reporting_failure_is_fine` turns its `ParseError` into `false`, and this call ignores the `false`. A failure inside `let_else_reporting_failure_is_fine` is treated as success
   --> $DIR/defaulted_failure.rs:393:13
    |
 LL |     let _ = let_else_reporting_failure_is_fine("a", &mut ports);
@@ -212,10 +212,10 @@ note: the error becomes `false` here
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
-   = help: make `let_else_reporting_failure_is_fine` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `let_else_reporting_failure_is_fine` and decide here what failure means. At minimum mark it `#[must_use]`
    = note: `#[warn(error_collapsed_to_bool)]` on by default
 
-warning: `let_else_returning_none_is_fine` turns its `ParseError` into `None`, and this call ignores the `None`, so a failure inside `let_else_returning_none_is_fine` is silently treated as success
+warning: `let_else_returning_none_is_fine` turns its `ParseError` into `None`, and this call ignores the `None`. A failure inside `let_else_returning_none_is_fine` is treated as success
   --> $DIR/defaulted_failure.rs:394:13
    |
 LL |     let _ = let_else_returning_none_is_fine("a");
@@ -226,7 +226,7 @@ note: the error becomes `None` here
    |
 LL |         return None;
    |         ^^^^^^^^^^^
-   = help: make `let_else_returning_none_is_fine` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `let_else_returning_none_is_fine` and decide here what failure means. At minimum mark it `#[must_use]`
 
 warning: 18 warnings emitted
 

--- a/ui/derived_field.stderr
+++ b/ui/derived_field.stderr
@@ -1,10 +1,10 @@
-warning: `limit` is always the same value for a given `ceiling` in all 3 places `Exceeded` is constructed, so it is a copy of something `ceiling` already decides
+warning: `limit` always has the same value for a given `ceiling`, in all 3 places `Exceeded` is b$DIRlt. It is a stored copy of something `ceiling` decides
   --> $DIR/derived_field.rs:15:1
    |
 LL | pub struct Exceeded {
    | ^^^^^^^^^^^^^^^^^^^
    |
-note: one of the constructions that pairs them
+note: one of the constructions
   --> $DIR/derived_field.rs:22:5
    |
 LL | /     Exceeded {
@@ -13,16 +13,16 @@ LL | |         limit: MAX_WORDS,
 LL | |         wanted,
 LL | |     }
    | |_____^
-   = help: give `Ceiling` a `fn limit(&self)` and delete the `limit` field; then a mismatched pair cannot be written
+   = help: add `fn limit(&self)` to `Ceiling` and delete the `limit` field
    = note: `#[warn(derived_field)]` on by default
 
-warning: `remaining` is always the same value for a given `header` in all 2 places `Entries` is constructed, so it is a copy of something `header` already decides
+warning: `remaining` always has the same value for a given `header`, in all 2 places `Entries` is b$DIRlt. It is a stored copy of something `header` decides
   --> $DIR/derived_field.rs:56:1
    |
 LL | pub struct Entries<'a> {
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the constructions that pairs them
+note: one of the constructions
   --> $DIR/derived_field.rs:63:5
    |
 LL | /     Entries {
@@ -31,7 +31,7 @@ LL | |         header: Header::Narrow,
 LL | |         remaining: None,
 LL | |     }
    | |_____^
-   = help: give `Header` a `fn remaining(&self)` and delete the `remaining` field; then a mismatched pair cannot be written
+   = help: add `fn remaining(&self)` to `Header` and delete the `remaining` field
 
 warning: 2 warnings emitted
 

--- a/ui/derived_field.stderr
+++ b/ui/derived_field.stderr
@@ -1,19 +1,37 @@
-warning: `ceiling` and `limit` of `Exceeded` agree one-for-one across all 3 places it is constructed, so one is a stored projection of the other
+warning: `limit` is always the same value for a given `ceiling` in all 3 places `Exceeded` is constructed, so it is a copy of something `ceiling` already decides
   --> $DIR/derived_field.rs:15:1
    |
 LL | pub struct Exceeded {
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: give the deciding field a method returning the other and drop the stored copy, so a pairing the constructors never make cannot be written
+note: one of the constructions that pairs them
+  --> $DIR/derived_field.rs:22:5
+   |
+LL | /     Exceeded {
+LL | |         ceiling: Ceiling::Words,
+LL | |         limit: MAX_WORDS,
+LL | |         wanted,
+LL | |     }
+   | |_____^
+   = help: give `Ceiling` a `fn limit(&self)` and delete the `limit` field; then a mismatched pair cannot be written
    = note: `#[warn(derived_field)]` on by default
 
-warning: `header` and `remaining` of `Entries` agree one-for-one across all 2 places it is constructed, so one is a stored projection of the other
+warning: `remaining` is always the same value for a given `header` in all 2 places `Entries` is constructed, so it is a copy of something `header` already decides
   --> $DIR/derived_field.rs:56:1
    |
 LL | pub struct Entries<'a> {
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: give the deciding field a method returning the other and drop the stored copy, so a pairing the constructors never make cannot be written
+note: one of the constructions that pairs them
+  --> $DIR/derived_field.rs:63:5
+   |
+LL | /     Entries {
+LL | |         buf,
+LL | |         header: Header::Narrow,
+LL | |         remaining: None,
+LL | |     }
+   | |_____^
+   = help: give `Header` a `fn remaining(&self)` and delete the `remaining` field; then a mismatched pair cannot be written
 
 warning: 2 warnings emitted
 

--- a/ui/discarded_error.stderr
+++ b/ui/discarded_error.stderr
@@ -1,10 +1,10 @@
-warning: `.ok()` in statement position discards the error unobserved
+warning: `.ok();` turns this `Result` into an `Option` and drops it on the spot, so its `u32` error is thrown away by something that reads like handling
   --> $DIR/discarded_error.rs:8:5
    |
 LL |     fallible().ok();
    |     ^^^^^^^^^^^^^^^
    |
-   = help: handle the error, or state the discard with `let _ = ...`
+   = help: handle the `Err` or propagate it with `?`; if dropping it is intended, write `let _ = ...;` so the discard is stated
    = note: `#[warn(discarded_error)]` on by default
 
 warning: 1 warning emitted

--- a/ui/discarded_error.stderr
+++ b/ui/discarded_error.stderr
@@ -1,10 +1,10 @@
-warning: `.ok();` turns this `Result` into an `Option` and drops it on the spot, so its `u32` error is thrown away by something that reads like handling
+warning: `.ok();` converts this `Result` to an `Option` and drops it, so the `u32` error disappears in a line that looks like handling
   --> $DIR/discarded_error.rs:8:5
    |
 LL |     fallible().ok();
    |     ^^^^^^^^^^^^^^^
    |
-   = help: handle the `Err` or propagate it with `?`; if dropping it is intended, write `let _ = ...;` so the discard is stated
+   = help: handle the `Err` or pass it on with `?`. If dropping it is intended, write `let _ = ...;` to say so
    = note: `#[warn(discarded_error)]` on by default
 
 warning: 1 warning emitted

--- a/ui/error_collapsed_to_bool.stderr
+++ b/ui/error_collapsed_to_bool.stderr
@@ -1,120 +1,120 @@
-warning: `write_pidfile` reports `SysError` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `write_pidfile` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `write_pidfile` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:23:5
    |
 LL |     write_pidfile(buf);
    |     ^^^^^^^^^^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/error_collapsed_to_bool.rs:17:9
    |
 LL |         Err(_) => false,
    |         ^^^^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `write_pidfile` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
    = note: `#[warn(error_collapsed_to_bool)]` on by default
 
-warning: `write_pidfile` reports `SysError` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `write_pidfile` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `write_pidfile` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:28:13
    |
 LL |     let _ = write_pidfile(buf);
    |             ^^^^^^^^^^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/error_collapsed_to_bool.rs:17:9
    |
 LL |         Err(_) => false,
    |         ^^^^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `write_pidfile` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
-warning: `set_mode` reports `SysError` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `set_mode` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `set_mode` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:43:13
    |
 LL |     let _ = set_mode(buf);
    |             ^^^^^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/error_collapsed_to_bool.rs:38:5
    |
 LL |     sys_write(buf, b"m").is_ok()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `set_mode` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
-warning: `sync_dir` reports `SysError` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `sync_dir` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `sync_dir` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:58:5
    |
 LL |     sync_dir(buf);
    |     ^^^^^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/error_collapsed_to_bool.rs:50:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `sync_dir` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
-warning: `reserve` reports `SysError` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `reserve` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `reserve` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:71:13
    |
 LL |     let _ = reserve(buf);
    |             ^^^^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/error_collapsed_to_bool.rs:64:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `reserve` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
-warning: `open_slot` reports `SysError` only as `None`, and this call drops the `None`: the failure can no longer be observed anywhere
+warning: `open_slot` turns its `SysError` into `None`, and this call ignores the `None`, so a failure inside `open_slot` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:82:5
    |
 LL |     open_slot(buf);
    |     ^^^^^^^^^^^^^^
    |
-note: the error becomes `None` here, and nothing else is done with it
+note: the error becomes `None` here
   --> $DIR/error_collapsed_to_bool.rs:76:13
    |
 LL |     let n = sys_write(buf, b"o").ok()?;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `open_slot` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
-warning: `probe_slot` reports `SysError` only as `None`, and this call drops the `None`: the failure can no longer be observed anywhere
+warning: `probe_slot` turns its `SysError` into `None`, and this call ignores the `None`, so a failure inside `probe_slot` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:112:5
    |
 LL |     probe_slot(buf);
    |     ^^^^^^^^^^^^^^^
    |
-note: the error becomes `None` here, and nothing else is done with it
+note: the error becomes `None` here
   --> $DIR/error_collapsed_to_bool.rs:106:9
    |
 LL |         None
    |         ^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `probe_slot` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
-warning: `fill` reports `SysError` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `fill` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `fill` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:179:5
    |
 LL |     fill(buf);
    |     ^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/error_collapsed_to_bool.rs:168:13
    |
 LL |             return false;
    |             ^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `fill` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
-warning: `is_digit` reports `&str` only as `false`, and this call drops the `false`: the failure can no longer be observed anywhere
+warning: `is_digit` turns its `&str` into `false`, and this call ignores the `false`, so a failure inside `is_digit` is silently treated as success
   --> $DIR/error_collapsed_to_bool.rs:197:13
    |
 LL |     let _ = is_digit("x");
    |             ^^^^^^^^^^^^^
    |
-note: the error becomes `false` here, and nothing else is done with it
+note: the error becomes `false` here
   --> $DIR/error_collapsed_to_bool.rs:192:5
    |
 LL |     parse_digit(s).is_ok()
    |     ^^^^^^^^^^^^^^^^^^^^^^
-   = help: return the `Result` and let this caller decide; failing that, `#[must_use]`
+   = help: make `is_digit` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
 
 warning: 9 warnings emitted
 

--- a/ui/error_collapsed_to_bool.stderr
+++ b/ui/error_collapsed_to_bool.stderr
@@ -1,4 +1,4 @@
-warning: `write_pidfile` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `write_pidfile` is silently treated as success
+warning: `write_pidfile` turns its `SysError` into `false`, and this call ignores the `false`. A failure inside `write_pidfile` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:23:5
    |
 LL |     write_pidfile(buf);
@@ -9,10 +9,10 @@ note: the error becomes `false` here
    |
 LL |         Err(_) => false,
    |         ^^^^^^^^^^^^^^^
-   = help: make `write_pidfile` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `write_pidfile` and decide here what failure means. At minimum mark it `#[must_use]`
    = note: `#[warn(error_collapsed_to_bool)]` on by default
 
-warning: `write_pidfile` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `write_pidfile` is silently treated as success
+warning: `write_pidfile` turns its `SysError` into `false`, and this call ignores the `false`. A failure inside `write_pidfile` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:28:13
    |
 LL |     let _ = write_pidfile(buf);
@@ -23,9 +23,9 @@ note: the error becomes `false` here
    |
 LL |         Err(_) => false,
    |         ^^^^^^^^^^^^^^^
-   = help: make `write_pidfile` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `write_pidfile` and decide here what failure means. At minimum mark it `#[must_use]`
 
-warning: `set_mode` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `set_mode` is silently treated as success
+warning: `set_mode` turns its `SysError` into `false`, and this call ignores the `false`. A failure inside `set_mode` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:43:13
    |
 LL |     let _ = set_mode(buf);
@@ -36,9 +36,9 @@ note: the error becomes `false` here
    |
 LL |     sys_write(buf, b"m").is_ok()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: make `set_mode` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `set_mode` and decide here what failure means. At minimum mark it `#[must_use]`
 
-warning: `sync_dir` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `sync_dir` is silently treated as success
+warning: `sync_dir` turns its `SysError` into `false`, and this call ignores the `false`. A failure inside `sync_dir` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:58:5
    |
 LL |     sync_dir(buf);
@@ -49,9 +49,9 @@ note: the error becomes `false` here
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
-   = help: make `sync_dir` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `sync_dir` and decide here what failure means. At minimum mark it `#[must_use]`
 
-warning: `reserve` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `reserve` is silently treated as success
+warning: `reserve` turns its `SysError` into `false`, and this call ignores the `false`. A failure inside `reserve` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:71:13
    |
 LL |     let _ = reserve(buf);
@@ -62,9 +62,9 @@ note: the error becomes `false` here
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
-   = help: make `reserve` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `reserve` and decide here what failure means. At minimum mark it `#[must_use]`
 
-warning: `open_slot` turns its `SysError` into `None`, and this call ignores the `None`, so a failure inside `open_slot` is silently treated as success
+warning: `open_slot` turns its `SysError` into `None`, and this call ignores the `None`. A failure inside `open_slot` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:82:5
    |
 LL |     open_slot(buf);
@@ -75,9 +75,9 @@ note: the error becomes `None` here
    |
 LL |     let n = sys_write(buf, b"o").ok()?;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: make `open_slot` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `open_slot` and decide here what failure means. At minimum mark it `#[must_use]`
 
-warning: `probe_slot` turns its `SysError` into `None`, and this call ignores the `None`, so a failure inside `probe_slot` is silently treated as success
+warning: `probe_slot` turns its `SysError` into `None`, and this call ignores the `None`. A failure inside `probe_slot` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:112:5
    |
 LL |     probe_slot(buf);
@@ -88,9 +88,9 @@ note: the error becomes `None` here
    |
 LL |         None
    |         ^^^^
-   = help: make `probe_slot` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `probe_slot` and decide here what failure means. At minimum mark it `#[must_use]`
 
-warning: `fill` turns its `SysError` into `false`, and this call ignores the `false`, so a failure inside `fill` is silently treated as success
+warning: `fill` turns its `SysError` into `false`, and this call ignores the `false`. A failure inside `fill` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:179:5
    |
 LL |     fill(buf);
@@ -101,9 +101,9 @@ note: the error becomes `false` here
    |
 LL |             return false;
    |             ^^^^^^^^^^^^
-   = help: make `fill` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `fill` and decide here what failure means. At minimum mark it `#[must_use]`
 
-warning: `is_digit` turns its `&str` into `false`, and this call ignores the `false`, so a failure inside `is_digit` is silently treated as success
+warning: `is_digit` turns its `&str` into `false`, and this call ignores the `false`. A failure inside `is_digit` is treated as success
   --> $DIR/error_collapsed_to_bool.rs:197:13
    |
 LL |     let _ = is_digit("x");
@@ -114,7 +114,7 @@ note: the error becomes `false` here
    |
 LL |     parse_digit(s).is_ok()
    |     ^^^^^^^^^^^^^^^^^^^^^^
-   = help: make `is_digit` return the `Result` and decide here what a failure means; failing that, mark it `#[must_use]` so this call cannot drop the answer
+   = help: return the `Result` from `is_digit` and decide here what failure means. At minimum mark it `#[must_use]`
 
 warning: 9 warnings emitted
 

--- a/ui/field_valid_only_when.stderr
+++ b/ui/field_valid_only_when.stderr
@@ -1,35 +1,55 @@
-warning: `raw` is only read where `tag == Tag::Subproc` has been tested (3 reads), and every `Child` made with another `tag` fills it with a placeholder (1 site)
+warning: `raw` is read only after testing `tag == Tag::Subproc` (3 reads) and gets a placeholder wherever `Child` is constructed with another `tag` (1 site), so it only means something in that one case, yet the struct carries it in all of them
   --> $DIR/field_valid_only_when.rs:16:5
    |
 LL |     raw: *mut u8,
    |     ^^^^^^^^^^^^
    |
-   = help: the field is the payload of that one case, stored flat; an enum variant carrying it leaves the other cases nothing to fill in or misread
+note: one of the reads, under that test
+  --> $DIR/field_valid_only_when.rs:37:16
+   |
+LL |         return c.raw as usize;
+   |                ^^^^^
+   = help: turn the `Subproc` case of `tag` into an enum variant that carries `raw`, and delete the flat field; the other cases then have nothing to fill in or misread
    = note: `#[warn(field_valid_only_when)]` on by default
 
-warning: `reject` is only read where `request` has been tested (2 reads), and every `Verify` made with another `request` fills it with a placeholder (1 site)
+warning: `reject` is read only after testing `request` (2 reads) and gets a placeholder wherever `Verify` is constructed with another `request` (1 site), so it only means something in that one case, yet the struct carries it in all of them
   --> $DIR/field_valid_only_when.rs:57:5
    |
 LL |     reject: bool,
    |     ^^^^^^^^^^^^
    |
-   = help: the field is the payload of that one case, stored flat; an enum variant carrying it leaves the other cases nothing to fill in or misread
+note: one of the reads, under that test
+  --> $DIR/field_valid_only_when.rs:80:25
+   |
+LL |         out += u8::from(v.reject);
+   |                         ^^^^^^^^
+   = help: turn the `true` case of `request` into an enum variant that carries `reject`, and delete the flat field; the other cases then have nothing to fill in or misread
 
-warning: `result` is only read where `state == State::Done` has been tested (1 read), and every `Job` made with another `state` fills it with a placeholder (1 site)
+warning: `result` is read only after testing `state == State::Done` (1 read) and gets a placeholder wherever `Job` is constructed with another `state` (1 site), so it only means something in that one case, yet the struct carries it in all of them
   --> $DIR/field_valid_only_when.rs:100:5
    |
 LL |     result: u64,
    |     ^^^^^^^^^^^
    |
-   = help: the field is the payload of that one case, stored flat; an enum variant carrying it leaves the other cases nothing to fill in or misread
+note: one of the reads, under that test
+  --> $DIR/field_valid_only_when.rs:120:29
+   |
+LL |         State::Done => Some(j.result),
+   |                             ^^^^^^^^
+   = help: turn the `Done` case of `state` into an enum variant that carries `result`, and delete the flat field; the other cases then have nothing to fill in or misread
 
-warning: `href` is only read where `depth == 1` has been tested (1 read), and every `Nest` made with another `depth` fills it with a placeholder (1 site)
+warning: `href` is read only after testing `depth == 1` (1 read) and gets a placeholder wherever `Nest` is constructed with another `depth` (1 site), so it only means something in that one case, yet the struct carries it in all of them
   --> $DIR/field_valid_only_when.rs:129:5
    |
 LL |     href: Option<u8>,
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: the field is the payload of that one case, stored flat; an enum variant carrying it leaves the other cases nothing to fill in or misread
+note: one of the reads, under that test
+  --> $DIR/field_valid_only_when.rs:147:33
+   |
+LL |     let out = if n.depth == 1 { n.href.take() } else { None };
+   |                                 ^^^^^^
+   = help: turn the `1` case of `depth` into an enum variant that carries `href`, and delete the flat field; the other cases then have nothing to fill in or misread
 
 warning: 4 warnings emitted
 

--- a/ui/field_valid_only_when.stderr
+++ b/ui/field_valid_only_when.stderr
@@ -1,55 +1,55 @@
-warning: `raw` is read only after testing `tag == Tag::Subproc` (3 reads) and gets a placeholder wherever `Child` is constructed with another `tag` (1 site), so it only means something in that one case, yet the struct carries it in all of them
+warning: `raw` is only read after checking `tag == Tag::Subproc` (3 reads), and every other `Child` fills it with a placeholder (1 place). The field only means something in that one case
   --> $DIR/field_valid_only_when.rs:16:5
    |
 LL |     raw: *mut u8,
    |     ^^^^^^^^^^^^
    |
-note: one of the reads, under that test
+note: one of the guarded reads
   --> $DIR/field_valid_only_when.rs:37:16
    |
 LL |         return c.raw as usize;
    |                ^^^^^
-   = help: turn the `Subproc` case of `tag` into an enum variant that carries `raw`, and delete the flat field; the other cases then have nothing to fill in or misread
+   = help: make the `Subproc` case of `tag` an enum variant that carries `raw`, and drop the flat field
    = note: `#[warn(field_valid_only_when)]` on by default
 
-warning: `reject` is read only after testing `request` (2 reads) and gets a placeholder wherever `Verify` is constructed with another `request` (1 site), so it only means something in that one case, yet the struct carries it in all of them
+warning: `reject` is only read after checking `request` (2 reads), and every other `Verify` fills it with a placeholder (1 place). The field only means something in that one case
   --> $DIR/field_valid_only_when.rs:57:5
    |
 LL |     reject: bool,
    |     ^^^^^^^^^^^^
    |
-note: one of the reads, under that test
+note: one of the guarded reads
   --> $DIR/field_valid_only_when.rs:80:25
    |
 LL |         out += u8::from(v.reject);
    |                         ^^^^^^^^
-   = help: turn the `true` case of `request` into an enum variant that carries `reject`, and delete the flat field; the other cases then have nothing to fill in or misread
+   = help: make the `true` case of `request` an enum variant that carries `reject`, and drop the flat field
 
-warning: `result` is read only after testing `state == State::Done` (1 read) and gets a placeholder wherever `Job` is constructed with another `state` (1 site), so it only means something in that one case, yet the struct carries it in all of them
+warning: `result` is only read after checking `state == State::Done` (1 read), and every other `Job` fills it with a placeholder (1 place). The field only means something in that one case
   --> $DIR/field_valid_only_when.rs:100:5
    |
 LL |     result: u64,
    |     ^^^^^^^^^^^
    |
-note: one of the reads, under that test
+note: one of the guarded reads
   --> $DIR/field_valid_only_when.rs:120:29
    |
 LL |         State::Done => Some(j.result),
    |                             ^^^^^^^^
-   = help: turn the `Done` case of `state` into an enum variant that carries `result`, and delete the flat field; the other cases then have nothing to fill in or misread
+   = help: make the `Done` case of `state` an enum variant that carries `result`, and drop the flat field
 
-warning: `href` is read only after testing `depth == 1` (1 read) and gets a placeholder wherever `Nest` is constructed with another `depth` (1 site), so it only means something in that one case, yet the struct carries it in all of them
+warning: `href` is only read after checking `depth == 1` (1 read), and every other `Nest` fills it with a placeholder (1 place). The field only means something in that one case
   --> $DIR/field_valid_only_when.rs:129:5
    |
 LL |     href: Option<u8>,
    |     ^^^^^^^^^^^^^^^^
    |
-note: one of the reads, under that test
+note: one of the guarded reads
   --> $DIR/field_valid_only_when.rs:147:33
    |
 LL |     let out = if n.depth == 1 { n.href.take() } else { None };
    |                                 ^^^^^^
-   = help: turn the `1` case of `depth` into an enum variant that carries `href`, and delete the flat field; the other cases then have nothing to fill in or misread
+   = help: make the `1` case of `depth` an enum variant that carries `href`, and drop the flat field
 
 warning: 4 warnings emitted
 

--- a/ui/forbidden_reach.stderr
+++ b/ui/forbidden_reach.stderr
@@ -1,4 +1,4 @@
-warning: `hot_path` can call `std::vec::Vec::<T, A>::push`, which this project's `forbidden-reach` config bans from it, through hot_path -> helper -> std::vec::Vec::<T, A>::push
+warning: `hot_path` can reach `std::vec::Vec::<T, A>::push`, which the `forbidden-reach` config bans for it. Path: hot_path -> helper -> std::vec::Vec::<T, A>::push
   --> $DIR/forbidden_reach.rs:4:1
    |
 LL | / fn hot_path(n: u32) -> u32 {
@@ -6,12 +6,12 @@ LL | |     helper(n)
 LL | | }
    | |_^
    |
-note: the last call in the chain, reaching `std::vec::Vec::<T, A>::push`
+note: the last call in that path, to `std::vec::Vec::<T, A>::push`
   --> $DIR/forbidden_reach.rs:10:5
    |
 LL |     v.push(n);
    |     ^^^^^^^^^
-   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `hot_path`
+   = help: break the path (each arrow is a real call in this crate), or relax the `forbidden-reach` rule for `hot_path` if the call is fine
    = note: `#[warn(forbidden_reach)]` on by default
 
 warning: 1 warning emitted

--- a/ui/forbidden_reach.stderr
+++ b/ui/forbidden_reach.stderr
@@ -1,4 +1,4 @@
-warning: `hot_path` reaches `std::vec::Vec::<T, A>::push`, which this project bans from it: hot_path -> helper -> std::vec::Vec::<T, A>::push
+warning: `hot_path` can call `std::vec::Vec::<T, A>::push`, which this project's `forbidden-reach` config bans from it, through hot_path -> helper -> std::vec::Vec::<T, A>::push
   --> $DIR/forbidden_reach.rs:4:1
    |
 LL | / fn hot_path(n: u32) -> u32 {
@@ -6,7 +6,12 @@ LL | |     helper(n)
 LL | | }
    | |_^
    |
-   = help: one finding per banned definition reached; every arrow is a real call in this crate, so break the chain or amend the rule
+note: the last call in the chain, reaching `std::vec::Vec::<T, A>::push`
+  --> $DIR/forbidden_reach.rs:10:5
+   |
+LL |     v.push(n);
+   |     ^^^^^^^^^
+   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `hot_path`
    = note: `#[warn(forbidden_reach)]` on by default
 
 warning: 1 warning emitted

--- a/ui/forbidden_reach_multi.stderr
+++ b/ui/forbidden_reach_multi.stderr
@@ -1,4 +1,4 @@
-warning: `two_bans` reaches `std::vec::Vec::<T, A>::push`, which this project bans from it: two_bans -> std::vec::Vec::<T, A>::push
+warning: `two_bans` can call `std::vec::Vec::<T, A>::push`, which this project's `forbidden-reach` config bans from it, through two_bans -> std::vec::Vec::<T, A>::push
   --> $DIR/forbidden_reach_multi.rs:7:1
    |
 LL | / fn two_bans(n: u32) -> u32 {
@@ -8,10 +8,15 @@ LL | |     v[0] + Some(n).expect("n")
 LL | | }
    | |_^
    |
-   = help: one finding per banned definition reached; every arrow is a real call in this crate, so break the chain or amend the rule
+note: the last call in the chain, reaching `std::vec::Vec::<T, A>::push`
+  --> $DIR/forbidden_reach_multi.rs:9:5
+   |
+LL |     v.push(n);
+   |     ^^^^^^^^^
+   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `two_bans`
    = note: `#[warn(forbidden_reach)]` on by default
 
-warning: `two_bans` reaches `std::option::Option::<T>::expect`, which this project bans from it: two_bans -> std::option::Option::<T>::expect
+warning: `two_bans` can call `std::option::Option::<T>::expect`, which this project's `forbidden-reach` config bans from it, through two_bans -> std::option::Option::<T>::expect
   --> $DIR/forbidden_reach_multi.rs:7:1
    |
 LL | / fn two_bans(n: u32) -> u32 {
@@ -21,9 +26,14 @@ LL | |     v[0] + Some(n).expect("n")
 LL | | }
    | |_^
    |
-   = help: one finding per banned definition reached; every arrow is a real call in this crate, so break the chain or amend the rule
+note: the last call in the chain, reaching `std::option::Option::<T>::expect`
+  --> $DIR/forbidden_reach_multi.rs:10:12
+   |
+LL |     v[0] + Some(n).expect("n")
+   |            ^^^^^^^^^^^^^^^^^^^
+   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `two_bans`
 
-warning: `one_ban_twice` reaches `std::vec::Vec::<T, A>::push`, which this project bans from it: one_ban_twice -> std::vec::Vec::<T, A>::push (and 1 further call site to it)
+warning: `one_ban_twice` can call `std::vec::Vec::<T, A>::push`, which this project's `forbidden-reach` config bans from it, through one_ban_twice -> std::vec::Vec::<T, A>::push (and 1 further call site to it)
   --> $DIR/forbidden_reach_multi.rs:15:1
    |
 LL | / fn one_ban_twice(n: u32) -> u32 {
@@ -34,7 +44,12 @@ LL | |     v[0]
 LL | | }
    | |_^
    |
-   = help: one finding per banned definition reached; every arrow is a real call in this crate, so break the chain or amend the rule
+note: the last call in the chain, reaching `std::vec::Vec::<T, A>::push`
+  --> $DIR/forbidden_reach_multi.rs:17:5
+   |
+LL |     v.push(n);
+   |     ^^^^^^^^^
+   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `one_ban_twice`
 
 warning: 3 warnings emitted
 

--- a/ui/forbidden_reach_multi.stderr
+++ b/ui/forbidden_reach_multi.stderr
@@ -1,4 +1,4 @@
-warning: `two_bans` can call `std::vec::Vec::<T, A>::push`, which this project's `forbidden-reach` config bans from it, through two_bans -> std::vec::Vec::<T, A>::push
+warning: `two_bans` can reach `std::vec::Vec::<T, A>::push`, which the `forbidden-reach` config bans for it. Path: two_bans -> std::vec::Vec::<T, A>::push
   --> $DIR/forbidden_reach_multi.rs:7:1
    |
 LL | / fn two_bans(n: u32) -> u32 {
@@ -8,15 +8,15 @@ LL | |     v[0] + Some(n).expect("n")
 LL | | }
    | |_^
    |
-note: the last call in the chain, reaching `std::vec::Vec::<T, A>::push`
+note: the last call in that path, to `std::vec::Vec::<T, A>::push`
   --> $DIR/forbidden_reach_multi.rs:9:5
    |
 LL |     v.push(n);
    |     ^^^^^^^^^
-   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `two_bans`
+   = help: break the path (each arrow is a real call in this crate), or relax the `forbidden-reach` rule for `two_bans` if the call is fine
    = note: `#[warn(forbidden_reach)]` on by default
 
-warning: `two_bans` can call `std::option::Option::<T>::expect`, which this project's `forbidden-reach` config bans from it, through two_bans -> std::option::Option::<T>::expect
+warning: `two_bans` can reach `std::option::Option::<T>::expect`, which the `forbidden-reach` config bans for it. Path: two_bans -> std::option::Option::<T>::expect
   --> $DIR/forbidden_reach_multi.rs:7:1
    |
 LL | / fn two_bans(n: u32) -> u32 {
@@ -26,14 +26,14 @@ LL | |     v[0] + Some(n).expect("n")
 LL | | }
    | |_^
    |
-note: the last call in the chain, reaching `std::option::Option::<T>::expect`
+note: the last call in that path, to `std::option::Option::<T>::expect`
   --> $DIR/forbidden_reach_multi.rs:10:12
    |
 LL |     v[0] + Some(n).expect("n")
    |            ^^^^^^^^^^^^^^^^^^^
-   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `two_bans`
+   = help: break the path (each arrow is a real call in this crate), or relax the `forbidden-reach` rule for `two_bans` if the call is fine
 
-warning: `one_ban_twice` can call `std::vec::Vec::<T, A>::push`, which this project's `forbidden-reach` config bans from it, through one_ban_twice -> std::vec::Vec::<T, A>::push (and 1 further call site to it)
+warning: `one_ban_twice` can reach `std::vec::Vec::<T, A>::push`, which the `forbidden-reach` config bans for it. Path: one_ban_twice -> std::vec::Vec::<T, A>::push (1 more call site reaches it)
   --> $DIR/forbidden_reach_multi.rs:15:1
    |
 LL | / fn one_ban_twice(n: u32) -> u32 {
@@ -44,12 +44,12 @@ LL | |     v[0]
 LL | | }
    | |_^
    |
-note: the last call in the chain, reaching `std::vec::Vec::<T, A>::push`
+note: the last call in that path, to `std::vec::Vec::<T, A>::push`
   --> $DIR/forbidden_reach_multi.rs:17:5
    |
 LL |     v.push(n);
    |     ^^^^^^^^^
-   = help: break that chain (every arrow is a real call in this crate), or if the call is acceptable after all, amend the `forbidden-reach` rule for `one_ban_twice`
+   = help: break the path (each arrow is a real call in this crate), or relax the `forbidden-reach` rule for `one_ban_twice` if the call is fine
 
 warning: 3 warnings emitted
 

--- a/ui/groups.stderr
+++ b/ui/groups.stderr
@@ -1,28 +1,28 @@
-warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Op` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/groups.rs:14:9
    |
 LL |         _ => 0,
    |         ^
    |
-note: `Op`, whose new variants would fall into this arm
+note: `Op` is defined here
   --> $DIR/groups.rs:4:1
    |
 LL | enum Op {
    | ^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
+help: list the remaining variants instead of `_`
    |
 LL -         _ => 0,
 LL +         Op::Sub | Op::Mul => 0,
    |
 
-warning: `.ok();` turns this `Result` into an `Option` and drops it on the spot, so its `std::num::ParseIntError` error is thrown away by something that reads like handling
+warning: `.ok();` converts this `Result` to an `Option` and drops it, so the `std::num::ParseIntError` error disappears in a line that looks like handling
   --> $DIR/groups.rs:30:5
    |
 LL |     "1".parse::<u8>().ok();
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: handle the `Err` or propagate it with `?`; if dropping it is intended, write `let _ = ...;` so the discard is stated
+   = help: handle the `Err` or pass it on with `?`. If dropping it is intended, write `let _ = ...;` to say so
    = note: `#[warn(discarded_error)]` on by default
 
 warning: 2 warnings emitted

--- a/ui/groups.stderr
+++ b/ui/groups.stderr
@@ -1,23 +1,28 @@
-warning: this arm absorbs every future variant of `Op` (3 variants today)
+warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/groups.rs:14:9
    |
 LL |         _ => 0,
    |         ^
    |
+note: `Op`, whose new variants would fall into this arm
+  --> $DIR/groups.rs:4:1
+   |
+LL | enum Op {
+   | ^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: list the remaining variants; the compiler then flags every new one added
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
    |
 LL -         _ => 0,
 LL +         Op::Sub | Op::Mul => 0,
    |
 
-warning: `.ok()` in statement position discards the error unobserved
+warning: `.ok();` turns this `Result` into an `Option` and drops it on the spot, so its `std::num::ParseIntError` error is thrown away by something that reads like handling
   --> $DIR/groups.rs:30:5
    |
 LL |     "1".parse::<u8>().ok();
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: handle the error, or state the discard with `let _ = ...`
+   = help: handle the `Err` or propagate it with `?`; if dropping it is intended, write `let _ = ...;` so the discard is stated
    = note: `#[warn(discarded_error)]` on by default
 
 warning: 2 warnings emitted

--- a/ui/guard_blind_to_action.stderr
+++ b/ui/guard_blind_to_action.stderr
@@ -1,27 +1,47 @@
-warning: `detach` is gated by `can_donate`, but touches `conns` which the guard never reads
+warning: `detach` runs only if `can_donate` says yes, but it changes `conns`, which `can_donate` never looks at, so the check cannot know whether `detach` is safe here
   --> $DIR/guard_blind_to_action.rs:22:9
    |
 LL |         self.detach();
    |         ^^^^^^^^^^^^^
    |
-   = help: a guard blind to part of the state its action manipulates cannot be sound; align what the pair reads
+note: `can_donate` reads only `queue`
+  --> $DIR/guard_blind_to_action.rs:9:5
+   |
+LL |     fn can_donate(&self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: make `can_donate` look at `conns` too, or move the `conns` work out from under this check
    = note: `#[warn(guard_blind_to_action)]` on by default
 
-warning: `drain` is gated by `can_donate`, but touches `conns` which the guard never reads
+warning: `drain` runs only if `can_donate` says yes, but it changes `conns`, which `can_donate` never looks at, so the check cannot know whether `drain` is safe here
   --> $DIR/guard_blind_to_action.rs:43:17
    |
 LL |         let n = self.drain();
    |                 ^^^^^^^^^^^^
    |
-   = help: a guard blind to part of the state its action manipulates cannot be sound; align what the pair reads
+note: `can_donate` reads only `queue`
+  --> $DIR/guard_blind_to_action.rs:9:5
+   |
+LL |     fn can_donate(&self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: make `can_donate` look at `conns` too, or move the `conns` work out from under this check
 
-warning: `detach` is gated by `can_donate` and `can_log`, but touches `conns` which none of the guards read
+warning: `detach` runs only if `can_donate` and `can_log` say yes, but it changes `conns`, which neither `can_donate` nor `can_log` looks at, so the checks cannot know whether `detach` is safe here
   --> $DIR/guard_blind_to_action.rs:120:13
    |
 LL |             self.detach();
    |             ^^^^^^^^^^^^^
    |
-   = help: a guard blind to part of the state its action manipulates cannot be sound; align what the pair reads
+note: `can_donate` reads only `queue`
+  --> $DIR/guard_blind_to_action.rs:9:5
+   |
+LL |     fn can_donate(&self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `can_log` reads only `queue`
+  --> $DIR/guard_blind_to_action.rs:109:5
+   |
+LL |     fn can_log(&self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: make `can_donate` or `can_log` look at `conns` too, or move the `conns` work out from under this check
 
 warning: 3 warnings emitted
 

--- a/ui/guard_blind_to_action.stderr
+++ b/ui/guard_blind_to_action.stderr
@@ -1,4 +1,4 @@
-warning: `detach` runs only if `can_donate` says yes, but it changes `conns`, which `can_donate` never looks at, so the check cannot know whether `detach` is safe here
+warning: `detach` only runs when `can_donate` returns true, but it changes `conns`, which `can_donate` never reads. The check cannot tell whether `detach` is safe
   --> $DIR/guard_blind_to_action.rs:22:9
    |
 LL |         self.detach();
@@ -12,7 +12,7 @@ LL |     fn can_donate(&self) -> bool {
    = help: make `can_donate` look at `conns` too, or move the `conns` work out from under this check
    = note: `#[warn(guard_blind_to_action)]` on by default
 
-warning: `drain` runs only if `can_donate` says yes, but it changes `conns`, which `can_donate` never looks at, so the check cannot know whether `drain` is safe here
+warning: `drain` only runs when `can_donate` returns true, but it changes `conns`, which `can_donate` never reads. The check cannot tell whether `drain` is safe
   --> $DIR/guard_blind_to_action.rs:43:17
    |
 LL |         let n = self.drain();
@@ -25,7 +25,7 @@ LL |     fn can_donate(&self) -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: make `can_donate` look at `conns` too, or move the `conns` work out from under this check
 
-warning: `detach` runs only if `can_donate` and `can_log` say yes, but it changes `conns`, which neither `can_donate` nor `can_log` looks at, so the checks cannot know whether `detach` is safe here
+warning: `detach` only runs when `can_donate` and `can_log` return true, but it changes `conns`, which neither `can_donate` nor `can_log` reads. The checks cannot tell whether `detach` is safe
   --> $DIR/guard_blind_to_action.rs:120:13
    |
 LL |             self.detach();

--- a/ui/index_of_other_kind.stderr
+++ b/ui/index_of_other_kind.stderr
@@ -1,81 +1,81 @@
-warning: `l.resolutions` is indexed by `pkg_id` here, but everywhere else in this function (1 site) it is indexed by `dep_id` and `pkg_id` is what indexes `l.packages`, so this looks like an index into the wrong table and, both being plain integers, it compiles
+warning: `l.resolutions` is indexed by `pkg_id` here. Elsewhere in this function it is indexed by `dep_id` (1 place), and `pkg_id` indexes `l.packages`. This looks like the wrong table
   --> $DIR/index_of_other_kind.rs:15:17
    |
 LL |     let stale = l.resolutions[pkg_id as usize];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `l.resolutions` indexed by its usual kind
+note: `l.resolutions` indexed the usual way
   --> $DIR/index_of_other_kind.rs:12:20
    |
 LL |     let resolved = l.resolutions[dep_id as usize];
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: give `l.resolutions` and `l.packages` each an index newtype and implement `Index` only for its own, so `l.resolutions[pkg_id]` is a type error; if this line is intended, rename the index to say so
+   = help: give `l.resolutions` and `l.packages` their own index newtypes so `l.resolutions[pkg_id]` cannot compile. If this line is intended, rename the index to say so
    = note: `#[warn(index_of_other_kind)]` on by default
 
-warning: `parts` is indexed by `source_index` here, but everywhere else in this function (1 site) it is indexed by `part_index` and `source_index` is what indexes `sources`, so this looks like an index into the wrong table and, both being plain integers, it compiles
+warning: `parts` is indexed by `source_index` here. Elsewhere in this function it is indexed by `part_index` (1 place), and `source_index` indexes `sources`. This looks like the wrong table
   --> $DIR/index_of_other_kind.rs:29:19
    |
 LL |     let crossed = parts.get(source_index);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `parts` indexed by its usual kind
+note: `parts` indexed the usual way
   --> $DIR/index_of_other_kind.rs:26:16
    |
 LL |     let part = parts.get(part_index);
    |                ^^^^^^^^^^^^^^^^^^^^^
-   = help: give `parts` and `sources` each an index newtype and implement `Index` only for its own, so `parts[source_index]` is a type error; if this line is intended, rename the index to say so
+   = help: give `parts` and `sources` their own index newtypes so `parts[source_index]` cannot compile. If this line is intended, rename the index to say so
 
-warning: `self.files` is indexed by `part_index` here, but everywhere else in this function (1 site) it is indexed by `source_index` and `part_index` is what indexes `self.parts[..]`, so this looks like an index into the wrong table and, both being plain integers, it compiles
+warning: `self.files` is indexed by `part_index` here. Elsewhere in this function it is indexed by `source_index` (1 place), and `part_index` indexes `self.parts[..]`. This looks like the wrong table
   --> $DIR/index_of_other_kind.rs:44:17
    |
 LL |         let _ = self.files.get_mut(part_index as usize);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `self.files` indexed by its usual kind
+note: `self.files` indexed the usual way
   --> $DIR/index_of_other_kind.rs:41:17
    |
 LL |         let _ = self.files[source_index as usize];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: give `self.files` and `self.parts[..]` each an index newtype and implement `Index` only for its own, so `self.files[part_index]` is a type error; if this line is intended, rename the index to say so
+   = help: give `self.files` and `self.parts[..]` their own index newtypes so `self.files[part_index]` cannot compile. If this line is intended, rename the index to say so
 
-warning: `states` is indexed by `dep_idx` here, but everywhere else in this function (1 site) it is indexed by `root_id` and `dep_id` (the same kind as `dep_idx`) is what indexes `dependencies`, so this looks like an index into the wrong table and, both being plain integers, it compiles
+warning: `states` is indexed by `dep_idx` here. Elsewhere in this function it is indexed by `root_id` (1 place), and `dep_id` (the same kind as `dep_idx`) indexes `dependencies`. This looks like the wrong table
   --> $DIR/index_of_other_kind.rs:78:24
    |
 LL |     unvisited + name + states[dep_idx]
    |                        ^^^^^^^^^^^^^^^
    |
-note: `states` indexed by its usual kind
+note: `states` indexed the usual way
   --> $DIR/index_of_other_kind.rs:75:21
    |
 LL |     let unvisited = states[root_id];
    |                     ^^^^^^^^^^^^^^^
-   = help: give `states` and `dependencies` each an index newtype and implement `Index` only for its own, so `states[dep_idx]` is a type error; if this line is intended, rename the index to say so
+   = help: give `states` and `dependencies` their own index newtypes so `states[dep_idx]` cannot compile. If this line is intended, rename the index to say so
 
-warning: `parts` is indexed by `source_index` here, but everywhere else in this function (1 site) it is indexed by `part_index` and `source_index` is what indexes `sources`, so this looks like an index into the wrong table and, both being plain integers, it compiles
+warning: `parts` is indexed by `source_index` here. Elsewhere in this function it is indexed by `part_index` (1 place), and `source_index` indexes `sources`. This looks like the wrong table
   --> $DIR/index_of_other_kind.rs:88:19
    |
 LL |     let crossed = parts[source_index];
    |                   ^^^^^^^^^^^^^^^^^^^
    |
-note: `parts` indexed by its usual kind
+note: `parts` indexed the usual way
   --> $DIR/index_of_other_kind.rs:89:15
    |
 LL |     crossed + parts[part_index] + sources[source_index]
    |               ^^^^^^^^^^^^^^^^^
-   = help: give `parts` and `sources` each an index newtype and implement `Index` only for its own, so `parts[source_index]` is a type error; if this line is intended, rename the index to say so
+   = help: give `parts` and `sources` their own index newtypes so `parts[source_index]` cannot compile. If this line is intended, rename the index to say so
 
-warning: `table` is indexed by `dep_id` here, but everywhere else in this function (3 sites) it is indexed by `pkg_id` and `dep_id` is what indexes `deps`, so this looks like an index into the wrong table and, both being plain integers, it compiles
+warning: `table` is indexed by `dep_id` here. Elsewhere in this function it is indexed by `pkg_id` (3 places), and `dep_id` indexes `deps`. This looks like the wrong table
   --> $DIR/index_of_other_kind.rs:103:11
    |
 LL |         + table[dep_id]
    |           ^^^^^^^^^^^^^
    |
-note: `table` indexed by its usual kind
+note: `table` indexed the usual way
   --> $DIR/index_of_other_kind.rs:101:5
    |
 LL |     table[pkg_id]
    |     ^^^^^^^^^^^^^
-   = help: give `table` and `deps` each an index newtype and implement `Index` only for its own, so `table[dep_id]` is a type error; if this line is intended, rename the index to say so
+   = help: give `table` and `deps` their own index newtypes so `table[dep_id]` cannot compile. If this line is intended, rename the index to say so
 
 warning: 6 warnings emitted
 

--- a/ui/index_of_other_kind.stderr
+++ b/ui/index_of_other_kind.stderr
@@ -1,81 +1,81 @@
-warning: `l.resolutions` is indexed by `pkg_id` here but by `dep_id` elsewhere in this function (1 site), while `pkg_id` is what indexes `l.packages`: the names claim different index kinds and both are plain integers, so the crossing compiles
+warning: `l.resolutions` is indexed by `pkg_id` here, but everywhere else in this function (1 site) it is indexed by `dep_id` and `pkg_id` is what indexes `l.packages`, so this looks like an index into the wrong table and, both being plain integers, it compiles
   --> $DIR/index_of_other_kind.rs:15:17
    |
 LL |     let stale = l.resolutions[pkg_id as usize];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: indexed by the other kind here
+note: `l.resolutions` indexed by its usual kind
   --> $DIR/index_of_other_kind.rs:12:20
    |
 LL |     let resolved = l.resolutions[dep_id as usize];
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: an index newtype per table, with `Index` implemented only for its own, turns the crossing into a type error
+   = help: give `l.resolutions` and `l.packages` each an index newtype and implement `Index` only for its own, so `l.resolutions[pkg_id]` is a type error; if this line is intended, rename the index to say so
    = note: `#[warn(index_of_other_kind)]` on by default
 
-warning: `parts` is indexed by `source_index` here but by `part_index` elsewhere in this function (1 site), while `source_index` is what indexes `sources`: the names claim different index kinds and both are plain integers, so the crossing compiles
+warning: `parts` is indexed by `source_index` here, but everywhere else in this function (1 site) it is indexed by `part_index` and `source_index` is what indexes `sources`, so this looks like an index into the wrong table and, both being plain integers, it compiles
   --> $DIR/index_of_other_kind.rs:29:19
    |
 LL |     let crossed = parts.get(source_index);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: indexed by the other kind here
+note: `parts` indexed by its usual kind
   --> $DIR/index_of_other_kind.rs:26:16
    |
 LL |     let part = parts.get(part_index);
    |                ^^^^^^^^^^^^^^^^^^^^^
-   = help: an index newtype per table, with `Index` implemented only for its own, turns the crossing into a type error
+   = help: give `parts` and `sources` each an index newtype and implement `Index` only for its own, so `parts[source_index]` is a type error; if this line is intended, rename the index to say so
 
-warning: `self.files` is indexed by `part_index` here but by `source_index` elsewhere in this function (1 site), while `part_index` is what indexes `self.parts[..]`: the names claim different index kinds and both are plain integers, so the crossing compiles
+warning: `self.files` is indexed by `part_index` here, but everywhere else in this function (1 site) it is indexed by `source_index` and `part_index` is what indexes `self.parts[..]`, so this looks like an index into the wrong table and, both being plain integers, it compiles
   --> $DIR/index_of_other_kind.rs:44:17
    |
 LL |         let _ = self.files.get_mut(part_index as usize);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: indexed by the other kind here
+note: `self.files` indexed by its usual kind
   --> $DIR/index_of_other_kind.rs:41:17
    |
 LL |         let _ = self.files[source_index as usize];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: an index newtype per table, with `Index` implemented only for its own, turns the crossing into a type error
+   = help: give `self.files` and `self.parts[..]` each an index newtype and implement `Index` only for its own, so `self.files[part_index]` is a type error; if this line is intended, rename the index to say so
 
-warning: `states` is indexed by `dep_idx` here but by `root_id` elsewhere in this function (1 site), while `dep_id` (the same kind as `dep_idx`) is what indexes `dependencies`: the names claim different index kinds and both are plain integers, so the crossing compiles
+warning: `states` is indexed by `dep_idx` here, but everywhere else in this function (1 site) it is indexed by `root_id` and `dep_id` (the same kind as `dep_idx`) is what indexes `dependencies`, so this looks like an index into the wrong table and, both being plain integers, it compiles
   --> $DIR/index_of_other_kind.rs:78:24
    |
 LL |     unvisited + name + states[dep_idx]
    |                        ^^^^^^^^^^^^^^^
    |
-note: indexed by the other kind here
+note: `states` indexed by its usual kind
   --> $DIR/index_of_other_kind.rs:75:21
    |
 LL |     let unvisited = states[root_id];
    |                     ^^^^^^^^^^^^^^^
-   = help: an index newtype per table, with `Index` implemented only for its own, turns the crossing into a type error
+   = help: give `states` and `dependencies` each an index newtype and implement `Index` only for its own, so `states[dep_idx]` is a type error; if this line is intended, rename the index to say so
 
-warning: `parts` is indexed by `source_index` here but by `part_index` elsewhere in this function (1 site), while `source_index` is what indexes `sources`: the names claim different index kinds and both are plain integers, so the crossing compiles
+warning: `parts` is indexed by `source_index` here, but everywhere else in this function (1 site) it is indexed by `part_index` and `source_index` is what indexes `sources`, so this looks like an index into the wrong table and, both being plain integers, it compiles
   --> $DIR/index_of_other_kind.rs:88:19
    |
 LL |     let crossed = parts[source_index];
    |                   ^^^^^^^^^^^^^^^^^^^
    |
-note: indexed by the other kind here
+note: `parts` indexed by its usual kind
   --> $DIR/index_of_other_kind.rs:89:15
    |
 LL |     crossed + parts[part_index] + sources[source_index]
    |               ^^^^^^^^^^^^^^^^^
-   = help: an index newtype per table, with `Index` implemented only for its own, turns the crossing into a type error
+   = help: give `parts` and `sources` each an index newtype and implement `Index` only for its own, so `parts[source_index]` is a type error; if this line is intended, rename the index to say so
 
-warning: `table` is indexed by `dep_id` here but by `pkg_id` elsewhere in this function (3 sites), while `dep_id` is what indexes `deps`: the names claim different index kinds and both are plain integers, so the crossing compiles
+warning: `table` is indexed by `dep_id` here, but everywhere else in this function (3 sites) it is indexed by `pkg_id` and `dep_id` is what indexes `deps`, so this looks like an index into the wrong table and, both being plain integers, it compiles
   --> $DIR/index_of_other_kind.rs:103:11
    |
 LL |         + table[dep_id]
    |           ^^^^^^^^^^^^^
    |
-note: indexed by the other kind here
+note: `table` indexed by its usual kind
   --> $DIR/index_of_other_kind.rs:101:5
    |
 LL |     table[pkg_id]
    |     ^^^^^^^^^^^^^
-   = help: an index newtype per table, with `Index` implemented only for its own, turns the crossing into a type error
+   = help: give `table` and `deps` each an index newtype and implement `Index` only for its own, so `table[dep_id]` is a type error; if this line is intended, rename the index to say so
 
 warning: 6 warnings emitted
 

--- a/ui/insert_then_unwrap.stderr
+++ b/ui/insert_then_unwrap.stderr
@@ -1,35 +1,55 @@
-warning: this unwrap re-fetches `m[1]`, which the insert above just proved present
+warning: this looks `1` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
   --> $DIR/insert_then_unwrap.rs:11:13
    |
 LL |     let v = m.get(&1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^
    |
-   = help: keep the inserted value, or use the entry API; the panic path and the second lookup both vanish
+note: the insert that already proves it present
+  --> $DIR/insert_then_unwrap.rs:10:5
+   |
+LL |     m.insert(1, 2);
+   |     ^^^^^^^^^^^^^^
+   = help: keep the value you inserted (or use `m.entry(1)`, which hands it back) instead of fetching it again
    = note: `#[warn(insert_then_unwrap)]` on by default
 
-warning: this unwrap re-fetches `m[7]`, which the insert above just proved present
+warning: this looks `7` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
   --> $DIR/insert_then_unwrap.rs:19:13
    |
 LL |     let v = m.get(&7).unwrap();
    |             ^^^^^^^^^^^^^^^^^^
    |
-   = help: keep the inserted value, or use the entry API; the panic path and the second lookup both vanish
+note: the insert that already proves it present
+  --> $DIR/insert_then_unwrap.rs:17:5
+   |
+LL |     m.insert(7, 8);
+   |     ^^^^^^^^^^^^^^
+   = help: keep the value you inserted (or use `m.entry(7)`, which hands it back) instead of fetching it again
 
-warning: this unwrap re-fetches `m[k]`, which the insert above just proved present
+warning: this looks `k` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
   --> $DIR/insert_then_unwrap.rs:80:13
    |
 LL |     let v = m.get(k).unwrap();
    |             ^^^^^^^^^^^^^^^^^
    |
-   = help: keep the inserted value, or use the entry API; the panic path and the second lookup both vanish
+note: the insert that already proves it present
+  --> $DIR/insert_then_unwrap.rs:79:5
+   |
+LL |     m.insert(*k, 2);
+   |     ^^^^^^^^^^^^^^^
+   = help: keep the value you inserted (or use `m.entry(k)`, which hands it back) instead of fetching it again
 
-warning: this unwrap re-fetches `m[k]`, which the insert above just proved present
+warning: this looks `k` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
   --> $DIR/insert_then_unwrap.rs:87:13
    |
 LL |     let k = m.get(&k).unwrap();
    |             ^^^^^^^^^^^^^^^^^^
    |
-   = help: keep the inserted value, or use the entry API; the panic path and the second lookup both vanish
+note: the insert that already proves it present
+  --> $DIR/insert_then_unwrap.rs:86:5
+   |
+LL |     m.insert(k, 2);
+   |     ^^^^^^^^^^^^^^
+   = help: keep the value you inserted (or use `m.entry(k)`, which hands it back) instead of fetching it again
 
 warning: 4 warnings emitted
 

--- a/ui/insert_then_unwrap.stderr
+++ b/ui/insert_then_unwrap.stderr
@@ -1,55 +1,55 @@
-warning: this looks `1` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
+warning: this looks up `1` in `m` and unwraps it right after the `insert` above put it there. Nothing in between could remove it, so the lookup and its panic are redundant
   --> $DIR/insert_then_unwrap.rs:11:13
    |
 LL |     let v = m.get(&1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^
    |
-note: the insert that already proves it present
+note: the insert
   --> $DIR/insert_then_unwrap.rs:10:5
    |
 LL |     m.insert(1, 2);
    |     ^^^^^^^^^^^^^^
-   = help: keep the value you inserted (or use `m.entry(1)`, which hands it back) instead of fetching it again
+   = help: keep the value you inserted, or use `m.entry(1)` which hands it back
    = note: `#[warn(insert_then_unwrap)]` on by default
 
-warning: this looks `7` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
+warning: this looks up `7` in `m` and unwraps it right after the `insert` above put it there. Nothing in between could remove it, so the lookup and its panic are redundant
   --> $DIR/insert_then_unwrap.rs:19:13
    |
 LL |     let v = m.get(&7).unwrap();
    |             ^^^^^^^^^^^^^^^^^^
    |
-note: the insert that already proves it present
+note: the insert
   --> $DIR/insert_then_unwrap.rs:17:5
    |
 LL |     m.insert(7, 8);
    |     ^^^^^^^^^^^^^^
-   = help: keep the value you inserted (or use `m.entry(7)`, which hands it back) instead of fetching it again
+   = help: keep the value you inserted, or use `m.entry(7)` which hands it back
 
-warning: this looks `k` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
+warning: this looks up `k` in `m` and unwraps it right after the `insert` above put it there. Nothing in between could remove it, so the lookup and its panic are redundant
   --> $DIR/insert_then_unwrap.rs:80:13
    |
 LL |     let v = m.get(k).unwrap();
    |             ^^^^^^^^^^^^^^^^^
    |
-note: the insert that already proves it present
+note: the insert
   --> $DIR/insert_then_unwrap.rs:79:5
    |
 LL |     m.insert(*k, 2);
    |     ^^^^^^^^^^^^^^^
-   = help: keep the value you inserted (or use `m.entry(k)`, which hands it back) instead of fetching it again
+   = help: keep the value you inserted, or use `m.entry(k)` which hands it back
 
-warning: this looks `k` up in `m` again and unwraps it, straight after the `insert` above put it there with nothing in between that could remove it, so the lookup and its panic path are both redundant
+warning: this looks up `k` in `m` and unwraps it right after the `insert` above put it there. Nothing in between could remove it, so the lookup and its panic are redundant
   --> $DIR/insert_then_unwrap.rs:87:13
    |
 LL |     let k = m.get(&k).unwrap();
    |             ^^^^^^^^^^^^^^^^^^
    |
-note: the insert that already proves it present
+note: the insert
   --> $DIR/insert_then_unwrap.rs:86:5
    |
 LL |     m.insert(k, 2);
    |     ^^^^^^^^^^^^^^
-   = help: keep the value you inserted (or use `m.entry(k)`, which hands it back) instead of fetching it again
+   = help: keep the value you inserted, or use `m.entry(k)` which hands it back
 
 warning: 4 warnings emitted
 

--- a/ui/interchangeable_aliases.stderr
+++ b/ui/interchangeable_aliases.stderr
@@ -1,159 +1,159 @@
-warning: `INVALID_PACKAGE - 1` is declared `PackageId` but defines `DependencyId` const `ROOT_DEPENDENCY`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `INVALID_PACKAGE - 1` is a `PackageId` but is used to define the `DependencyId` const `ROOT_DEPENDENCY`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:11:43
    |
 LL | pub const ROOT_DEPENDENCY: DependencyId = INVALID_PACKAGE - 1;
    |                                           ^^^^^^^^^^^^^^^^^^^
    |
-note: the `PackageId` declaration this value comes from
+note: the `PackageId` this value comes from
   --> $DIR/interchangeable_aliases.rs:9:28
    |
 LL | pub const INVALID_PACKAGE: PackageId = PackageId::MAX;
    |                            ^^^^^^^^^
-   = help: make `PackageId` and `DependencyId` newtypes (`struct DependencyId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `PackageId` and `DependencyId` newtypes instead of aliases. This line then fails to compile until the right id is used
    = note: `#[warn(interchangeable_aliases)]` on by default
 
-warning: `dep` is declared `DependencyId` but is passed as `PackageId` parameter `package` of `link`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `dep` is a `DependencyId` but is passed as the `PackageId` parameter `package` of `link`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:32:10
    |
 LL |     link(dep, pkg)
    |          ^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:30:53
    |
 LL | pub fn swapped_call_is_flagged(pkg: PackageId, dep: DependencyId) -> u32 {
    |                                                     ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `pkg` is declared `PackageId` but is passed as `DependencyId` parameter `dependency` of `link`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `pkg` is a `PackageId` but is passed as the `DependencyId` parameter `dependency` of `link`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:32:15
    |
 LL |     link(dep, pkg)
    |               ^^^
    |
-note: the `PackageId` declaration this value comes from
+note: the `PackageId` this value comes from
   --> $DIR/interchangeable_aliases.rs:30:37
    |
 LL | pub fn swapped_call_is_flagged(pkg: PackageId, dep: DependencyId) -> u32 {
    |                                     ^^^^^^^^^
-   = help: make `PackageId` and `DependencyId` newtypes (`struct DependencyId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `PackageId` and `DependencyId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `dep` is declared `DependencyId` but is stored in `PackageId` field `package`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `dep` is a `DependencyId` but is stored in the `PackageId` field `package`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:38:18
    |
 LL |         package: dep,
    |                  ^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:35:55
    |
 LL | pub fn struct_literal_is_flagged(pkg: PackageId, dep: DependencyId) -> Resolution {
    |                                                       ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `other.dependency` is declared `DependencyId` but is stored in `PackageId` field `package`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `other.dependency` is a `DependencyId` but is stored in the `PackageId` field `package`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:50:17
    |
 LL |     r.package = other.dependency;
    |                 ^^^^^^^^^^^^^^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:17:21
    |
 LL |     pub dependency: DependencyId,
    |                     ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `first_dependency(r)` is declared `DependencyId` but is bound to `pkg: PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `first_dependency(r)` is a `DependencyId` but is bound to `pkg: PackageId`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:57:26
    |
 LL |     let pkg: PackageId = first_dependency(r);
    |                          ^^^^^^^^^^^^^^^^^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:26:44
    |
 LL | pub fn first_dependency(r: &Resolution) -> DependencyId {
    |                                            ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `dep` is declared `DependencyId` but is returned from `return_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `dep` is a `DependencyId` but is returned from `return_is_flagged` as a `PackageId`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:64:5
    |
 LL |     dep
    |     ^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:61:31
    |
 LL | pub fn return_is_flagged(dep: DependencyId) -> PackageId {
    |                               ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `r.dependency` is declared `DependencyId` but is returned from `branch_tail_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `r.dependency` is a `DependencyId` but is returned from `branch_tail_is_flagged` as a `PackageId`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:70:9
    |
 LL |         r.dependency
    |         ^^^^^^^^^^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:17:21
    |
 LL |     pub dependency: DependencyId,
    |                     ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `first_dependency(r)` is declared `DependencyId` but is returned from `branch_tail_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `first_dependency(r)` is a `DependencyId` but is returned from `branch_tail_is_flagged` as a `PackageId`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:74:18
    |
 LL |             _ => first_dependency(r),
    |                  ^^^^^^^^^^^^^^^^^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:26:44
    |
 LL | pub fn first_dependency(r: &Resolution) -> DependencyId {
    |                                            ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `r.dependency` is declared `DependencyId` but is returned from `explicit_return_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `r.dependency` is a `DependencyId` but is returned from `explicit_return_is_flagged` as a `PackageId`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:82:16
    |
 LL |         return r.dependency;
    |                ^^^^^^^^^^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:17:21
    |
 LL |     pub dependency: DependencyId,
    |                     ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `dep` is declared `DependencyId` but is stored in `PackageId` field `0`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `dep` is a `DependencyId` but is stored in the `PackageId` field `0`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:92:13
    |
 LL |     (Pinned(dep, dep), Pinned(pkg, dep))
    |             ^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:89:58
    |
 LL | pub fn tuple_constructor_is_flagged(pkg: PackageId, dep: DependencyId) -> (Pinned, Pinned) {
    |                                                          ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
-warning: `dep` is declared `DependencyId` but is compared with `INVALID_PACKAGE`, declared `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
+warning: `dep` is a `DependencyId` but is compared with `INVALID_PACKAGE`, a `PackageId`. Both are plain `u32`, so the mix-up compiles
   --> $DIR/interchangeable_aliases.rs:97:8
    |
 LL |     if dep == INVALID_PACKAGE {
    |        ^^^
    |
-note: the `DependencyId` declaration this value comes from
+note: the `DependencyId` this value comes from
   --> $DIR/interchangeable_aliases.rs:95:51
    |
 LL | pub fn comparison_is_flagged(r: &Resolution, dep: DependencyId) -> bool {
    |                                                   ^^^^^^^^^^^^
-   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
+   = help: make `DependencyId` and `PackageId` newtypes instead of aliases. This line then fails to compile until the right id is used
 
 warning: 12 warnings emitted
 

--- a/ui/interchangeable_aliases.stderr
+++ b/ui/interchangeable_aliases.stderr
@@ -1,99 +1,159 @@
-warning: `INVALID_PACKAGE - 1` is declared `PackageId` but defines `DependencyId` const `ROOT_DEPENDENCY`; both are `u32`, so nothing rejects the crossing
+warning: `INVALID_PACKAGE - 1` is declared `PackageId` but defines `DependencyId` const `ROOT_DEPENDENCY`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:11:43
    |
 LL | pub const ROOT_DEPENDENCY: DependencyId = INVALID_PACKAGE - 1;
    |                                           ^^^^^^^^^^^^^^^^^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `PackageId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:9:28
+   |
+LL | pub const INVALID_PACKAGE: PackageId = PackageId::MAX;
+   |                            ^^^^^^^^^
+   = help: make `PackageId` and `DependencyId` newtypes (`struct DependencyId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
    = note: `#[warn(interchangeable_aliases)]` on by default
 
-warning: `dep` is declared `DependencyId` but is passed as `PackageId` parameter `package` of `link`; both are `u32`, so nothing rejects the crossing
+warning: `dep` is declared `DependencyId` but is passed as `PackageId` parameter `package` of `link`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:32:10
    |
 LL |     link(dep, pkg)
    |          ^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:30:53
+   |
+LL | pub fn swapped_call_is_flagged(pkg: PackageId, dep: DependencyId) -> u32 {
+   |                                                     ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `pkg` is declared `PackageId` but is passed as `DependencyId` parameter `dependency` of `link`; both are `u32`, so nothing rejects the crossing
+warning: `pkg` is declared `PackageId` but is passed as `DependencyId` parameter `dependency` of `link`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:32:15
    |
 LL |     link(dep, pkg)
    |               ^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `PackageId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:30:37
+   |
+LL | pub fn swapped_call_is_flagged(pkg: PackageId, dep: DependencyId) -> u32 {
+   |                                     ^^^^^^^^^
+   = help: make `PackageId` and `DependencyId` newtypes (`struct DependencyId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `dep` is declared `DependencyId` but is stored in `PackageId` field `package`; both are `u32`, so nothing rejects the crossing
+warning: `dep` is declared `DependencyId` but is stored in `PackageId` field `package`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:38:18
    |
 LL |         package: dep,
    |                  ^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:35:55
+   |
+LL | pub fn struct_literal_is_flagged(pkg: PackageId, dep: DependencyId) -> Resolution {
+   |                                                       ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `other.dependency` is declared `DependencyId` but is stored in `PackageId` field `package`; both are `u32`, so nothing rejects the crossing
+warning: `other.dependency` is declared `DependencyId` but is stored in `PackageId` field `package`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:50:17
    |
 LL |     r.package = other.dependency;
    |                 ^^^^^^^^^^^^^^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:17:21
+   |
+LL |     pub dependency: DependencyId,
+   |                     ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `first_dependency(r)` is declared `DependencyId` but is bound to `pkg: PackageId`; both are `u32`, so nothing rejects the crossing
+warning: `first_dependency(r)` is declared `DependencyId` but is bound to `pkg: PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:57:26
    |
 LL |     let pkg: PackageId = first_dependency(r);
    |                          ^^^^^^^^^^^^^^^^^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:26:44
+   |
+LL | pub fn first_dependency(r: &Resolution) -> DependencyId {
+   |                                            ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `dep` is declared `DependencyId` but is returned from `return_is_flagged` as `PackageId`; both are `u32`, so nothing rejects the crossing
+warning: `dep` is declared `DependencyId` but is returned from `return_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:64:5
    |
 LL |     dep
    |     ^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:61:31
+   |
+LL | pub fn return_is_flagged(dep: DependencyId) -> PackageId {
+   |                               ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `r.dependency` is declared `DependencyId` but is returned from `branch_tail_is_flagged` as `PackageId`; both are `u32`, so nothing rejects the crossing
+warning: `r.dependency` is declared `DependencyId` but is returned from `branch_tail_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:70:9
    |
 LL |         r.dependency
    |         ^^^^^^^^^^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:17:21
+   |
+LL |     pub dependency: DependencyId,
+   |                     ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `first_dependency(r)` is declared `DependencyId` but is returned from `branch_tail_is_flagged` as `PackageId`; both are `u32`, so nothing rejects the crossing
+warning: `first_dependency(r)` is declared `DependencyId` but is returned from `branch_tail_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:74:18
    |
 LL |             _ => first_dependency(r),
    |                  ^^^^^^^^^^^^^^^^^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:26:44
+   |
+LL | pub fn first_dependency(r: &Resolution) -> DependencyId {
+   |                                            ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `r.dependency` is declared `DependencyId` but is returned from `explicit_return_is_flagged` as `PackageId`; both are `u32`, so nothing rejects the crossing
+warning: `r.dependency` is declared `DependencyId` but is returned from `explicit_return_is_flagged` as `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:82:16
    |
 LL |         return r.dependency;
    |                ^^^^^^^^^^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:17:21
+   |
+LL |     pub dependency: DependencyId,
+   |                     ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `dep` is declared `DependencyId` but is stored in `PackageId` field `0`; both are `u32`, so nothing rejects the crossing
+warning: `dep` is declared `DependencyId` but is stored in `PackageId` field `0`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:92:13
    |
 LL |     (Pinned(dep, dep), Pinned(pkg, dep))
    |             ^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:89:58
+   |
+LL | pub fn tuple_constructor_is_flagged(pkg: PackageId, dep: DependencyId) -> (Pinned, Pinned) {
+   |                                                          ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
-warning: `dep` is declared `DependencyId` but is compared with `INVALID_PACKAGE`, declared `PackageId`; both are `u32`, so nothing rejects the crossing
+warning: `dep` is declared `DependencyId` but is compared with `INVALID_PACKAGE`, declared `PackageId`, and since both aliases are plain `u32` the compiler accepts one where the other is meant
   --> $DIR/interchangeable_aliases.rs:97:8
    |
 LL |     if dep == INVALID_PACKAGE {
    |        ^^^
    |
-   = help: a newtype per id kind makes this a type error
+note: the `DependencyId` declaration this value comes from
+  --> $DIR/interchangeable_aliases.rs:95:51
+   |
+LL | pub fn comparison_is_flagged(r: &Resolution, dep: DependencyId) -> bool {
+   |                                                   ^^^^^^^^^^^^
+   = help: make `DependencyId` and `PackageId` newtypes (`struct PackageId(u32);`) instead of aliases; this line then fails to compile until the right id is passed
 
 warning: 12 warnings emitted
 

--- a/ui/key_not_identity.stderr
+++ b/ui/key_not_identity.stderr
@@ -1,59 +1,59 @@
-warning: map keyed on `Span`, which this project declares is not an identity
+warning: this map is keyed on `Span`, and `Span` is listed in this project's `key-not-identity-types`: equal `Span`s need not mean the same thing, so distinct entries can collide
   --> $DIR/key_not_identity.rs:17:9
    |
 LL |         m.insert(*s, i);
    |         ^^^^^^^^^^^^^^^
    |
-   = help: key on the canonical identity of the thing this names
+   = help: key on what does identify the value: this project's `key-not-identity-fixes` names `FileId` as what makes a `Span` unambiguous, so put that in the key beside it
    = note: `#[warn(key_not_identity)]` on by default
 
-warning: map keyed on `Span`, which this project declares is not an identity
+warning: this map is keyed on `Span`, and `Span` is listed in this project's `key-not-identity-types`: equal `Span`s need not mean the same thing, so distinct entries can collide
   --> $DIR/key_not_identity.rs:23:5
    |
 LL |     m.get(&s).copied()
    |     ^^^^^^^^^
    |
-   = help: key on the canonical identity of the thing this names
+   = help: key on what does identify the value: this project's `key-not-identity-fixes` names `FileId` as what makes a `Span` unambiguous, so put that in the key beside it
 
-warning: map keyed on `to_bits()` of a float
+warning: this map is keyed on a float's `to_bits()`; for a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys
   --> $DIR/key_not_identity.rs:29:21
    |
 LL |         pool.insert(c.to_bits(), i);
    |                     ^^^^^^^^^^^
    |
-   = help: for boxed or interned values the bits are a pointer, not the value; key on the canonical identity
+   = help: key on the value itself or its canonical handle, not on its bit pattern
 
-warning: map keyed on `to_bits()` of a float
+warning: this map is keyed on a float's `to_bits()`; for a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys
   --> $DIR/key_not_identity.rs:36:17
    |
 LL |     seen.insert(x.to_bits());
    |                 ^^^^^^^^^^^
    |
-   = help: for boxed or interned values the bits are a pointer, not the value; key on the canonical identity
+   = help: key on the value itself or its canonical handle, not on its bit pattern
 
-warning: map keyed on a pointer cast to an integer
+warning: this map is keyed on a pointer cast to an integer, which names an allocation rather than a value: equal values at two addresses get two entries, and a freed-and-reused address aliases an old one
   --> $DIR/key_not_identity.rs:43:20
    |
 LL |         ids.insert(v.as_ptr() as usize, ());
    |                    ^^^^^^^^^^^^^^^^^^^
    |
-   = help: pointer bits name an allocation, not a value; key on the canonical identity
+   = help: key on the value, or on an id assigned when it is created, not on its address
 
-warning: map keyed on `to_raw()`, which this project declares is not an identity
+warning: this map is keyed on the result of `to_raw()`, which this project's `key-not-identity-methods` lists as not an identity, so equal things can land under different keys
   --> $DIR/key_not_identity.rs:59:18
    |
 LL |         m.insert(v.to_raw(), i);
    |                  ^^^^^^^^^^
    |
-   = help: key on the canonical identity of the thing this names
+   = help: key on the value's identity rather than on what `to_raw()` returns
 
-warning: map keyed on `(Span, u32)` carrying `Span`, which this project declares is not an identity
+warning: this map is keyed on `(Span, u32)`, which contains a `Span`, and `Span` is listed in this project's `key-not-identity-types`: equal `Span`s need not mean the same thing, so distinct entries can collide
   --> $DIR/key_not_identity.rs:76:9
    |
 LL |         m.insert((*s, 0u32), i);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: key on the canonical identity of the thing this names
+   = help: key on what does identify the value: this project's `key-not-identity-fixes` names `FileId` as what makes a `Span` unambiguous, so put that in the key beside it
 
 warning: 7 warnings emitted
 

--- a/ui/key_not_identity.stderr
+++ b/ui/key_not_identity.stderr
@@ -1,37 +1,37 @@
-warning: this map is keyed on `Span`, and `Span` is listed in this project's `key-not-identity-types`: equal `Span`s need not mean the same thing, so distinct entries can collide
+warning: this map is keyed on `Span`, which this project's config says is not an identity. Two different things can share a `Span` and overwrite each other
   --> $DIR/key_not_identity.rs:17:9
    |
 LL |         m.insert(*s, i);
    |         ^^^^^^^^^^^^^^^
    |
-   = help: key on what does identify the value: this project's `key-not-identity-fixes` names `FileId` as what makes a `Span` unambiguous, so put that in the key beside it
+   = help: key on something that does identify the value. The config names `FileId` as what makes a `Span` unambiguous, so add it to the key
    = note: `#[warn(key_not_identity)]` on by default
 
-warning: this map is keyed on `Span`, and `Span` is listed in this project's `key-not-identity-types`: equal `Span`s need not mean the same thing, so distinct entries can collide
+warning: this map is keyed on `Span`, which this project's config says is not an identity. Two different things can share a `Span` and overwrite each other
   --> $DIR/key_not_identity.rs:23:5
    |
 LL |     m.get(&s).copied()
    |     ^^^^^^^^^
    |
-   = help: key on what does identify the value: this project's `key-not-identity-fixes` names `FileId` as what makes a `Span` unambiguous, so put that in the key beside it
+   = help: key on something that does identify the value. The config names `FileId` as what makes a `Span` unambiguous, so add it to the key
 
-warning: this map is keyed on a float's `to_bits()`; for a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys
+warning: this map is keyed on a float's `to_bits()`. For a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys
   --> $DIR/key_not_identity.rs:29:21
    |
 LL |         pool.insert(c.to_bits(), i);
    |                     ^^^^^^^^^^^
    |
-   = help: key on the value itself or its canonical handle, not on its bit pattern
+   = help: key on the value itself or its handle, not on its bit pattern
 
-warning: this map is keyed on a float's `to_bits()`; for a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys
+warning: this map is keyed on a float's `to_bits()`. For a NaN-boxed or interned value those bits are a pointer, so two equal values can land under different keys
   --> $DIR/key_not_identity.rs:36:17
    |
 LL |     seen.insert(x.to_bits());
    |                 ^^^^^^^^^^^
    |
-   = help: key on the value itself or its canonical handle, not on its bit pattern
+   = help: key on the value itself or its handle, not on its bit pattern
 
-warning: this map is keyed on a pointer cast to an integer, which names an allocation rather than a value: equal values at two addresses get two entries, and a freed-and-reused address aliases an old one
+warning: this map is keyed on a pointer cast to an integer, which names an allocation and not a value. Equal values at two addresses get two entries, and a freed and reused address looks like an old one
   --> $DIR/key_not_identity.rs:43:20
    |
 LL |         ids.insert(v.as_ptr() as usize, ());
@@ -39,21 +39,21 @@ LL |         ids.insert(v.as_ptr() as usize, ());
    |
    = help: key on the value, or on an id assigned when it is created, not on its address
 
-warning: this map is keyed on the result of `to_raw()`, which this project's `key-not-identity-methods` lists as not an identity, so equal things can land under different keys
+warning: this map is keyed on the result of `to_raw()`, which this project's config says is not an identity. Two equal things can land under different keys
   --> $DIR/key_not_identity.rs:59:18
    |
 LL |         m.insert(v.to_raw(), i);
    |                  ^^^^^^^^^^
    |
-   = help: key on the value's identity rather than on what `to_raw()` returns
+   = help: key on what identifies the value, not on what `to_raw()` returns
 
-warning: this map is keyed on `(Span, u32)`, which contains a `Span`, and `Span` is listed in this project's `key-not-identity-types`: equal `Span`s need not mean the same thing, so distinct entries can collide
+warning: this map is keyed on `(Span, u32)`, which contains a `Span`, and this project's config says `Span` is not an identity. Two different things can share a `Span` and overwrite each other
   --> $DIR/key_not_identity.rs:76:9
    |
 LL |         m.insert((*s, 0u32), i);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: key on what does identify the value: this project's `key-not-identity-fixes` names `FileId` as what makes a `Span` unambiguous, so put that in the key beside it
+   = help: key on something that does identify the value. The config names `FileId` as what makes a `Span` unambiguous, so add it to the key
 
 warning: 7 warnings emitted
 

--- a/ui/lock_order.stderr
+++ b/ui/lock_order.stderr
@@ -1,19 +1,29 @@
-warning: `a` is locked before `b` here, but `b` before `a` at $DIR/lock_order.rs:21:18: 21:31
+warning: `b` is locked here while `a` is held, and another place locks `a` while `b` is held, so two threads taking one path each can deadlock
   --> $DIR/lock_order.rs:14:18
    |
 LL |         let gb = self.b.lock().unwrap();
    |                  ^^^^^^^^^^^^^
    |
-   = help: both orders existing is the shape of a deadlock; pick one order and hold to it everywhere
+note: the opposite order: `a` locked while `b` is held
+  --> $DIR/lock_order.rs:21:18
+   |
+LL |         let ga = self.a.lock().unwrap();
+   |                  ^^^^^^^^^^^^^
+   = help: pick one order for `a` and `b` and take them that way in both places, or take both under one lock
    = note: `#[warn(lock_order)]` on by default
 
-warning: `g` is locked before `h` here, but `h` before `g` at $DIR/lock_order.rs:123:22: 123:35
+warning: `h` is locked here while `g` is held, and another place locks `g` while `h` is held, so two threads taking one path each can deadlock
   --> $DIR/lock_order.rs:114:18
    |
 LL |         let gh = self.h.lock().unwrap();
    |                  ^^^^^^^^^^^^^
    |
-   = help: both orders existing is the shape of a deadlock; pick one order and hold to it everywhere
+note: the opposite order: `g` locked while `h` is held
+  --> $DIR/lock_order.rs:123:22
+   |
+LL |             let gg = self.g.lock().unwrap();
+   |                      ^^^^^^^^^^^^^
+   = help: pick one order for `g` and `h` and take them that way in both places, or take both under one lock
 
 warning: 2 warnings emitted
 

--- a/ui/lock_order.stderr
+++ b/ui/lock_order.stderr
@@ -1,29 +1,29 @@
-warning: `b` is locked here while `a` is held, and another place locks `a` while `b` is held, so two threads taking one path each can deadlock
+warning: `b` is locked here while `a` is held. Another place locks `a` while `b` is held. Two threads, one on each path, can deadlock
   --> $DIR/lock_order.rs:14:18
    |
 LL |         let gb = self.b.lock().unwrap();
    |                  ^^^^^^^^^^^^^
    |
-note: the opposite order: `a` locked while `b` is held
+note: the opposite order is here
   --> $DIR/lock_order.rs:21:18
    |
 LL |         let ga = self.a.lock().unwrap();
    |                  ^^^^^^^^^^^^^
-   = help: pick one order for `a` and `b` and take them that way in both places, or take both under one lock
+   = help: pick one order for `a` and `b` and use it in both places, or guard both with one lock
    = note: `#[warn(lock_order)]` on by default
 
-warning: `h` is locked here while `g` is held, and another place locks `g` while `h` is held, so two threads taking one path each can deadlock
+warning: `h` is locked here while `g` is held. Another place locks `g` while `h` is held. Two threads, one on each path, can deadlock
   --> $DIR/lock_order.rs:114:18
    |
 LL |         let gh = self.h.lock().unwrap();
    |                  ^^^^^^^^^^^^^
    |
-note: the opposite order: `g` locked while `h` is held
+note: the opposite order is here
   --> $DIR/lock_order.rs:123:22
    |
 LL |             let gg = self.g.lock().unwrap();
    |                      ^^^^^^^^^^^^^
-   = help: pick one order for `g` and `h` and take them that way in both places, or take both under one lock
+   = help: pick one order for `g` and `h` and use it in both places, or guard both with one lock
 
 warning: 2 warnings emitted
 

--- a/ui/narrowed_two_ways.stderr
+++ b/ui/narrowed_two_ways.stderr
@@ -1,55 +1,55 @@
-warning: narrowed two ways: `b.len` is `usize` and becomes `u32` through `as` here, which wraps silently, while another site converts the same place into `u32` with a range check
+warning: `b.len` is `usize` and is cut down to `u32` with `as` here, which silently wraps a value that does not fit, while another place converts the same `b.len` to `u32` with `try_from`/`try_into` because it might not
   --> $DIR/narrowed_two_ways.rs:18:5
    |
 LL |     b.len as u32
    |     ^^^^^^^^^^^^
    |
-note: the same place, converted with a check here
+note: the checked conversion of the same place
   --> $DIR/narrowed_two_ways.rs:22:5
    |
 LL |     u32::try_from(b.len).expect("length fits the header")
    |     ^^^^^^^^^^^^^^^^^^^^
-   = help: the check says the value may not fit; declare the place with the narrow type, or a newtype whose constructor checks the range once, so no reader can truncate it (or convert with `try_from` here as well)
+   = help: declare `b.len` as `u32` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `u32::try_from` here too
    = note: `#[warn(narrowed_two_ways)]` on by default
 
-warning: narrowed two ways: `b.offset` is `u64` and becomes `i64` through `as` here, which wraps silently, while another site converts the same place into `i64` with a range check
+warning: `b.offset` is `u64` and is cut down to `i64` with `as` here, which silently wraps a value that does not fit, while another place converts the same `b.offset` to `i64` with `try_from`/`try_into` because it might not
   --> $DIR/narrowed_two_ways.rs:27:5
    |
 LL |     b.offset as i64
    |     ^^^^^^^^^^^^^^^
    |
-note: the same place, converted with a check here
+note: the checked conversion of the same place
   --> $DIR/narrowed_two_ways.rs:31:5
    |
 LL |     i64::try_from(b.offset).expect("offset fits off_t")
    |     ^^^^^^^^^^^^^^^^^^^^^^^
-   = help: the check says the value may not fit; declare the place with the narrow type, or a newtype whose constructor checks the range once, so no reader can truncate it (or convert with `try_from` here as well)
+   = help: declare `b.offset` as `i64` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `i64::try_from` here too
 
-warning: narrowed two ways: `b.count` is `u32` and becomes `u8` through `as` here, which wraps silently, while another site converts the same place into `u8` with a range check
+warning: `b.count` is `u32` and is cut down to `u8` with `as` here, which silently wraps a value that does not fit, while another place converts the same `b.count` to `u8` with `try_from`/`try_into` because it might not
   --> $DIR/narrowed_two_ways.rs:36:5
    |
 LL |     b.count as u8
    |     ^^^^^^^^^^^^^
    |
-note: the same place, converted with a check here
+note: the checked conversion of the same place
   --> $DIR/narrowed_two_ways.rs:40:17
    |
 LL |     let c: u8 = b.count.try_into().unwrap_or(u8::MAX);
    |                 ^^^^^^^^^^^^^^^^^^
-   = help: the check says the value may not fit; declare the place with the narrow type, or a newtype whose constructor checks the range once, so no reader can truncate it (or convert with `try_from` here as well)
+   = help: declare `b.count` as `u8` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `u8::try_from` here too
 
-warning: narrowed two ways: `n` is `u64` and becomes `u16` through `as` here, which wraps silently, while another site converts the same place into `u16` with a range check
+warning: `n` is `u64` and is cut down to `u16` with `as` here, which silently wraps a value that does not fit, while another place converts the same `n` to `u16` with `try_from`/`try_into` because it might not
   --> $DIR/narrowed_two_ways.rs:47:6
    |
 LL |     (n as u16, checked)
    |      ^^^^^^^^
    |
-note: the same place, converted with a check here
+note: the checked conversion of the same place
   --> $DIR/narrowed_two_ways.rs:46:19
    |
 LL |     let checked = u16::try_from(n).unwrap_or(u16::MAX);
    |                   ^^^^^^^^^^^^^^^^
-   = help: the check says the value may not fit; declare the place with the narrow type, or a newtype whose constructor checks the range once, so no reader can truncate it (or convert with `try_from` here as well)
+   = help: declare `n` as `u16` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `u16::try_from` here too
 
 warning: 4 warnings emitted
 

--- a/ui/narrowed_two_ways.stderr
+++ b/ui/narrowed_two_ways.stderr
@@ -1,55 +1,55 @@
-warning: `b.len` is `usize` and is cut down to `u32` with `as` here, which silently wraps a value that does not fit, while another place converts the same `b.len` to `u32` with `try_from`/`try_into` because it might not
+warning: `b.len` is a `usize` cut down to `u32` with `as` here, which wraps silently. Another place converts the same `b.len` to `u32` with `try_from` because it might not fit
   --> $DIR/narrowed_two_ways.rs:18:5
    |
 LL |     b.len as u32
    |     ^^^^^^^^^^^^
    |
-note: the checked conversion of the same place
+note: the checked conversion
   --> $DIR/narrowed_two_ways.rs:22:5
    |
 LL |     u32::try_from(b.len).expect("length fits the header")
    |     ^^^^^^^^^^^^^^^^^^^^
-   = help: declare `b.len` as `u32` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `u32::try_from` here too
+   = help: store `b.len` as `u32` (or a newtype checked once at construction) so nobody has to narrow it. At least use `u32::try_from` here as well
    = note: `#[warn(narrowed_two_ways)]` on by default
 
-warning: `b.offset` is `u64` and is cut down to `i64` with `as` here, which silently wraps a value that does not fit, while another place converts the same `b.offset` to `i64` with `try_from`/`try_into` because it might not
+warning: `b.offset` is a `u64` cut down to `i64` with `as` here, which wraps silently. Another place converts the same `b.offset` to `i64` with `try_from` because it might not fit
   --> $DIR/narrowed_two_ways.rs:27:5
    |
 LL |     b.offset as i64
    |     ^^^^^^^^^^^^^^^
    |
-note: the checked conversion of the same place
+note: the checked conversion
   --> $DIR/narrowed_two_ways.rs:31:5
    |
 LL |     i64::try_from(b.offset).expect("offset fits off_t")
    |     ^^^^^^^^^^^^^^^^^^^^^^^
-   = help: declare `b.offset` as `i64` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `i64::try_from` here too
+   = help: store `b.offset` as `i64` (or a newtype checked once at construction) so nobody has to narrow it. At least use `i64::try_from` here as well
 
-warning: `b.count` is `u32` and is cut down to `u8` with `as` here, which silently wraps a value that does not fit, while another place converts the same `b.count` to `u8` with `try_from`/`try_into` because it might not
+warning: `b.count` is a `u32` cut down to `u8` with `as` here, which wraps silently. Another place converts the same `b.count` to `u8` with `try_from` because it might not fit
   --> $DIR/narrowed_two_ways.rs:36:5
    |
 LL |     b.count as u8
    |     ^^^^^^^^^^^^^
    |
-note: the checked conversion of the same place
+note: the checked conversion
   --> $DIR/narrowed_two_ways.rs:40:17
    |
 LL |     let c: u8 = b.count.try_into().unwrap_or(u8::MAX);
    |                 ^^^^^^^^^^^^^^^^^^
-   = help: declare `b.count` as `u8` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `u8::try_from` here too
+   = help: store `b.count` as `u8` (or a newtype checked once at construction) so nobody has to narrow it. At least use `u8::try_from` here as well
 
-warning: `n` is `u64` and is cut down to `u16` with `as` here, which silently wraps a value that does not fit, while another place converts the same `n` to `u16` with `try_from`/`try_into` because it might not
+warning: `n` is a `u64` cut down to `u16` with `as` here, which wraps silently. Another place converts the same `n` to `u16` with `try_from` because it might not fit
   --> $DIR/narrowed_two_ways.rs:47:6
    |
 LL |     (n as u16, checked)
    |      ^^^^^^^^
    |
-note: the checked conversion of the same place
+note: the checked conversion
   --> $DIR/narrowed_two_ways.rs:46:19
    |
 LL |     let checked = u16::try_from(n).unwrap_or(u16::MAX);
    |                   ^^^^^^^^^^^^^^^^
-   = help: declare `n` as `u16` (or a newtype whose constructor checks the range once) so no reader has to narrow it, or at least use `u16::try_from` here too
+   = help: store `n` as `u16` (or a newtype checked once at construction) so nobody has to narrow it. At least use `u16::try_from` here as well
 
 warning: 4 warnings emitted
 

--- a/ui/options_as_enum.stderr
+++ b/ui/options_as_enum.stderr
@@ -1,10 +1,18 @@
-warning: no construction of `Outcome` sets more than one of `ok`, `err` to `Some` (2 sites checked)
+warning: none of the 2 places `Outcome` is constructed sets more than one of `ok`, `err` to `Some`, so these fields are alternatives that the struct nevertheless lets be set together
   --> $DIR/options_as_enum.rs:4:1
    |
 LL | struct Outcome {
    | ^^^^^^^^^^^^^^
    |
-   = help: these fields encode one state; an enum with one variant per field represents it
+note: one of the constructions
+  --> $DIR/options_as_enum.rs:10:5
+   |
+LL | /     Outcome {
+LL | |         ok: Some(1),
+LL | |         err: None,
+LL | |     }
+   | |_____^
+   = help: replace `ok`, `err` with one enum field that has a variant per case; two `Some`s at once then cannot be written
    = note: `#[warn(options_as_enum)]` on by default
 
 warning: 1 warning emitted

--- a/ui/options_as_enum.stderr
+++ b/ui/options_as_enum.stderr
@@ -1,4 +1,4 @@
-warning: none of the 2 places `Outcome` is constructed sets more than one of `ok`, `err` to `Some`, so these fields are alternatives that the struct nevertheless lets be set together
+warning: `Outcome` is b$DIRlt in 2 places and none sets more than one of `ok`, `err` to `Some`. The fields are alternatives, but the struct allows both at once
   --> $DIR/options_as_enum.rs:4:1
    |
 LL | struct Outcome {
@@ -12,7 +12,7 @@ LL | |         ok: Some(1),
 LL | |         err: None,
 LL | |     }
    | |_____^
-   = help: replace `ok`, `err` with one enum field that has a variant per case; two `Some`s at once then cannot be written
+   = help: replace `ok`, `err` with one enum field, one variant per case
    = note: `#[warn(options_as_enum)]` on by default
 
 warning: 1 warning emitted

--- a/ui/parallel_bools.stderr
+++ b/ui/parallel_bools.stderr
@@ -1,10 +1,15 @@
-warning: the bool fields `done`, `running` of `Task` are only ever assigned together (2 sites in 2 functions)
+warning: the bool fields `done`, `running` of `Task` are always assigned together (2 blocks in 2 functions), so between them they hold one state that the struct lets fall out of step
   --> $DIR/parallel_bools.rs:4:1
    |
 LL | struct Task {
    | ^^^^^^^^^^^
    |
-   = help: together these fields encode one state; an enum makes the unpaired combinations unrepresentable
+note: one of the blocks that assigns them together
+  --> $DIR/parallel_bools.rs:13:9
+   |
+LL |         self.done = false;
+   |         ^^^^^^^^^^^^^^^^^
+   = help: replace `done`, `running` with one enum field naming the states those blocks set; a combination no block writes then cannot exist
    = note: `#[warn(parallel_bools)]` on by default
 
 warning: 1 warning emitted

--- a/ui/parallel_bools.stderr
+++ b/ui/parallel_bools.stderr
@@ -1,15 +1,15 @@
-warning: the bool fields `done`, `running` of `Task` are always assigned together (2 blocks in 2 functions), so between them they hold one state that the struct lets fall out of step
+warning: `done` and `running` of `Task` are always assigned together (2 blocks in 2 functions). Together they hold one state, and the struct lets them drift apart
   --> $DIR/parallel_bools.rs:4:1
    |
 LL | struct Task {
    | ^^^^^^^^^^^
    |
-note: one of the blocks that assigns them together
+note: one of the blocks that sets both
   --> $DIR/parallel_bools.rs:13:9
    |
 LL |         self.done = false;
    |         ^^^^^^^^^^^^^^^^^
-   = help: replace `done`, `running` with one enum field naming the states those blocks set; a combination no block writes then cannot exist
+   = help: replace `done`, `running` with one enum field whose variants are the states those blocks set
    = note: `#[warn(parallel_bools)]` on by default
 
 warning: 1 warning emitted

--- a/ui/parallel_params.stderr
+++ b/ui/parallel_params.stderr
@@ -1,19 +1,29 @@
-warning: parameters `w: u32` and `h: u32` pass unchanged between `decode`, `scale` and `checksum` (`decode` hands them to `scale` in one call): one value travelling as 2 parameters
+warning: `w: u32` and `h: u32` are declared alike by `decode`, `scale` and `checksum` and handed between them unchanged, so they are one value that only exists as 2 loose parameters a caller can mix up or pass by halves
   --> $DIR/parallel_params.rs:5:23
    |
 LL | fn decode(src: &[u8], w: u32, h: u32) -> Vec<u8> {
    |                       ^^^^^^
    |
-   = help: a struct with these fields names the value; each function then takes, checks and forwards one parameter
+note: `decode` hands them to `scale` here
+  --> $DIR/parallel_params.rs:6:15
+   |
+LL |     let out = scale(src, w, h, 2);
+   |               ^^^^^^^^^^^^^^^^^^^
+   = help: declare a struct with fields `w` and `h` and make `decode`, `scale` and `checksum` take it as one parameter
    = note: `#[warn(parallel_params)]` on by default
 
-warning: parameters `host: &str`, `port: u16` and `tls: Tls` pass unchanged between `send`, `dial` and `log_target` (`send` hands them to `dial` in one call): one value travelling as 3 parameters
+warning: `host: &str`, `port: u16` and `tls: Tls` are declared alike by `send`, `dial` and `log_target` and handed between them unchanged, so they are one value that only exists as 3 loose parameters a caller can mix up or pass by halves
   --> $DIR/parallel_params.rs:37:20
    |
 LL |     fn send(&self, host: &str, port: u16, tls: Tls, sink: &mut Vec<String>) {
    |                    ^^^^^^^^^^
    |
-   = help: a struct with these fields names the value; each function then takes, checks and forwards one parameter
+note: `send` hands them to `dial` here
+  --> $DIR/parallel_params.rs:39:13
+   |
+LL |             self.dial(host, port, tls, &mut *sink);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: declare a struct with fields `host`, `port` and `tls` and make `send`, `dial` and `log_target` take it as one parameter
 
 warning: 2 warnings emitted
 

--- a/ui/parallel_params.stderr
+++ b/ui/parallel_params.stderr
@@ -1,4 +1,4 @@
-warning: `w: u32` and `h: u32` are declared alike by `decode`, `scale` and `checksum` and handed between them unchanged, so they are one value that only exists as 2 loose parameters a caller can mix up or pass by halves
+warning: `w: u32` and `h: u32` are declared the same way by `decode`, `scale` and `checksum` and passed between them unchanged. They are one value travelling as 2 loose parameters
   --> $DIR/parallel_params.rs:5:23
    |
 LL | fn decode(src: &[u8], w: u32, h: u32) -> Vec<u8> {
@@ -9,10 +9,10 @@ note: `decode` hands them to `scale` here
    |
 LL |     let out = scale(src, w, h, 2);
    |               ^^^^^^^^^^^^^^^^^^^
-   = help: declare a struct with fields `w` and `h` and make `decode`, `scale` and `checksum` take it as one parameter
+   = help: put `w` and `h` in a struct and pass that
    = note: `#[warn(parallel_params)]` on by default
 
-warning: `host: &str`, `port: u16` and `tls: Tls` are declared alike by `send`, `dial` and `log_target` and handed between them unchanged, so they are one value that only exists as 3 loose parameters a caller can mix up or pass by halves
+warning: `host: &str`, `port: u16` and `tls: Tls` are declared the same way by `send`, `dial` and `log_target` and passed between them unchanged. They are one value travelling as 3 loose parameters
   --> $DIR/parallel_params.rs:37:20
    |
 LL |     fn send(&self, host: &str, port: u16, tls: Tls, sink: &mut Vec<String>) {
@@ -23,7 +23,7 @@ note: `send` hands them to `dial` here
    |
 LL |             self.dial(host, port, tls, &mut *sink);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: declare a struct with fields `host`, `port` and `tls` and make `send`, `dial` and `log_target` take it as one parameter
+   = help: put `host`, `port` and `tls` in a struct and pass that
 
 warning: 2 warnings emitted
 

--- a/ui/parallel_vecs.stderr
+++ b/ui/parallel_vecs.stderr
@@ -1,27 +1,42 @@
-warning: parallel vecs: the fields `ages`, `names` of `People` only change length together (2 blocks) and are read at one index, so element `i` of each is one record kept in 2 places
+warning: `ages`, `names` of `People` only ever change length together (2 blocks) and are read at the same index, so element `i` of each is one record split across 2 vecs whose lengths the struct lets differ
   --> $DIR/parallel_vecs.rs:7:1
    |
 LL | struct People {
    | ^^^^^^^^^^^^^
    |
-   = help: one `Vec` of a struct with these fields holds the pairing in the type and cannot let the lengths differ
+note: one of the reads at a shared index
+  --> $DIR/parallel_vecs.rs:42:44
+   |
+LL |         format!("{} is {}", self.names[i], self.ages[i])
+   |                                            ^^^^^^^^^^^^
+   = help: replace the 2 fields with one `Vec` whose element struct has a field for each; then there is one length and one push
    = note: `#[warn(parallel_vecs)]` on by default
 
-warning: parallel vecs: the fields `keys`, `phases`, `values` of `Table` only change length together (1 block) and are read at one index, so element `i` of each is one record kept in 3 places
+warning: `keys`, `phases`, `values` of `Table` only ever change length together (1 block) and are read at the same index, so element `i` of each is one record split across 3 vecs whose lengths the struct lets differ
   --> $DIR/parallel_vecs.rs:54:1
    |
 LL | struct Table {
    | ^^^^^^^^^^^^
    |
-   = help: one `Vec` of a struct with these fields holds the pairing in the type and cannot let the lengths differ
+note: one of the reads at a shared index
+  --> $DIR/parallel_vecs.rs:67:19
+   |
+LL |     for (k, v) in t.keys.iter().zip(&t.values) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: replace the 3 fields with one `Vec` whose element struct has a field for each; then there is one length and one push
 
-warning: parallel vecs: the fields `items`, `locs` of `Tape` only change length together (2 blocks) and are read at one index, so element `i` of each is one record kept in 2 places
+warning: `items`, `locs` of `Tape` only ever change length together (2 blocks) and are read at the same index, so element `i` of each is one record split across 2 vecs whose lengths the struct lets differ
   --> $DIR/parallel_vecs.rs:73:1
    |
 LL | struct Tape {
    | ^^^^^^^^^^^
    |
-   = help: one `Vec` of a struct with these fields holds the pairing in the type and cannot let the lengths differ
+note: one of the reads at a shared index
+  --> $DIR/parallel_vecs.rs:89:49
+   |
+LL |         let n = self.tape.items[mark..].len() + self.tape.locs[mark..].len();
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^
+   = help: replace the 2 fields with one `Vec` whose element struct has a field for each; then there is one length and one push
 
 warning: 3 warnings emitted
 

--- a/ui/parallel_vecs.stderr
+++ b/ui/parallel_vecs.stderr
@@ -1,4 +1,4 @@
-warning: `ages`, `names` of `People` only ever change length together (2 blocks) and are read at the same index, so element `i` of each is one record split across 2 vecs whose lengths the struct lets differ
+warning: `ages` and `names` of `People` only change length together (2 blocks) and are read at the same index. Element `i` of each is one record split across 2 vecs
   --> $DIR/parallel_vecs.rs:7:1
    |
 LL | struct People {
@@ -9,10 +9,10 @@ note: one of the reads at a shared index
    |
 LL |         format!("{} is {}", self.names[i], self.ages[i])
    |                                            ^^^^^^^^^^^^
-   = help: replace the 2 fields with one `Vec` whose element struct has a field for each; then there is one length and one push
+   = help: use one `Vec` of a struct with a field for each. One length, one push
    = note: `#[warn(parallel_vecs)]` on by default
 
-warning: `keys`, `phases`, `values` of `Table` only ever change length together (1 block) and are read at the same index, so element `i` of each is one record split across 3 vecs whose lengths the struct lets differ
+warning: `keys`, `phases` and `values` of `Table` only change length together (1 block) and are read at the same index. Element `i` of each is one record split across 3 vecs
   --> $DIR/parallel_vecs.rs:54:1
    |
 LL | struct Table {
@@ -23,9 +23,9 @@ note: one of the reads at a shared index
    |
 LL |     for (k, v) in t.keys.iter().zip(&t.values) {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: replace the 3 fields with one `Vec` whose element struct has a field for each; then there is one length and one push
+   = help: use one `Vec` of a struct with a field for each. One length, one push
 
-warning: `items`, `locs` of `Tape` only ever change length together (2 blocks) and are read at the same index, so element `i` of each is one record split across 2 vecs whose lengths the struct lets differ
+warning: `items` and `locs` of `Tape` only change length together (2 blocks) and are read at the same index. Element `i` of each is one record split across 2 vecs
   --> $DIR/parallel_vecs.rs:73:1
    |
 LL | struct Tape {
@@ -36,7 +36,7 @@ note: one of the reads at a shared index
    |
 LL |         let n = self.tape.items[mark..].len() + self.tape.locs[mark..].len();
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^
-   = help: replace the 2 fields with one `Vec` whose element struct has a field for each; then there is one length and one push
+   = help: use one `Vec` of a struct with a field for each. One length, one push
 
 warning: 3 warnings emitted
 

--- a/ui/param_wider_than_callers.stderr
+++ b/ui/param_wider_than_callers.stderr
@@ -1,22 +1,22 @@
-warning: this catch-all also matches any variant added to `Shape` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Shape` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/param_wider_than_callers.rs:34:9
    |
 LL |         _ => unreachable!("only circles have diameters"),
    |         ^
    |
-note: `Shape`, whose new variants would fall into this arm
+note: `Shape` is defined here
   --> $DIR/param_wider_than_callers.rs:4:1
    |
 LL | enum Shape {
    | ^^^^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Shape` grows
+help: list the remaining variants instead of `_`
    |
 LL -         _ => unreachable!("only circles have diameters"),
 LL +         Shape::Square(..) | Shape::Line => unreachable!("only circles have diameters"),
    |
 
-warning: this arm panics on `Line`, but all 2 calls to `area` pass only `Circle`, `Square`, so the panic guards a case the parameter type allows and no caller uses
+warning: this arm panics on `Line`, but all 2 calls to `area` pass only `Circle`, `Square`. The parameter type allows a case no caller uses
   --> $DIR/param_wider_than_callers.rs:16:9
    |
 LL |         Shape::Line => unreachable!("lines have no area"),
@@ -27,10 +27,10 @@ note: one of the calls
    |
 LL |     let _ = area(Shape::Circle(2));
    |                  ^^^^^^^^^^^^^^^^
-   = help: narrow `area`'s parameter to a type that cannot be `Line` (a smaller enum, or the payload itself); a future caller passing `Line` then fails to compile instead of panicking
+   = help: narrow `area`'s parameter to a type that cannot be `Line`, such as a smaller enum or the payload itself. A caller passing `Line` then fails to compile
    = note: `#[warn(param_wider_than_callers)]` on by default
 
-warning: this arm panics on `Line`, but all 2 calls to `corners` pass only `Circle`, `Square`, so the panic guards a case the parameter type allows and no caller uses
+warning: this arm panics on `Line`, but all 2 calls to `corners` pass only `Circle`, `Square`. The parameter type allows a case no caller uses
   --> $DIR/param_wider_than_callers.rs:58:13
    |
 LL |             Shape::Line => unreachable!("lines have no corners"),
@@ -41,7 +41,7 @@ note: one of the calls
    |
 LL |     let _ = Shape::Circle(1).corners();
    |             ^^^^^^^^^^^^^^^^
-   = help: narrow `corners`'s parameter to a type that cannot be `Line` (a smaller enum, or the payload itself); a future caller passing `Line` then fails to compile instead of panicking
+   = help: narrow `corners`'s parameter to a type that cannot be `Line`, such as a smaller enum or the payload itself. A caller passing `Line` then fails to compile
 
 warning: 3 warnings emitted
 

--- a/ui/param_wider_than_callers.stderr
+++ b/ui/param_wider_than_callers.stderr
@@ -1,32 +1,47 @@
-warning: this arm absorbs every future variant of `Shape` (3 variants today)
+warning: this catch-all also matches any variant added to `Shape` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/param_wider_than_callers.rs:34:9
    |
 LL |         _ => unreachable!("only circles have diameters"),
    |         ^
    |
+note: `Shape`, whose new variants would fall into this arm
+  --> $DIR/param_wider_than_callers.rs:4:1
+   |
+LL | enum Shape {
+   | ^^^^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: list the remaining variants; the compiler then flags every new one added
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Shape` grows
    |
 LL -         _ => unreachable!("only circles have diameters"),
 LL +         Shape::Square(..) | Shape::Line => unreachable!("only circles have diameters"),
    |
 
-warning: all 2 call sites of `area` pass `Circle`, `Square`; this arm panics on `Line`, which no existing caller sends
+warning: this arm panics on `Line`, but all 2 calls to `area` pass only `Circle`, `Square`, so the panic guards a case the parameter type allows and no caller uses
   --> $DIR/param_wider_than_callers.rs:16:9
    |
 LL |         Shape::Line => unreachable!("lines have no area"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the parameter is wider than the function's domain; narrow the type and the panic becomes a compile error for future callers
+note: one of the calls
+  --> $DIR/param_wider_than_callers.rs:74:18
+   |
+LL |     let _ = area(Shape::Circle(2));
+   |                  ^^^^^^^^^^^^^^^^
+   = help: narrow `area`'s parameter to a type that cannot be `Line` (a smaller enum, or the payload itself); a future caller passing `Line` then fails to compile instead of panicking
    = note: `#[warn(param_wider_than_callers)]` on by default
 
-warning: all 2 call sites of `corners` pass `Circle`, `Square`; this arm panics on `Line`, which no existing caller sends
+warning: this arm panics on `Line`, but all 2 calls to `corners` pass only `Circle`, `Square`, so the panic guards a case the parameter type allows and no caller uses
   --> $DIR/param_wider_than_callers.rs:58:13
    |
 LL |             Shape::Line => unreachable!("lines have no corners"),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the parameter is wider than the function's domain; narrow the type and the panic becomes a compile error for future callers
+note: one of the calls
+  --> $DIR/param_wider_than_callers.rs:81:13
+   |
+LL |     let _ = Shape::Circle(1).corners();
+   |             ^^^^^^^^^^^^^^^^
+   = help: narrow `corners`'s parameter to a type that cannot be `Line` (a smaller enum, or the payload itself); a future caller passing `Line` then fails to compile instead of panicking
 
 warning: 3 warnings emitted
 

--- a/ui/reimplemented_helper.stderr
+++ b/ui/reimplemented_helper.stderr
@@ -1,42 +1,42 @@
-warning: `bounded_sum` has the same signature and body as `clamp_add`
+warning: `bounded_sum` has the same signature and, up to renamed locals, the same body as `clamp_add`, so one helper exists twice and a fix to either silently misses the other
   --> $DIR/reimplemented_helper.rs:10:1
    |
 LL | pub fn bounded_sum(a: u32, b: u32, max: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the same body is here
+note: `clamp_add`, the other copy
   --> $DIR/reimplemented_helper.rs:4:1
    |
 LL | pub fn clamp_add(base: u32, delta: u32, limit: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: one helper written twice drifts apart at the first fix; keep one and call it from the other's callers
+   = help: delete `bounded_sum` and call `clamp_add` from its callers (or the reverse)
    = note: `#[warn(reimplemented_helper)]` on by default
 
-warning: `Row::footprint` has the same signature and body as `Row::extent`
+warning: `Row::footprint` has the same signature and, up to renamed locals, the same body as `Row::extent`, so one helper exists twice and a fix to either silently misses the other
   --> $DIR/reimplemented_helper.rs:43:5
    |
 LL |     pub fn footprint(&self) -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the same body is here
+note: `Row::extent`, the other copy
   --> $DIR/reimplemented_helper.rs:38:5
    |
 LL |     pub fn extent(&self) -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: one helper written twice drifts apart at the first fix; keep one and call it from the other's callers
+   = help: delete `Row::footprint` and call `Row::extent` from its callers (or the reverse)
 
-warning: `first_third` has the same signature and body as `low_third`
+warning: `first_third` has the same signature and, up to renamed locals, the same body as `low_third`, so one helper exists twice and a fix to either silently misses the other
   --> $DIR/reimplemented_helper.rs:105:1
    |
 LL | pub fn first_third((first, _): (u32, u32), k: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the same body is here
+note: `low_third`, the other copy
   --> $DIR/reimplemented_helper.rs:92:1
    |
 LL | pub fn low_third((lo, _): (u32, u32), bias: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: one helper written twice drifts apart at the first fix; keep one and call it from the other's callers
+   = help: delete `first_third` and call `low_third` from its callers (or the reverse)
 
 warning: 3 warnings emitted
 

--- a/ui/reimplemented_helper.stderr
+++ b/ui/reimplemented_helper.stderr
@@ -1,4 +1,4 @@
-warning: `bounded_sum` has the same signature and, up to renamed locals, the same body as `clamp_add`, so one helper exists twice and a fix to either silently misses the other
+warning: `bounded_sum` has the same signature and the same body as `clamp_add`, apart from local names. A fix to one will miss the other
   --> $DIR/reimplemented_helper.rs:10:1
    |
 LL | pub fn bounded_sum(a: u32, b: u32, max: u32) -> u32 {
@@ -9,10 +9,10 @@ note: `clamp_add`, the other copy
    |
 LL | pub fn clamp_add(base: u32, delta: u32, limit: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: delete `bounded_sum` and call `clamp_add` from its callers (or the reverse)
+   = help: delete `bounded_sum` and call `clamp_add` instead, or the other way round
    = note: `#[warn(reimplemented_helper)]` on by default
 
-warning: `Row::footprint` has the same signature and, up to renamed locals, the same body as `Row::extent`, so one helper exists twice and a fix to either silently misses the other
+warning: `Row::footprint` has the same signature and the same body as `Row::extent`, apart from local names. A fix to one will miss the other
   --> $DIR/reimplemented_helper.rs:43:5
    |
 LL |     pub fn footprint(&self) -> u32 {
@@ -23,9 +23,9 @@ note: `Row::extent`, the other copy
    |
 LL |     pub fn extent(&self) -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: delete `Row::footprint` and call `Row::extent` from its callers (or the reverse)
+   = help: delete `Row::footprint` and call `Row::extent` instead, or the other way round
 
-warning: `first_third` has the same signature and, up to renamed locals, the same body as `low_third`, so one helper exists twice and a fix to either silently misses the other
+warning: `first_third` has the same signature and the same body as `low_third`, apart from local names. A fix to one will miss the other
   --> $DIR/reimplemented_helper.rs:105:1
    |
 LL | pub fn first_third((first, _): (u32, u32), k: u32) -> u32 {
@@ -36,7 +36,7 @@ note: `low_third`, the other copy
    |
 LL | pub fn low_third((lo, _): (u32, u32), bias: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: delete `first_third` and call `low_third` from its callers (or the reverse)
+   = help: delete `first_third` and call `low_third` instead, or the other way round
 
 warning: 3 warnings emitted
 

--- a/ui/return_wider_than_body.stderr
+++ b/ui/return_wider_than_body.stderr
@@ -1,31 +1,46 @@
-warning: this arm absorbs every future variant of `Token` (3 variants today)
+warning: this catch-all also matches any variant added to `Token` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/return_wider_than_body.rs:63:9
    |
 LL |         other => other,
    |         ^^^^^
    |
+note: `Token`, whose new variants would fall into this arm
+  --> $DIR/return_wider_than_body.rs:4:1
+   |
+LL | enum Token {
+   | ^^^^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: list the remaining variants; the compiler then flags every new one added
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Token` grows
    |
 LL |         other @ (Token::Space | Token::Eof) => other,
    |               +++++++++++++++++++++++++++++
 
-warning: `next_token` only ever returns `Space`, `Word`; this arm panics on `Eof`, which it never constructs
+warning: this arm panics on `Eof`, but `next_token` only ever returns `Space`, `Word`, so the arm exists only because `next_token`'s return type `Token` is wider than what it produces
   --> $DIR/return_wider_than_body.rs:26:9
    |
 LL |         Token::Eof => unreachable!("the tokenizer never yields Eof here"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the return type promises more than the function delivers; narrow it and this arm becomes unnecessary at compile time
+note: `next_token`, declared to return any `Token`
+  --> $DIR/return_wider_than_body.rs:11:1
+   |
+LL | fn next_token(n: u32) -> Token {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: give `next_token` a return type without `Eof` (a smaller enum, or a struct for the one shape); this arm then cannot be written
    = note: `#[warn(return_wider_than_body)]` on by default
 
-warning: `via_local` only ever returns `Space`, `Word`; this arm panics on `Eof`, which it never constructs
+warning: this arm panics on `Eof`, but `via_local` only ever returns `Space`, `Word`, so the arm exists only because `via_local`'s return type `Token` is wider than what it produces
   --> $DIR/return_wider_than_body.rs:41:9
    |
 LL |         Token::Eof => unreachable!("never yielded by via_local"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the return type promises more than the function delivers; narrow it and this arm becomes unnecessary at compile time
+note: `via_local`, declared to return any `Token`
+  --> $DIR/return_wider_than_body.rs:32:1
+   |
+LL | fn via_local(n: u32) -> Token {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: give `via_local` a return type without `Eof` (a smaller enum, or a struct for the one shape); this arm then cannot be written
 
 warning: 3 warnings emitted
 

--- a/ui/return_wider_than_body.stderr
+++ b/ui/return_wider_than_body.stderr
@@ -1,46 +1,46 @@
-warning: this catch-all also matches any variant added to `Token` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Token` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/return_wider_than_body.rs:63:9
    |
 LL |         other => other,
    |         ^^^^^
    |
-note: `Token`, whose new variants would fall into this arm
+note: `Token` is defined here
   --> $DIR/return_wider_than_body.rs:4:1
    |
 LL | enum Token {
    | ^^^^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Token` grows
+help: list the remaining variants instead of `other`
    |
 LL |         other @ (Token::Space | Token::Eof) => other,
    |               +++++++++++++++++++++++++++++
 
-warning: this arm panics on `Eof`, but `next_token` only ever returns `Space`, `Word`, so the arm exists only because `next_token`'s return type `Token` is wider than what it produces
+warning: this arm panics on `Eof`, but `next_token` only ever returns `Space`, `Word`. The return type `Token` is wider than what the function produces
   --> $DIR/return_wider_than_body.rs:26:9
    |
 LL |         Token::Eof => unreachable!("the tokenizer never yields Eof here"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `next_token`, declared to return any `Token`
+note: `next_token`'s signature
   --> $DIR/return_wider_than_body.rs:11:1
    |
 LL | fn next_token(n: u32) -> Token {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: give `next_token` a return type without `Eof` (a smaller enum, or a struct for the one shape); this arm then cannot be written
+   = help: give `next_token` a return type without `Eof`. This arm then cannot be written
    = note: `#[warn(return_wider_than_body)]` on by default
 
-warning: this arm panics on `Eof`, but `via_local` only ever returns `Space`, `Word`, so the arm exists only because `via_local`'s return type `Token` is wider than what it produces
+warning: this arm panics on `Eof`, but `via_local` only ever returns `Space`, `Word`. The return type `Token` is wider than what the function produces
   --> $DIR/return_wider_than_body.rs:41:9
    |
 LL |         Token::Eof => unreachable!("never yielded by via_local"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: `via_local`, declared to return any `Token`
+note: `via_local`'s signature
   --> $DIR/return_wider_than_body.rs:32:1
    |
 LL | fn via_local(n: u32) -> Token {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: give `via_local` a return type without `Eof` (a smaller enum, or a struct for the one shape); this arm then cannot be written
+   = help: give `via_local` a return type without `Eof`. This arm then cannot be written
 
 warning: 3 warnings emitted
 

--- a/ui/runtime_typestate.stderr
+++ b/ui/runtime_typestate.stderr
@@ -1,10 +1,15 @@
-warning: `ready` is tested and bailed on at the start of 2 methods of `Conn`
+warning: 2 methods of `Conn` start by testing `ready` and returning early, so whether they may be called yet is decided at runtime, method by method
   --> $DIR/runtime_typestate.rs:5:5
    |
 LL |     ready: bool,
    |     ^^^^^^^^^^^
    |
-   = help: the ordering invariant lives at runtime; a separate type for the guarded state enforces it at compile time
+note: the test at the top of one of those methods
+  --> $DIR/runtime_typestate.rs:11:12
+   |
+LL |         if !self.ready {
+   |            ^^^^^^^^^^^
+   = help: split `Conn` into one type per state and put those 2 methods only on the type where `ready` allows them; calling one too early is then a compile error
    = note: `#[warn(runtime_typestate)]` on by default
 
 warning: 1 warning emitted

--- a/ui/runtime_typestate.stderr
+++ b/ui/runtime_typestate.stderr
@@ -1,15 +1,15 @@
-warning: 2 methods of `Conn` start by testing `ready` and returning early, so whether they may be called yet is decided at runtime, method by method
+warning: 2 methods of `Conn` begin by testing `ready` and returning early. Whether they may be called yet is checked at runtime, one method at a time
   --> $DIR/runtime_typestate.rs:5:5
    |
 LL |     ready: bool,
    |     ^^^^^^^^^^^
    |
-note: the test at the top of one of those methods
+note: the test at the top of one of them
   --> $DIR/runtime_typestate.rs:11:12
    |
 LL |         if !self.ready {
    |            ^^^^^^^^^^^
-   = help: split `Conn` into one type per state and put those 2 methods only on the type where `ready` allows them; calling one too early is then a compile error
+   = help: split `Conn` into a type per state and put those 2 methods only on the one `ready` allows. Calling them too early becomes a compile error
    = note: `#[warn(runtime_typestate)]` on by default
 
 warning: 1 warning emitted

--- a/ui/same_match_twice.stderr
+++ b/ui/same_match_twice.stderr
@@ -1,4 +1,4 @@
-warning: this `match` on `Step` is written out arm for arm a second time
+warning: this `match` on `Step` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
   --> $DIR/same_match_twice.rs:31:10
    |
 LL |       Some(match cause.step {
@@ -9,7 +9,7 @@ LL | |         Step::Parse => (cause.code + 2, "parse"),
 LL | |     })
    | |_____^
    |
-note: the same match is here
+note: the other copy
   --> $DIR/same_match_twice.rs:18:5
    |
 LL | /     match f.step {
@@ -18,10 +18,10 @@ LL | |         Step::Read => (f.code + 1, "read"),
 LL | |         Step::Parse => (f.code + 2, "parse"),
 LL | |     }
    | |_____^
-   = help: the mapping lives in two places kept in step by hand; a method on the enum states it once
+   = help: move the mapping into a method on `Step` and call it from both places
    = note: `#[warn(same_match_twice)]` on by default
 
-warning: this `match` on `Step` is written out arm for arm a second time
+warning: this `match` on `Step` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
   --> $DIR/same_match_twice.rs:41:13
    |
 LL |       let d = match f.step {
@@ -32,7 +32,7 @@ LL | |         Step::Parse => (f.code + 2, "parse"),
 LL | |     };
    | |_____^
    |
-note: the same match is here
+note: the other copy
   --> $DIR/same_match_twice.rs:18:5
    |
 LL | /     match f.step {
@@ -41,9 +41,9 @@ LL | |         Step::Read => (f.code + 1, "read"),
 LL | |         Step::Parse => (f.code + 2, "parse"),
 LL | |     }
    | |_____^
-   = help: the mapping lives in two places kept in step by hand; a method on the enum states it once
+   = help: move the mapping into a method on `Step` and call it from both places
 
-warning: this `match` on `Shape` is written out arm for arm a second time
+warning: this `match` on `Shape` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
   --> $DIR/same_match_twice.rs:186:17
    |
 LL |       let cells = match shape {
@@ -56,7 +56,7 @@ LL | |         },
 LL | |     };
    | |_____^
    |
-note: the same match is here
+note: the other copy
   --> $DIR/same_match_twice.rs:173:5
    |
 LL | /     match s {
@@ -67,9 +67,9 @@ LL | |         Shape::Rect(w, h) => match (w, h) {
 LL | |         },
 LL | |     }
    | |_____^
-   = help: the mapping lives in two places kept in step by hand; a method on the enum states it once
+   = help: move the mapping into a method on `Shape` and call it from both places
 
-warning: this `match` on `Axis` is written out arm for arm a second time
+warning: this `match` on `Axis` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
   --> $DIR/same_match_twice.rs:218:15
    |
 LL |       let far = match axis {
@@ -79,7 +79,7 @@ LL | |         Axis::Down => h + 1,
 LL | |     };
    | |_____^
    |
-note: the same match is here
+note: the other copy
   --> $DIR/same_match_twice.rs:214:16
    |
 LL |       let near = match axis {
@@ -88,7 +88,7 @@ LL | |         Axis::Across => w,
 LL | |         Axis::Down => h + 1,
 LL | |     };
    | |_____^
-   = help: the mapping lives in two places kept in step by hand; a method on the enum states it once
+   = help: move the mapping into a method on `Axis` and call it from both places
 
 warning: 4 warnings emitted
 

--- a/ui/same_match_twice.stderr
+++ b/ui/same_match_twice.stderr
@@ -1,4 +1,4 @@
-warning: this `match` on `Step` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
+warning: this `match` on `Step` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other
   --> $DIR/same_match_twice.rs:31:10
    |
 LL |       Some(match cause.step {
@@ -21,7 +21,7 @@ LL | |     }
    = help: move the mapping into a method on `Step` and call it from both places
    = note: `#[warn(same_match_twice)]` on by default
 
-warning: this `match` on `Step` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
+warning: this `match` on `Step` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other
   --> $DIR/same_match_twice.rs:41:13
    |
 LL |       let d = match f.step {
@@ -43,7 +43,7 @@ LL | |     }
    | |_____^
    = help: move the mapping into a method on `Step` and call it from both places
 
-warning: this `match` on `Shape` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
+warning: this `match` on `Shape` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other
   --> $DIR/same_match_twice.rs:186:17
    |
 LL |       let cells = match shape {
@@ -69,7 +69,7 @@ LL | |     }
    | |_____^
    = help: move the mapping into a method on `Shape` and call it from both places
 
-warning: this `match` on `Axis` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
+warning: this `match` on `Axis` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other
   --> $DIR/same_match_twice.rs:218:15
    |
 LL |       let far = match axis {

--- a/ui/sentinel_integer.stderr
+++ b/ui/sentinel_integer.stderr
@@ -1,68 +1,68 @@
-warning: `Entry.slot` can be `INVALID_SLOT`, which 2 other places in the crate test for as "no value", but `rename` indexes with it here without any such test, so the sentinel becomes an out-of-range index
+warning: `Entry.slot` can be `INVALID_SLOT`, which 2 other places treat as "no value". `rename` indexes with it here without checking, so the sentinel becomes an out-of-range index
   --> $DIR/sentinel_integer.rs:34:9
    |
 LL |         self.names[e.slot as usize] = to;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the places that treats `INVALID_SLOT` as "no value"
+note: one of the places that checks for `INVALID_SLOT`
   --> $DIR/sentinel_integer.rs:25:12
    |
 LL |         if e.slot == INVALID_SLOT {
    |            ^^^^^^^^^^^^^^^^^^^^^^
-   = help: store `slot` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `rename` has to decide the empty case before it can use the number
+   = help: store `slot` as an `Option` (over `NonZero` or `NonMax` to keep the size). `rename` then has to handle the empty case before it can index
    = note: `#[warn(sentinel_integer)]` on by default
 
-warning: `Entry.slot` can be `INVALID_SLOT`, which 2 other places in the crate test for as "no value", but `name_after` indexes with it here without any such test, so the sentinel becomes an out-of-range index
+warning: `Entry.slot` can be `INVALID_SLOT`, which 2 other places treat as "no value". `name_after` indexes with it here without checking, so the sentinel becomes an out-of-range index
   --> $DIR/sentinel_integer.rs:68:9
    |
 LL |         self.names[e.width as usize + e.slot as usize]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the places that treats `INVALID_SLOT` as "no value"
+note: one of the places that checks for `INVALID_SLOT`
   --> $DIR/sentinel_integer.rs:25:12
    |
 LL |         if e.slot == INVALID_SLOT {
    |            ^^^^^^^^^^^^^^^^^^^^^^
-   = help: store `slot` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `name_after` has to decide the empty case before it can use the number
+   = help: store `slot` as an `Option` (over `NonZero` or `NonMax` to keep the size). `name_after` then has to handle the empty case before it can index
 
-warning: `Entry.parent` can be `u32::MAX`, which 3 other places in the crate test for as "no value", but `parent_ptr` offsets a pointer by it here without any such test, so the sentinel becomes a wild offset
+warning: `Entry.parent` can be `u32::MAX`, which 3 other places treat as "no value". `parent_ptr` offsets a pointer by it here without checking, so the sentinel becomes a wild offset
   --> $DIR/sentinel_integer.rs:82:18
    |
 LL |         unsafe { self.entries.as_ptr().add(e.parent as usize) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the places that treats `u32::MAX` as "no value"
+note: one of the places that checks for `u32::MAX`
   --> $DIR/sentinel_integer.rs:76:9
    |
 LL |         e.parent == u32::MAX
    |         ^^^^^^^^^^^^^^^^^^^^
-   = help: store `parent` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `parent_ptr` has to decide the empty case before it can use the number
+   = help: store `parent` as an `Option` (over `NonZero` or `NonMax` to keep the size). `parent_ptr` then has to handle the empty case before it can offset
 
-warning: `Entry.parent` can be `u32::MAX`, which 3 other places in the crate test for as "no value", but `parent_ptr_wrapping` offsets a pointer by it here without any such test, so the sentinel becomes a wild offset
+warning: `Entry.parent` can be `u32::MAX`, which 3 other places treat as "no value". `parent_ptr_wrapping` offsets a pointer by it here without checking, so the sentinel becomes a wild offset
   --> $DIR/sentinel_integer.rs:87:9
    |
 LL |         self.entries.as_ptr().wrapping_add(e.parent as usize)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the places that treats `u32::MAX` as "no value"
+note: one of the places that checks for `u32::MAX`
   --> $DIR/sentinel_integer.rs:76:9
    |
 LL |         e.parent == u32::MAX
    |         ^^^^^^^^^^^^^^^^^^^^
-   = help: store `parent` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `parent_ptr_wrapping` has to decide the empty case before it can use the number
+   = help: store `parent` as an `Option` (over `NonZero` or `NonMax` to keep the size). `parent_ptr_wrapping` then has to handle the empty case before it can offset
 
-warning: `Entry.depth` can be `-1`, which 2 other places in the crate test for as "no value", but `below` indexes with it here without any such test, so the sentinel becomes an out-of-range index
+warning: `Entry.depth` can be `-1`, which 2 other places treat as "no value". `below` indexes with it here without checking, so the sentinel becomes an out-of-range index
   --> $DIR/sentinel_integer.rs:133:10
    |
 LL |         &self.entries[(e.depth + 1) as usize]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the places that treats `-1` as "no value"
+note: one of the places that checks for `-1`
   --> $DIR/sentinel_integer.rs:124:9
    |
 LL |         e.depth != -1
    |         ^^^^^^^^^^^^^
-   = help: store `depth` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `below` has to decide the empty case before it can use the number
+   = help: store `depth` as an `Option` (over `NonZero` or `NonMax` to keep the size). `below` then has to handle the empty case before it can index
 
 warning: 5 warnings emitted
 

--- a/ui/sentinel_integer.stderr
+++ b/ui/sentinel_integer.stderr
@@ -1,43 +1,68 @@
-warning: sentinel `INVALID_SLOT` can reach this use: `rename` indexes with `Entry.slot` and nothing in it tests the field, which the crate compares against that sentinel at 2 other sites
+warning: `Entry.slot` can be `INVALID_SLOT`, which 2 other places in the crate test for as "no value", but `rename` indexes with it here without any such test, so the sentinel becomes an out-of-range index
   --> $DIR/sentinel_integer.rs:34:9
    |
 LL |         self.names[e.slot as usize] = to;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the field's value set is `Option<int>`; store that (a `NonZero`/`NonMax` niche keeps the size) and no reader can index without deciding the empty case
+note: one of the places that treats `INVALID_SLOT` as "no value"
+  --> $DIR/sentinel_integer.rs:25:12
+   |
+LL |         if e.slot == INVALID_SLOT {
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   = help: store `slot` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `rename` has to decide the empty case before it can use the number
    = note: `#[warn(sentinel_integer)]` on by default
 
-warning: sentinel `INVALID_SLOT` can reach this use: `name_after` indexes with `Entry.slot` and nothing in it tests the field, which the crate compares against that sentinel at 2 other sites
+warning: `Entry.slot` can be `INVALID_SLOT`, which 2 other places in the crate test for as "no value", but `name_after` indexes with it here without any such test, so the sentinel becomes an out-of-range index
   --> $DIR/sentinel_integer.rs:68:9
    |
 LL |         self.names[e.width as usize + e.slot as usize]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the field's value set is `Option<int>`; store that (a `NonZero`/`NonMax` niche keeps the size) and no reader can index without deciding the empty case
+note: one of the places that treats `INVALID_SLOT` as "no value"
+  --> $DIR/sentinel_integer.rs:25:12
+   |
+LL |         if e.slot == INVALID_SLOT {
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   = help: store `slot` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `name_after` has to decide the empty case before it can use the number
 
-warning: sentinel `u32::MAX` can reach this use: `parent_ptr` offsets a pointer by `Entry.parent` and nothing in it tests the field, which the crate compares against that sentinel at 3 other sites
+warning: `Entry.parent` can be `u32::MAX`, which 3 other places in the crate test for as "no value", but `parent_ptr` offsets a pointer by it here without any such test, so the sentinel becomes a wild offset
   --> $DIR/sentinel_integer.rs:82:18
    |
 LL |         unsafe { self.entries.as_ptr().add(e.parent as usize) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the field's value set is `Option<int>`; store that (a `NonZero`/`NonMax` niche keeps the size) and no reader can index without deciding the empty case
+note: one of the places that treats `u32::MAX` as "no value"
+  --> $DIR/sentinel_integer.rs:76:9
+   |
+LL |         e.parent == u32::MAX
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = help: store `parent` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `parent_ptr` has to decide the empty case before it can use the number
 
-warning: sentinel `u32::MAX` can reach this use: `parent_ptr_wrapping` offsets a pointer by `Entry.parent` and nothing in it tests the field, which the crate compares against that sentinel at 3 other sites
+warning: `Entry.parent` can be `u32::MAX`, which 3 other places in the crate test for as "no value", but `parent_ptr_wrapping` offsets a pointer by it here without any such test, so the sentinel becomes a wild offset
   --> $DIR/sentinel_integer.rs:87:9
    |
 LL |         self.entries.as_ptr().wrapping_add(e.parent as usize)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the field's value set is `Option<int>`; store that (a `NonZero`/`NonMax` niche keeps the size) and no reader can index without deciding the empty case
+note: one of the places that treats `u32::MAX` as "no value"
+  --> $DIR/sentinel_integer.rs:76:9
+   |
+LL |         e.parent == u32::MAX
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = help: store `parent` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `parent_ptr_wrapping` has to decide the empty case before it can use the number
 
-warning: sentinel `-1` can reach this use: `below` indexes with `Entry.depth` and nothing in it tests the field, which the crate compares against that sentinel at 2 other sites
+warning: `Entry.depth` can be `-1`, which 2 other places in the crate test for as "no value", but `below` indexes with it here without any such test, so the sentinel becomes an out-of-range index
   --> $DIR/sentinel_integer.rs:133:10
    |
 LL |         &self.entries[(e.depth + 1) as usize]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the field's value set is `Option<int>`; store that (a `NonZero`/`NonMax` niche keeps the size) and no reader can index without deciding the empty case
+note: one of the places that treats `-1` as "no value"
+  --> $DIR/sentinel_integer.rs:124:9
+   |
+LL |         e.depth != -1
+   |         ^^^^^^^^^^^^^
+   = help: store `depth` as an `Option` (over a `NonZero`/`NonMax` type to keep the size), so `below` has to decide the empty case before it can use the number
 
 warning: 5 warnings emitted
 

--- a/ui/some_still_unchecked.stderr
+++ b/ui/some_still_unchecked.stderr
@@ -1,57 +1,57 @@
-warning: a `Some` that fails `j.ready` is handled as if it were `None`
+warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
   --> $DIR/some_still_unchecked.rs:28:9
    |
 LL |         Some(j) if j.ready => j.id,
    |         ^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, handled like `None`
+note: the failing `Some` lands here, together with `None`
   --> $DIR/some_still_unchecked.rs:29:9
    |
 LL |         _ => wait(),
    |         ^
-   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
    = note: `#[warn(some_still_unchecked)]` on by default
 
-warning: a `Some` that fails `j.ready` is handled as if it were `None`
+warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
   --> $DIR/some_still_unchecked.rs:38:9
    |
 LL |         Some(j) if j.ready => j.id,
    |         ^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, handled like `None`
+note: the failing `Some` lands here, together with `None`
   --> $DIR/some_still_unchecked.rs:39:9
    |
 LL |         Some(_) => wait(),
    |         ^^^^^^^
-   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
 
-warning: a `Some` that fails `j.ready && j.id > 0` is handled as if it were `None`
+warning: a `Some` that fails `j.ready && j.id > 0` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
   --> $DIR/some_still_unchecked.rs:46:9
    |
 LL |         Some(j) if j.ready && j.id > 0 => j.id,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, handled like `None`
+note: the failing `Some` lands here, together with `None`
   --> $DIR/some_still_unchecked.rs:47:9
    |
 LL |         Some(_) | None => wait(),
    |         ^^^^^^^^^^^^^^
-   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+   = help: make whatever produces `next()` reject values failing `j.ready && j.id > 0` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
 
-warning: an `Ok` that fails `n > 2` is handled as if it were `Err`
+warning: an `Ok` that fails `n > 2` is handled exactly like `Err` here, so `Ok` alone does not mean usable and every other consumer of this value has to repeat the check
   --> $DIR/some_still_unchecked.rs:54:9
    |
 LL |         Ok(n) if n > 2 => n,
    |         ^^^^^^^^^^^^^^
    |
-note: the failing `Ok` lands here, handled like `Err`
+note: the failing `Ok` lands here, together with `Err`
   --> $DIR/some_still_unchecked.rs:55:9
    |
 LL |         Err(_) | Ok(_) => wait(),
    |         ^^^^^^^^^^^^^^
-   = help: reject where the value is produced (an error for this case, or a type whose `Ok` is always valid) so `Ok` needs no second check here
+   = help: make whatever produces `parse()` reject values failing `n > 2` (an error for that case, or a payload type that cannot fail it), so an `Ok` reaching here needs no second check
 
-warning: a `Some` that fails `j.ready` is handled as if it were `None`
+warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
   --> $DIR/some_still_unchecked.rs:61:8
    |
 LL |       if let Some(j) = next()
@@ -59,7 +59,7 @@ LL |       if let Some(j) = next()
 LL | |         && j.ready
    | |__________________^
    |
-note: the failing `Some` lands here, handled like `None`
+note: the failing `Some` lands here, together with `None`
   --> $DIR/some_still_unchecked.rs:65:12
    |
 LL |       } else {
@@ -67,20 +67,20 @@ LL |       } else {
 LL | |         wait()
 LL | |     }
    | |_____^
-   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
 
-warning: a `Some` that fails `j.ready` is handled as if it were `None`
+warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
   --> $DIR/some_still_unchecked.rs:72:8
    |
 LL |     if let Some(j) = next() {
    |        ^^^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, handled like `None`
+note: the failing `Some` lands here, together with `None`
   --> $DIR/some_still_unchecked.rs:73:34
    |
 LL |         if j.ready { j.id } else { wait() + 1 }
    |                                  ^^^^^^^^^^^^^^
-   = help: filter where the value is produced (`.filter(..)`, or a type whose `Some` is always valid) so `Some` needs no second check here
+   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
 
 warning: 6 warnings emitted
 

--- a/ui/some_still_unchecked.stderr
+++ b/ui/some_still_unchecked.stderr
@@ -1,57 +1,57 @@
-warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
+warning: a `Some` that fails `j.ready` is treated exactly like `None` here. `Some` alone does not mean usable, and every consumer has to repeat the check
   --> $DIR/some_still_unchecked.rs:28:9
    |
 LL |         Some(j) if j.ready => j.id,
    |         ^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, together with `None`
+note: the failing `Some` ends up here, with `None`
   --> $DIR/some_still_unchecked.rs:29:9
    |
 LL |         _ => wait(),
    |         ^
-   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
+   = help: filter where `next()` is produced, with `.filter(..)` or a payload type that cannot fail `j.ready`
    = note: `#[warn(some_still_unchecked)]` on by default
 
-warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
+warning: a `Some` that fails `j.ready` is treated exactly like `None` here. `Some` alone does not mean usable, and every consumer has to repeat the check
   --> $DIR/some_still_unchecked.rs:38:9
    |
 LL |         Some(j) if j.ready => j.id,
    |         ^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, together with `None`
+note: the failing `Some` ends up here, with `None`
   --> $DIR/some_still_unchecked.rs:39:9
    |
 LL |         Some(_) => wait(),
    |         ^^^^^^^
-   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
+   = help: filter where `next()` is produced, with `.filter(..)` or a payload type that cannot fail `j.ready`
 
-warning: a `Some` that fails `j.ready && j.id > 0` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
+warning: a `Some` that fails `j.ready && j.id > 0` is treated exactly like `None` here. `Some` alone does not mean usable, and every consumer has to repeat the check
   --> $DIR/some_still_unchecked.rs:46:9
    |
 LL |         Some(j) if j.ready && j.id > 0 => j.id,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, together with `None`
+note: the failing `Some` ends up here, with `None`
   --> $DIR/some_still_unchecked.rs:47:9
    |
 LL |         Some(_) | None => wait(),
    |         ^^^^^^^^^^^^^^
-   = help: make whatever produces `next()` reject values failing `j.ready && j.id > 0` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
+   = help: filter where `next()` is produced, with `.filter(..)` or a payload type that cannot fail `j.ready && j.id > 0`
 
-warning: an `Ok` that fails `n > 2` is handled exactly like `Err` here, so `Ok` alone does not mean usable and every other consumer of this value has to repeat the check
+warning: an `Ok` that fails `n > 2` is treated exactly like `Err` here. `Ok` alone does not mean usable, and every consumer has to repeat the check
   --> $DIR/some_still_unchecked.rs:54:9
    |
 LL |         Ok(n) if n > 2 => n,
    |         ^^^^^^^^^^^^^^
    |
-note: the failing `Ok` lands here, together with `Err`
+note: the failing `Ok` ends up here, with `Err`
   --> $DIR/some_still_unchecked.rs:55:9
    |
 LL |         Err(_) | Ok(_) => wait(),
    |         ^^^^^^^^^^^^^^
-   = help: make whatever produces `parse()` reject values failing `n > 2` (an error for that case, or a payload type that cannot fail it), so an `Ok` reaching here needs no second check
+   = help: reject that case where `parse()` is produced, with an error for it or a payload type that cannot fail `n > 2`
 
-warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
+warning: a `Some` that fails `j.ready` is treated exactly like `None` here. `Some` alone does not mean usable, and every consumer has to repeat the check
   --> $DIR/some_still_unchecked.rs:61:8
    |
 LL |       if let Some(j) = next()
@@ -59,7 +59,7 @@ LL |       if let Some(j) = next()
 LL | |         && j.ready
    | |__________________^
    |
-note: the failing `Some` lands here, together with `None`
+note: the failing `Some` ends up here, with `None`
   --> $DIR/some_still_unchecked.rs:65:12
    |
 LL |       } else {
@@ -67,20 +67,20 @@ LL |       } else {
 LL | |         wait()
 LL | |     }
    | |_____^
-   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
+   = help: filter where `next()` is produced, with `.filter(..)` or a payload type that cannot fail `j.ready`
 
-warning: a `Some` that fails `j.ready` is handled exactly like `None` here, so `Some` alone does not mean usable and every other consumer of this value has to repeat the check
+warning: a `Some` that fails `j.ready` is treated exactly like `None` here. `Some` alone does not mean usable, and every consumer has to repeat the check
   --> $DIR/some_still_unchecked.rs:72:8
    |
 LL |     if let Some(j) = next() {
    |        ^^^^^^^^^^^^^^^^^^^^
    |
-note: the failing `Some` lands here, together with `None`
+note: the failing `Some` ends up here, with `None`
   --> $DIR/some_still_unchecked.rs:73:34
    |
 LL |         if j.ready { j.id } else { wait() + 1 }
    |                                  ^^^^^^^^^^^^^^
-   = help: make whatever produces `next()` reject values failing `j.ready` (a `.filter(..)`, or a payload type that cannot fail it), so a `Some` reaching here needs no second check
+   = help: filter where `next()` is produced, with `.filter(..)` or a payload type that cannot fail `j.ready`
 
 warning: 6 warnings emitted
 

--- a/ui/stale_across_reentry.stderr
+++ b/ui/stale_across_reentry.stderr
@@ -1,237 +1,237 @@
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:129:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:128:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
    = note: `#[warn(stale_across_reentry)]` on by default
 
-warning: `last` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `last` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:135:9
    |
 LL |         self.items.remove(last)
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:134:9
    |
 LL |         self.sink.drain(&mut self.items);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `last`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `last`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:144:20
    |
 LL |         if n > 0 { self.items[0] } else { 0 }
    |                    ^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:143:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:155:22
    |
 LL |             total += self.items[i];
    |                      ^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:152:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `had` was read off `self.pending` before a call that can run code with access to `self`, and is used here as if `self.pending` could not have changed in between
+warning: `had` was read from `self.pending` before a call that can run other code with access to `self`. It is used here as if `self.pending` had not changed
   --> $DIR/stale_across_reentry.rs:163:18
    |
 LL |         if had { self.pending.take().unwrap() } else { 0 }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.pending`
+note: control leaves this function here, and what runs can reach `self.pending`
   --> $DIR/stale_across_reentry.rs:162:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read `self.pending` after that call instead of reusing `had`, or hold the element itself rather than its position across the call
+   = help: read `self.pending` again after the call instead of reusing `had`, or hold the element itself across the call
 
-warning: `p` points into `self.buf` as it was before a call that can run code with access to `self`, which may have moved or freed that buffer by the time `p` is used here
+warning: `p` points into `self.buf` as it was before a call that can run other code with access to `self`. That code may have moved or freed the buffer by the time `p` is used here
   --> $DIR/stale_across_reentry.rs:169:19
    |
 LL |         unsafe { *p }
    |                   ^
    |
-note: control leaves this function here, and whatever runs can reach `self.buf`
+note: control leaves this function here, and what runs can reach `self.buf`
   --> $DIR/stale_across_reentry.rs:168:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: take the pointer from `self.buf` again after that call, or keep the data alive across it by value
+   = help: take the pointer from `self.buf` again after the call, or keep the data alive across it by value
 
-warning: `n` was read off `self.log` before a call that can run code with access to `self`, and is used here as if `self.log` could not have changed in between
+warning: `n` was read from `self.log` before a call that can run other code with access to `self`. It is used here as if `self.log` had not changed
   --> $DIR/stale_across_reentry.rs:175:9
    |
 LL |         self.log.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.log`
+note: control leaves this function here, and what runs can reach `self.log`
   --> $DIR/stale_across_reentry.rs:174:9
    |
 LL |         self.sink.notify();
    |         ^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.log` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.log` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.log` before a call that can run code with access to `self`, and is used here as if `self.log` could not have changed in between
+warning: `n` was read from `self.log` before a call that can run other code with access to `self`. It is used here as if `self.log` had not changed
   --> $DIR/stale_across_reentry.rs:181:9
    |
 LL |         self.log.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.log`
+note: control leaves this function here, and what runs can reach `self.log`
   --> $DIR/stale_across_reentry.rs:180:9
    |
 LL |         yield_now().await;
    |         ^^^^^^^^^^^^^^^^^
-   = help: re-read `self.log` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.log` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:187:9
    |
 LL |         self.items[n as usize - 1]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:186:9
    |
 LL |         self.vm.run_callback();
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:193:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:192:9
    |
 LL |         self.dispatch_event();
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:311:12
    |
 LL |         if self.items[n - 1] > 0 { 1 } else { 0 }
    |            ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:310:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:317:15
    |
 LL |         match self.items.remove(n - 1) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:316:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:331:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:327:17
    |
 LL |                 (self.on_event)(self);
    |                 ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:337:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:336:9
    |
 LL |         self.worker.run_job();
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
+warning: `n` was read from `self.items` before a call that can run other code with access to `self`. It is used here as if `self.items` had not changed
   --> $DIR/stale_across_reentry.rs:343:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.items`
+note: control leaves this function here, and what runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:342:9
    |
 LL |         self.worker.schedule();
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.items` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.journal` before a call that can run code with access to `self`, and is used here as if `self.journal` could not have changed in between
+warning: `n` was read from `self.journal` before a call that can run other code with access to `self`. It is used here as if `self.journal` had not changed
   --> $DIR/stale_across_reentry.rs:349:9
    |
 LL |         self.journal.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.journal`
+note: control leaves this function here, and what runs can reach `self.journal`
   --> $DIR/stale_across_reentry.rs:348:9
    |
 LL |         self.sink.notify();
    |         ^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.journal` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.journal` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.ring` before a call that can run code with access to `self`, and is used here as if `self.ring` could not have changed in between
+warning: `n` was read from `self.ring` before a call that can run other code with access to `self`. It is used here as if `self.ring` had not changed
   --> $DIR/stale_across_reentry.rs:355:9
    |
 LL |         self.ring[n - 1]
    |         ^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.ring`
+note: control leaves this function here, and what runs can reach `self.ring`
   --> $DIR/stale_across_reentry.rs:354:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read `self.ring` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.ring` again after the call instead of reusing `n`, or hold the element itself across the call
 
-warning: `n` was read off `self.log` before a call that can run code with access to `self`, and is used here as if `self.log` could not have changed in between
+warning: `n` was read from `self.log` before a call that can run other code with access to `self`. It is used here as if `self.log` had not changed
   --> $DIR/stale_across_reentry.rs:361:9
    |
 LL |         self.log.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, and whatever runs can reach `self.log`
+note: control leaves this function here, and what runs can reach `self.log`
   --> $DIR/stale_across_reentry.rs:360:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read `self.log` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
+   = help: read `self.log` again after the call instead of reusing `n`, or hold the element itself across the call
 
 warning: 18 warnings emitted
 

--- a/ui/stale_across_reentry.stderr
+++ b/ui/stale_across_reentry.stderr
@@ -1,237 +1,237 @@
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:129:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:128:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
    = note: `#[warn(stale_across_reentry)]` on by default
 
-warning: `last` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `last` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:135:9
    |
 LL |         self.items.remove(last)
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:134:9
    |
 LL |         self.sink.drain(&mut self.items);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `last`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:144:20
    |
 LL |         if n > 0 { self.items[0] } else { 0 }
    |                    ^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:143:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:155:22
    |
 LL |             total += self.items[i];
    |                      ^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:152:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `had` describes `self.pending` as it stood before a call that can re-enter and change it
+warning: `had` was read off `self.pending` before a call that can run code with access to `self`, and is used here as if `self.pending` could not have changed in between
   --> $DIR/stale_across_reentry.rs:163:18
    |
 LL |         if had { self.pending.take().unwrap() } else { 0 }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.pending`
   --> $DIR/stale_across_reentry.rs:162:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.pending` after that call instead of reusing `had`, or hold the element itself rather than its position across the call
 
-warning: `p` points into `self.buf` as it stood before a call that can re-enter and move or free it
+warning: `p` points into `self.buf` as it was before a call that can run code with access to `self`, which may have moved or freed that buffer by the time `p` is used here
   --> $DIR/stale_across_reentry.rs:169:19
    |
 LL |         unsafe { *p }
    |                   ^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.buf`
   --> $DIR/stale_across_reentry.rs:168:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: take the pointer after the call, or keep what it points at alive across it by value
+   = help: take the pointer from `self.buf` again after that call, or keep the data alive across it by value
 
-warning: `n` describes `self.log` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.log` before a call that can run code with access to `self`, and is used here as if `self.log` could not have changed in between
   --> $DIR/stale_across_reentry.rs:175:9
    |
 LL |         self.log.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.log`
   --> $DIR/stale_across_reentry.rs:174:9
    |
 LL |         self.sink.notify();
    |         ^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.log` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.log` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.log` before a call that can run code with access to `self`, and is used here as if `self.log` could not have changed in between
   --> $DIR/stale_across_reentry.rs:181:9
    |
 LL |         self.log.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.log`
   --> $DIR/stale_across_reentry.rs:180:9
    |
 LL |         yield_now().await;
    |         ^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.log` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:187:9
    |
 LL |         self.items[n as usize - 1]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:186:9
    |
 LL |         self.vm.run_callback();
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:193:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:192:9
    |
 LL |         self.dispatch_event();
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:311:12
    |
 LL |         if self.items[n - 1] > 0 { 1 } else { 0 }
    |            ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:310:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:317:15
    |
 LL |         match self.items.remove(n - 1) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:316:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:331:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:327:17
    |
 LL |                 (self.on_event)(self);
    |                 ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:337:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:336:9
    |
 LL |         self.worker.run_job();
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.items` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.items` before a call that can run code with access to `self`, and is used here as if `self.items` could not have changed in between
   --> $DIR/stale_across_reentry.rs:343:9
    |
 LL |         self.items[n - 1]
    |         ^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.items`
   --> $DIR/stale_across_reentry.rs:342:9
    |
 LL |         self.worker.schedule();
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.items` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.journal` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.journal` before a call that can run code with access to `self`, and is used here as if `self.journal` could not have changed in between
   --> $DIR/stale_across_reentry.rs:349:9
    |
 LL |         self.journal.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.journal`
   --> $DIR/stale_across_reentry.rs:348:9
    |
 LL |         self.sink.notify();
    |         ^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.journal` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.ring` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.ring` before a call that can run code with access to `self`, and is used here as if `self.ring` could not have changed in between
   --> $DIR/stale_across_reentry.rs:355:9
    |
 LL |         self.ring[n - 1]
    |         ^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.ring`
   --> $DIR/stale_across_reentry.rs:354:9
    |
 LL |         (self.on_event)(self);
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.ring` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
-warning: `n` describes `self.log` as it stood before a call that can re-enter and change it
+warning: `n` was read off `self.log` before a call that can run code with access to `self`, and is used here as if `self.log` could not have changed in between
   --> $DIR/stale_across_reentry.rs:361:9
    |
 LL |         self.log.remove(n - 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: control leaves this function here, with `self` reachable from whatever runs
+note: control leaves this function here, and whatever runs can reach `self.log`
   --> $DIR/stale_across_reentry.rs:360:9
    |
 LL |         f(self);
    |         ^^^^^^^
-   = help: re-read the field after the call, or hold the item itself rather than its position
+   = help: re-read `self.log` after that call instead of reusing `n`, or hold the element itself rather than its position across the call
 
 warning: 18 warnings emitted
 

--- a/ui/stale_panic_message.stderr
+++ b/ui/stale_panic_message.stderr
@@ -1,19 +1,19 @@
-warning: this message mentions `frame_lock`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so whoever hits this panic is sent looking for something that is gone
+warning: this message mentions `frame_lock`, but nothing with that name exists in this file, this crate, or any crate it links. Whoever hits the panic is sent looking for something that is gone
   --> $DIR/stale_panic_message.rs:12:28
    |
 LL |     *t.slots.get(i).expect("guarded upstream by `frame_lock`")
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: rewrite the message in terms of whatever replaced `frame_lock`
+   = help: rewrite the message in terms of what replaced `frame_lock`
    = note: `#[warn(stale_panic_message)]` on by default
 
-warning: this message mentions `normalizer`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so whoever hits this panic is sent looking for something that is gone
+warning: this message mentions `normalizer`, but nothing with that name exists in this file, this crate, or any crate it links. Whoever hits the panic is sent looking for something that is gone
   --> $DIR/stale_panic_message.rs:18:27
    |
 LL |         _ => unreachable!("`normalizer` rejects nonzero values before this"),
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: rewrite the message in terms of whatever replaced `normalizer`
+   = help: rewrite the message in terms of what replaced `normalizer`
 
 warning: 2 warnings emitted
 

--- a/ui/stale_panic_message.stderr
+++ b/ui/stale_panic_message.stderr
@@ -1,19 +1,19 @@
-warning: this message names `frame_lock`, which appears nowhere in this file's code, this crate, or any crate it links
+warning: this message mentions `frame_lock`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so whoever hits this panic is sent looking for something that is gone
   --> $DIR/stale_panic_message.rs:12:28
    |
 LL |     *t.slots.get(i).expect("guarded upstream by `frame_lock`")
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: whoever reads this at a crash site will search for a name that no longer exists; update the message
+   = help: rewrite the message in terms of whatever replaced `frame_lock`
    = note: `#[warn(stale_panic_message)]` on by default
 
-warning: this message names `normalizer`, which appears nowhere in this file's code, this crate, or any crate it links
+warning: this message mentions `normalizer`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so whoever hits this panic is sent looking for something that is gone
   --> $DIR/stale_panic_message.rs:18:27
    |
 LL |         _ => unreachable!("`normalizer` rejects nonzero values before this"),
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: whoever reads this at a crash site will search for a name that no longer exists; update the message
+   = help: rewrite the message in terms of whatever replaced `normalizer`
 
 warning: 2 warnings emitted
 

--- a/ui/stale_safety_comment.stderr
+++ b/ui/stale_safety_comment.stderr
@@ -1,11 +1,11 @@
-warning: this SAFETY comment names `frames_lock`, which appears nowhere in this file's code, this crate, or any crate it links
+warning: this SAFETY comment relies on `frames_lock`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so the justification describes code that is gone
   --> $DIR/stale_safety_comment.rs:9:1
    |
 LL | /     // SAFETY: `frames_lock` is held for the duration of this read.
 LL | |     unsafe { *p }
    | |_^
    |
-   = help: the guard this justification described has moved or gone; update the comment or restore the guard
+   = help: find what replaced `frames_lock` and restate the comment in its terms; if nothing did, this `unsafe` block has lost the guard it depended on and needs one
    = note: `#[warn(stale_safety_comment)]` on by default
 
 warning: 1 warning emitted

--- a/ui/stale_safety_comment.stderr
+++ b/ui/stale_safety_comment.stderr
@@ -1,11 +1,11 @@
-warning: this SAFETY comment relies on `frames_lock`, but nothing by that name exists any more in this file's code, this crate, or any crate it links, so the justification describes code that is gone
+warning: this SAFETY comment relies on `frames_lock`, but nothing with that name exists in this file, this crate, or any crate it links. The justification describes code that is gone
   --> $DIR/stale_safety_comment.rs:9:1
    |
 LL | /     // SAFETY: `frames_lock` is held for the duration of this read.
 LL | |     unsafe { *p }
    | |_^
    |
-   = help: find what replaced `frames_lock` and restate the comment in its terms; if nothing did, this `unsafe` block has lost the guard it depended on and needs one
+   = help: restate the comment in terms of what replaced `frames_lock`. If nothing did, this `unsafe` block has lost its guard and needs one
    = note: `#[warn(stale_safety_comment)]` on by default
 
 warning: 1 warning emitted

--- a/ui/stringified_error.stderr
+++ b/ui/stringified_error.stderr
@@ -1,19 +1,19 @@
-warning: typed error `ParseError` collapsed into a string
+warning: this `map_err` turns `ParseError` into `String`, so from here on callers cannot match on which failure it was
   --> $DIR/stringified_error.rs:23:5
    |
 LL |     r.map_err(|e| e.to_string())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return the error type, or an error enum with a variant that wraps it
+   = help: return `ParseError` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed
    = note: `#[warn(stringified_error)]` on by default
 
-warning: typed error `ParseError` collapsed into a string
+warning: this `map_err` turns `ParseError` into `String`, so from here on callers cannot match on which failure it was
   --> $DIR/stringified_error.rs:27:5
    |
 LL |     r.map_err(|e| format!("parse failed: {e}"))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return the error type, or an error enum with a variant that wraps it
+   = help: return `ParseError` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed
 
 warning: 2 warnings emitted
 

--- a/ui/stringified_error.stderr
+++ b/ui/stringified_error.stderr
@@ -1,19 +1,19 @@
-warning: this `map_err` turns `ParseError` into `String`, so from here on callers cannot match on which failure it was
+warning: this `map_err` turns a `ParseError` into a `String`. From here on, callers cannot match on which failure it was
   --> $DIR/stringified_error.rs:23:5
    |
 LL |     r.map_err(|e| e.to_string())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return `ParseError` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed
+   = help: return `ParseError` itself, or an error enum that wraps it, and turn it into text only where it is shown
    = note: `#[warn(stringified_error)]` on by default
 
-warning: this `map_err` turns `ParseError` into `String`, so from here on callers cannot match on which failure it was
+warning: this `map_err` turns a `ParseError` into a `String`. From here on, callers cannot match on which failure it was
   --> $DIR/stringified_error.rs:27:5
    |
 LL |     r.map_err(|e| format!("parse failed: {e}"))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return `ParseError` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed
+   = help: return `ParseError` itself, or an error enum that wraps it, and turn it into text only where it is shown
 
 warning: 2 warnings emitted
 

--- a/ui/stringly_error.stderr
+++ b/ui/stringly_error.stderr
@@ -1,46 +1,46 @@
-warning: `public_string_err_is_flagged` is public and returns `Result<_, String>`, so its callers can only tell failures apart by reading the message text
+warning: `public_string_err_is_flagged` is public and returns `Result<_, String>`. Callers can only tell failures apart by reading the message
   --> $DIR/stringly_error.rs:7:48
    |
 LL | pub fn public_string_err_is_flagged(x: u32) -> Result<u32, String> {
    |                                                ^^^^^^^^^^^^^^^^^^^
    |
-   = help: define an error enum with a variant per way `public_string_err_is_flagged` can fail and return that; keep the text in its `Display` impl
+   = help: return an error enum with a variant per failure, and keep the text in its `Display` impl
    = note: `#[warn(stringly_error)]` on by default
 
-warning: `public_str_err_is_flagged` is public and returns `Result<_, &str>`, so its callers can only tell failures apart by reading the message text
+warning: `public_str_err_is_flagged` is public and returns `Result<_, &str>`. Callers can only tell failures apart by reading the message
   --> $DIR/stringly_error.rs:11:45
    |
 LL | pub fn public_str_err_is_flagged(x: u32) -> Result<u32, &'static str> {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: define an error enum with a variant per way `public_str_err_is_flagged` can fail and return that; keep the text in its `Display` impl
+   = help: return an error enum with a variant per failure, and keep the text in its `Display` impl
 
-warning: `public_cow_err_is_flagged` is public and returns `Result<_, Cow<str>>`, so its callers can only tell failures apart by reading the message text
+warning: `public_cow_err_is_flagged` is public and returns `Result<_, Cow<str>>`. Callers can only tell failures apart by reading the message
   --> $DIR/stringly_error.rs:15:45
    |
 LL | pub fn public_cow_err_is_flagged(x: u32) -> Result<u32, Cow<'static, str>> {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: define an error enum with a variant per way `public_cow_err_is_flagged` can fail and return that; keep the text in its `Display` impl
+   = help: return an error enum with a variant per failure, and keep the text in its `Display` impl
 
-warning: `req$DIRred_method_is_flagged` is public and returns `Result<_, String>`, so its callers can only tell failures apart by reading the message text
+warning: `req$DIRred_method_is_flagged` is public and returns `Result<_, String>`. Callers can only tell failures apart by reading the message
   --> $DIR/stringly_error.rs:20:58
    |
 LL |     fn req$DIRred_method_is_flagged(&self, input: &str) -> Result<u32, String>;
    |                                                          ^^^^^^^^^^^^^^^^^^^
    |
-   = help: define an error enum with a variant per way `req$DIRred_method_is_flagged` can fail and return that; keep the text in its `Display` impl
+   = help: return an error enum with a variant per failure, and keep the text in its `Display` impl
 
-warning: this `map_err` turns `std::num::ParseIntError` into `String`, so from here on callers cannot match on which failure it was
+warning: this `map_err` turns a `std::num::ParseIntError` into a `String`. From here on, callers cannot match on which failure it was
   --> $DIR/stringly_error.rs:42:9
    |
 LL |         s.parse().map(Numeric).map_err(|e| e.to_string())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return `std::num::ParseIntError` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed
+   = help: return `std::num::ParseIntError` itself, or an error enum that wraps it, and turn it into text only where it is shown
    = note: `#[warn(stringified_error)]` on by default
 
-warning: `private_string_err_is_fine` has the same signature and, up to renamed locals, the same body as `public_string_err_is_flagged`, so one helper exists twice and a fix to either silently misses the other
+warning: `private_string_err_is_fine` has the same signature and the same body as `public_string_err_is_flagged`, apart from local names. A fix to one will miss the other
   --> $DIR/stringly_error.rs:31:1
    |
 LL | fn private_string_err_is_fine(x: u32) -> Result<u32, String> {
@@ -51,7 +51,7 @@ note: `public_string_err_is_flagged`, the other copy
    |
 LL | pub fn public_string_err_is_flagged(x: u32) -> Result<u32, String> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: delete `private_string_err_is_fine` and call `public_string_err_is_flagged` from its callers (or the reverse)
+   = help: delete `private_string_err_is_fine` and call `public_string_err_is_flagged` instead, or the other way round
    = note: `#[warn(reimplemented_helper)]` on by default
 
 warning: 6 warnings emitted

--- a/ui/stringly_error.stderr
+++ b/ui/stringly_error.stderr
@@ -1,57 +1,57 @@
-warning: public signature returns `Result<_, String>`
+warning: `public_string_err_is_flagged` is public and returns `Result<_, String>`, so its callers can only tell failures apart by reading the message text
   --> $DIR/stringly_error.rs:7:48
    |
 LL | pub fn public_string_err_is_flagged(x: u32) -> Result<u32, String> {
    |                                                ^^^^^^^^^^^^^^^^^^^
    |
-   = help: a string error has no variants to match on; define an error enum and return it
+   = help: define an error enum with a variant per way `public_string_err_is_flagged` can fail and return that; keep the text in its `Display` impl
    = note: `#[warn(stringly_error)]` on by default
 
-warning: public signature returns `Result<_, &str>`
+warning: `public_str_err_is_flagged` is public and returns `Result<_, &str>`, so its callers can only tell failures apart by reading the message text
   --> $DIR/stringly_error.rs:11:45
    |
 LL | pub fn public_str_err_is_flagged(x: u32) -> Result<u32, &'static str> {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: a string error has no variants to match on; define an error enum and return it
+   = help: define an error enum with a variant per way `public_str_err_is_flagged` can fail and return that; keep the text in its `Display` impl
 
-warning: public signature returns `Result<_, Cow<str>>`
+warning: `public_cow_err_is_flagged` is public and returns `Result<_, Cow<str>>`, so its callers can only tell failures apart by reading the message text
   --> $DIR/stringly_error.rs:15:45
    |
 LL | pub fn public_cow_err_is_flagged(x: u32) -> Result<u32, Cow<'static, str>> {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: a string error has no variants to match on; define an error enum and return it
+   = help: define an error enum with a variant per way `public_cow_err_is_flagged` can fail and return that; keep the text in its `Display` impl
 
-warning: public signature returns `Result<_, String>`
+warning: `req$DIRred_method_is_flagged` is public and returns `Result<_, String>`, so its callers can only tell failures apart by reading the message text
   --> $DIR/stringly_error.rs:20:58
    |
 LL |     fn req$DIRred_method_is_flagged(&self, input: &str) -> Result<u32, String>;
    |                                                          ^^^^^^^^^^^^^^^^^^^
    |
-   = help: a string error has no variants to match on; define an error enum and return it
+   = help: define an error enum with a variant per way `req$DIRred_method_is_flagged` can fail and return that; keep the text in its `Display` impl
 
-warning: typed error `std::num::ParseIntError` collapsed into a string
+warning: this `map_err` turns `std::num::ParseIntError` into `String`, so from here on callers cannot match on which failure it was
   --> $DIR/stringly_error.rs:42:9
    |
 LL |         s.parse().map(Numeric).map_err(|e| e.to_string())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return the error type, or an error enum with a variant that wraps it
+   = help: return `std::num::ParseIntError` itself, or an error enum with a variant that wraps it, and turn it into text only where it is displayed
    = note: `#[warn(stringified_error)]` on by default
 
-warning: `private_string_err_is_fine` has the same signature and body as `public_string_err_is_flagged`
+warning: `private_string_err_is_fine` has the same signature and, up to renamed locals, the same body as `public_string_err_is_flagged`, so one helper exists twice and a fix to either silently misses the other
   --> $DIR/stringly_error.rs:31:1
    |
 LL | fn private_string_err_is_fine(x: u32) -> Result<u32, String> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the same body is here
+note: `public_string_err_is_flagged`, the other copy
   --> $DIR/stringly_error.rs:7:1
    |
 LL | pub fn public_string_err_is_flagged(x: u32) -> Result<u32, String> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: one helper written twice drifts apart at the first fix; keep one and call it from the other's callers
+   = help: delete `private_string_err_is_fine` and call `public_string_err_is_flagged` from its callers (or the reverse)
    = note: `#[warn(reimplemented_helper)]` on by default
 
 warning: 6 warnings emitted

--- a/ui/stringly_state.stderr
+++ b/ui/stringly_state.stderr
@@ -1,96 +1,96 @@
-warning: `kind` only ever holds one of `"download"`, `"extract"` (3 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
+warning: `kind` only ever holds `"download"` or `"extract"` (3 stores) and is read by comparing against literals. It is an enum written as a string, and a typo still compiles
   --> $DIR/stringly_state.rs:5:5
    |
 LL |     kind: &'static str,
    |     ^^^^^^^^^^^^^^^^^^
    |
-note: one of the comparisons against a literal
+note: one of the comparisons
   --> $DIR/stringly_state.rs:20:8
    |
 LL |     if t.kind == "download" { t.id } else { 0 }
    |        ^^^^^^^^^^^^^^^^^^^^
-   = help: declare an enum with a variant per string and store that in `kind`; keep the text in an `as_str` method for wherever it is printed
+   = help: declare an enum with a variant per string and store that in `kind`. Keep the text in an `as_str` method for printing
    = note: `#[warn(stringly_state)]` on by default
 
-warning: `name` only ever holds one of `"link"`, `"resolve"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
+warning: `name` only ever holds `"link"` or `"resolve"` (2 stores) and is read by comparing against literals. It is an enum written as a string, and a typo still compiles
   --> $DIR/stringly_state.rs:25:5
    |
 LL |     name: Vec<u8>,
    |     ^^^^^^^^^^^^^
    |
-note: one of the comparisons against a literal
+note: one of the comparisons
   --> $DIR/stringly_state.rs:40:11
    |
 LL |     match p.name.as_slice() {
    |           ^^^^^^^^^^^^^^^^^
-   = help: declare an enum with a variant per string and store that in `name`; keep the text in an `as_str` method for wherever it is printed
+   = help: declare an enum with a variant per string and store that in `name`. Keep the text in an `as_str` method for printing
 
-warning: `label` only ever holds one of `"fast"`, `"slow"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
+warning: `label` only ever holds `"fast"` or `"slow"` (2 stores) and is read by comparing against literals. It is an enum written as a string, and a typo still compiles
   --> $DIR/stringly_state.rs:48:5
    |
 LL |     label: String,
    |     ^^^^^^^^^^^^^
    |
-note: one of the comparisons against a literal
+note: one of the comparisons
   --> $DIR/stringly_state.rs:64:5
    |
 LL |     m.label.eq_ignore_ascii_case("FAST")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: declare an enum with a variant per string and store that in `label`; keep the text in an `as_str` method for wherever it is printed
+   = help: declare an enum with a variant per string and store that in `label`. Keep the text in an `as_str` method for printing
 
-warning: `scheme` only ever holds one of `"ws"`, `"wss"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
+warning: `scheme` only ever holds `"ws"` or `"wss"` (2 stores) and is read by comparing against literals. It is an enum written as a string, and a typo still compiles
   --> $DIR/stringly_state.rs:69:5
    |
 LL |     scheme: &'static [u8],
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the comparisons against a literal
+note: one of the comparisons
   --> $DIR/stringly_state.rs:88:14
    |
 LL |     matches!(c.scheme, b"wss") == (c.port == 443)
    |              ^^^^^^^^
-   = help: declare an enum with a variant per string and store that in `scheme`; keep the text in an `as_str` method for wherever it is printed
+   = help: declare an enum with a variant per string and store that in `scheme`. Keep the text in an `as_str` method for printing
 
-warning: `color` only ever holds one of `"green"`, `"red"`, `"yellow"` (3 stores) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
+warning: `color` only ever holds `"green"`, `"red"` or `"yellow"` (3 stores) and is read by comparing against literals. It is an enum written as a string, and a typo still compiles
   --> $DIR/stringly_state.rs:93:9
    |
 LL |     let mut color = "green";
    |         ^^^^^^^^^
    |
-note: one of the comparisons against a literal
+note: one of the comparisons
   --> $DIR/stringly_state.rs:99:8
    |
 LL |     if color == "red" {
    |        ^^^^^^^^^^^^^^
-   = help: declare an enum with a variant per string and store that in `color`; keep the text in an `as_str` method for wherever it is printed
+   = help: declare an enum with a variant per string and store that in `color`. Keep the text in an `as_str` method for printing
 
-warning: `level` only ever holds one of `"hi"`, `"lo"` (1 store) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
+warning: `level` only ever holds `"hi"` or `"lo"` (1 store) and is read by comparing against literals. It is an enum written as a string, and a typo still compiles
   --> $DIR/stringly_state.rs:110:9
    |
 LL |     let level = if n > 9 { "hi" } else { "lo" };
    |         ^^^^^
    |
-note: one of the comparisons against a literal
+note: one of the comparisons
   --> $DIR/stringly_state.rs:111:14
    |
 LL |     matches!(level, "hi")
    |              ^^^^^
-   = help: declare an enum with a variant per string and store that in `level`; keep the text in an `as_str` method for wherever it is printed
+   = help: declare an enum with a variant per string and store that in `level`. Keep the text in an `as_str` method for printing
 
-warning: `step` only ever holds one of `"emit"`, `"parse"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
+warning: `step` only ever holds `"emit"` or `"parse"` (2 stores) and is read by comparing against literals. It is an enum written as a string, and a typo still compiles
   --> $DIR/stringly_state.rs:117:5
    |
 LL |     step: &'static str,
    |     ^^^^^^^^^^^^^^^^^^
    |
-note: one of the comparisons against a literal
+note: one of the comparisons
   --> $DIR/stringly_state.rs:126:5
    |
 LL |     s.step == "parse"
    |     ^^^^^^^^^^^^^^^^^
-   = help: declare an enum with a variant per string and store that in `step`; keep the text in an `as_str` method for wherever it is printed
+   = help: declare an enum with a variant per string and store that in `step`. Keep the text in an `as_str` method for printing
 
-warning: `severity` takes `bool` parameters `major` and `minor`, and 1 of its 1 calls passes bare `true`/`false` for both, so at `severity(true, false)` nothing says which flag is which and the swapped call compiles too
+warning: `severity` takes bools `major` and `minor`, and 1 of its 1 calls passes bare `true`/`false` for both. At `severity(true, false)` nothing says which is which
   --> $DIR/stringly_state.rs:92:4
    |
 LL | fn severity(major: bool, minor: bool) -> u8 {
@@ -101,7 +101,7 @@ note: one of those calls
    |
 LL |     let _ = severity(true, false) + tier(3) as u8;
    |             ^^^^^^^^^^^^^^^^^^^^^
-   = help: give `major` and `minor` each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error
+   = help: give `major` and `minor` a two-variant enum each, or an options struct, so every call names what it sets
    = note: `#[warn(bare_bool_args)]` on by default
 
 warning: 8 warnings emitted

--- a/ui/stringly_state.stderr
+++ b/ui/stringly_state.stderr
@@ -1,72 +1,107 @@
-warning: every value stored in `kind` is one of `"download"`, `"extract"` (3 stores across the crate), and it is read by comparing against literals
+warning: `kind` only ever holds one of `"download"`, `"extract"` (3 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
   --> $DIR/stringly_state.rs:5:5
    |
 LL |     kind: &'static str,
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: these strings are the variants of an enum; store the enum and keep the text in an `as_str` method, so a misspelt state is a compile error
+note: one of the comparisons against a literal
+  --> $DIR/stringly_state.rs:20:8
+   |
+LL |     if t.kind == "download" { t.id } else { 0 }
+   |        ^^^^^^^^^^^^^^^^^^^^
+   = help: declare an enum with a variant per string and store that in `kind`; keep the text in an `as_str` method for wherever it is printed
    = note: `#[warn(stringly_state)]` on by default
 
-warning: every value stored in `name` is one of `"link"`, `"resolve"` (2 stores across the crate), and it is read by comparing against literals
+warning: `name` only ever holds one of `"link"`, `"resolve"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
   --> $DIR/stringly_state.rs:25:5
    |
 LL |     name: Vec<u8>,
    |     ^^^^^^^^^^^^^
    |
-   = help: these strings are the variants of an enum; store the enum and keep the text in an `as_str` method, so a misspelt state is a compile error
+note: one of the comparisons against a literal
+  --> $DIR/stringly_state.rs:40:11
+   |
+LL |     match p.name.as_slice() {
+   |           ^^^^^^^^^^^^^^^^^
+   = help: declare an enum with a variant per string and store that in `name`; keep the text in an `as_str` method for wherever it is printed
 
-warning: every value stored in `label` is one of `"fast"`, `"slow"` (2 stores across the crate), and it is read by comparing against literals
+warning: `label` only ever holds one of `"fast"`, `"slow"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
   --> $DIR/stringly_state.rs:48:5
    |
 LL |     label: String,
    |     ^^^^^^^^^^^^^
    |
-   = help: these strings are the variants of an enum; store the enum and keep the text in an `as_str` method, so a misspelt state is a compile error
+note: one of the comparisons against a literal
+  --> $DIR/stringly_state.rs:64:5
+   |
+LL |     m.label.eq_ignore_ascii_case("FAST")
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: declare an enum with a variant per string and store that in `label`; keep the text in an `as_str` method for wherever it is printed
 
-warning: every value stored in `scheme` is one of `"ws"`, `"wss"` (2 stores across the crate), and it is read by comparing against literals
+warning: `scheme` only ever holds one of `"ws"`, `"wss"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
   --> $DIR/stringly_state.rs:69:5
    |
 LL |     scheme: &'static [u8],
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: these strings are the variants of an enum; store the enum and keep the text in an `as_str` method, so a misspelt state is a compile error
+note: one of the comparisons against a literal
+  --> $DIR/stringly_state.rs:88:14
+   |
+LL |     matches!(c.scheme, b"wss") == (c.port == 443)
+   |              ^^^^^^^^
+   = help: declare an enum with a variant per string and store that in `scheme`; keep the text in an `as_str` method for wherever it is printed
 
-warning: every value stored in `color` is one of `"green"`, `"red"`, `"yellow"` (3 stores), and it is read by comparing against literals
+warning: `color` only ever holds one of `"green"`, `"red"`, `"yellow"` (3 stores) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
   --> $DIR/stringly_state.rs:93:9
    |
 LL |     let mut color = "green";
    |         ^^^^^^^^^
    |
-   = help: these strings are the variants of an enum; store the enum and keep the text in an `as_str` method, so a misspelt state is a compile error
+note: one of the comparisons against a literal
+  --> $DIR/stringly_state.rs:99:8
+   |
+LL |     if color == "red" {
+   |        ^^^^^^^^^^^^^^
+   = help: declare an enum with a variant per string and store that in `color`; keep the text in an `as_str` method for wherever it is printed
 
-warning: every value stored in `level` is one of `"hi"`, `"lo"` (1 store), and it is read by comparing against literals
+warning: `level` only ever holds one of `"hi"`, `"lo"` (1 store) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
   --> $DIR/stringly_state.rs:110:9
    |
 LL |     let level = if n > 9 { "hi" } else { "lo" };
    |         ^^^^^
    |
-   = help: these strings are the variants of an enum; store the enum and keep the text in an `as_str` method, so a misspelt state is a compile error
+note: one of the comparisons against a literal
+  --> $DIR/stringly_state.rs:111:14
+   |
+LL |     matches!(level, "hi")
+   |              ^^^^^
+   = help: declare an enum with a variant per string and store that in `level`; keep the text in an `as_str` method for wherever it is printed
 
-warning: every value stored in `step` is one of `"emit"`, `"parse"` (2 stores across the crate), and it is read by comparing against literals
+warning: `step` only ever holds one of `"emit"`, `"parse"` (2 stores across the crate) and is read by comparing against literals, so it is an enum spelled as a string and a misspelt state still compiles
   --> $DIR/stringly_state.rs:117:5
    |
 LL |     step: &'static str,
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: these strings are the variants of an enum; store the enum and keep the text in an `as_str` method, so a misspelt state is a compile error
+note: one of the comparisons against a literal
+  --> $DIR/stringly_state.rs:126:5
+   |
+LL |     s.step == "parse"
+   |     ^^^^^^^^^^^^^^^^^
+   = help: declare an enum with a variant per string and store that in `step`; keep the text in an `as_str` method for wherever it is printed
 
-warning: `severity` takes `bool` parameters `major` and `minor`, and 1 of its 1 call sites passes bare `true`/`false` for both: nothing at `severity(true, false)` says which flag each one sets
+warning: `severity` takes `bool` parameters `major` and `minor`, and 1 of its 1 calls passes bare `true`/`false` for both, so at `severity(true, false)` nothing says which flag is which and the swapped call compiles too
   --> $DIR/stringly_state.rs:92:4
    |
 LL | fn severity(major: bool, minor: bool) -> u8 {
    |    ^^^^^^^^
    |
-note: one such call
+note: one of those calls
   --> $DIR/stringly_state.rs:344:13
    |
 LL |     let _ = severity(true, false) + tier(3) as u8;
    |             ^^^^^^^^^^^^^^^^^^^^^
-   = help: a two-variant enum per flag, or one options struct, names every argument at the call site and turns a swapped pair into a type error
+   = help: give `major` and `minor` each a two-variant enum type named for the flag (or group them in an options struct), so every call names what it sets and a swap is a type error
    = note: `#[warn(bare_bool_args)]` on by default
 
 warning: 8 warnings emitted

--- a/ui/tuple_wants_struct.stderr
+++ b/ui/tuple_wants_struct.stderr
@@ -1,18 +1,18 @@
-warning: every one of the 2 calls to `measure` (in 2 functions) unpacks this as `(depth, width)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u32` a swapped pair still compiles
+warning: both of the 2 calls to `measure` unpack the result as `(depth, width)`. The names exist everywhere except in the type, and since both members are `u32` a swapped pair compiles
   --> $DIR/tuple_wants_struct.rs:12:25
    |
 LL | fn measure(n: &Node) -> (u32, u32) {
    |                         ^^^^^^^^^^
    |
-note: one of the calls that names them
+note: one of the calls
   --> $DIR/tuple_wants_struct.rs:17:26
    |
 LL |     let (depth, width) = measure(a);
    |                          ^^^^^^^^^^
-   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
+   = help: return a struct with fields `depth` and `width`
    = note: `#[warn(tuple_wants_struct)]` on by default
 
-warning: every one of the 2 calls to `clamped` (in 2 functions) unpacks this as `(depth, width)`, but the body returns them as `(width, depth)`, and since `.0` and `.1` are both `u32` both orders compile and one of them is wrong
+warning: both of the 2 calls to `clamped` unpack the result as `(depth, width)`, but the body returns them as `(width, depth)`. Since both members are `u32` both orders compile, and one of them is wrong
   --> $DIR/tuple_wants_struct.rs:29:35
    |
 LL | fn clamped(n: &Node, max: u32) -> (u32, u32) {
@@ -23,59 +23,59 @@ note: the body returns them in the other order here
    |
 LL |         return (width, depth);
    |                ^^^^^^^^^^^^^^
-   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
+   = help: return a struct with fields `depth` and `width`
 
-warning: every one of the 2 calls to `folded` (in 2 functions) unpacks this as `(depth, width)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u32` a swapped pair still compiles
+warning: both of the 2 calls to `folded` unpack the result as `(depth, width)`. The names exist everywhere except in the type, and since both members are `u32` a swapped pair compiles
   --> $DIR/tuple_wants_struct.rs:50:24
    |
 LL | fn folded(n: &Node) -> (u32, u32) {
    |                        ^^^^^^^^^^
    |
-note: one of the calls that names them
+note: one of the calls
   --> $DIR/tuple_wants_struct.rs:62:26
    |
 LL |     let (depth, width) = folded(n);
    |                          ^^^^^^^^^
-   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
+   = help: return a struct with fields `depth` and `width`
 
-warning: every one of the 2 calls to `grown` (in 2 functions) unpacks this as `(depth, width)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u32` a swapped pair still compiles
+warning: both of the 2 calls to `grown` unpack the result as `(depth, width)`. The names exist everywhere except in the type, and since both members are `u32` a swapped pair compiles
   --> $DIR/tuple_wants_struct.rs:73:23
    |
 LL | fn grown(n: &Node) -> (u32, u32) {
    |                       ^^^^^^^^^^
    |
-note: one of the calls that names them
+note: one of the calls
   --> $DIR/tuple_wants_struct.rs:78:26
    |
 LL |     (n.depth, n.width) = grown(n);
    |                          ^^^^^^^^
-   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
+   = help: return a struct with fields `depth` and `width`
 
-warning: every one of the 4 calls to `split` (in 3 functions) unpacks this as `(key, value)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `&str` a swapped pair still compiles
+warning: all 4 calls to `split` unpack the result as `(key, value)`. The names exist everywhere except in the type, and since both members are `&str` a swapped pair compiles
   --> $DIR/tuple_wants_struct.rs:89:22
    |
 LL | fn split(s: &str) -> Option<(&str, &str)> {
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the calls that names them
+note: one of the calls
   --> $DIR/tuple_wants_struct.rs:97:24
    |
 LL |     let (key, value) = split(s)?;
    |                        ^^^^^^^^
-   = help: return a struct with fields `key`, `value` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
+   = help: return a struct with fields `key` and `value`
 
-warning: every one of the 2 calls to `bounds` (in 2 functions) unpacks this as `(low, high)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u8` a swapped pair still compiles
+warning: both of the 2 calls to `bounds` unpack the result as `(low, high)`. The names exist everywhere except in the type, and since both members are `u8` a swapped pair compiles
   --> $DIR/tuple_wants_struct.rs:125:25
    |
 LL |     fn bounds(&self) -> Result<(u8, u8), ()> {
    |                         ^^^^^^^^^^^^^^^^^^^^
    |
-note: one of the calls that names them
+note: one of the calls
   --> $DIR/tuple_wants_struct.rs:130:27
    |
 LL |         let (low, high) = self.bounds().map_err(|()| Unbounded)?;
    |                           ^^^^^^^^^^^^^
-   = help: return a struct with fields `low`, `high` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
+   = help: return a struct with fields `low` and `high`
 
 warning: 6 warnings emitted
 

--- a/ui/tuple_wants_struct.stderr
+++ b/ui/tuple_wants_struct.stderr
@@ -1,56 +1,81 @@
-warning: all 2 call sites of `measure`, in 2 functions, destructure this as `(depth, width)`: the members are named everywhere except in the type; `.0` and `.1` are both `u32`, so transposing them still type-checks
+warning: every one of the 2 calls to `measure` (in 2 functions) unpacks this as `(depth, width)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u32` a swapped pair still compiles
   --> $DIR/tuple_wants_struct.rs:12:25
    |
 LL | fn measure(n: &Node) -> (u32, u32) {
    |                         ^^^^^^^^^^
    |
-   = help: return a struct with these fields: the names move into the signature, and members of one type can no longer trade places
+note: one of the calls that names them
+  --> $DIR/tuple_wants_struct.rs:17:26
+   |
+LL |     let (depth, width) = measure(a);
+   |                          ^^^^^^^^^^
+   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
    = note: `#[warn(tuple_wants_struct)]` on by default
 
-warning: all 2 call sites of `clamped`, in 2 functions, destructure this as `(depth, width)`, but the body returns them as `(width, depth)`; `.0` and `.1` are both `u32`, so both orders type-check and one of them is wrong
+warning: every one of the 2 calls to `clamped` (in 2 functions) unpacks this as `(depth, width)`, but the body returns them as `(width, depth)`, and since `.0` and `.1` are both `u32` both orders compile and one of them is wrong
   --> $DIR/tuple_wants_struct.rs:29:35
    |
 LL | fn clamped(n: &Node, max: u32) -> (u32, u32) {
    |                                   ^^^^^^^^^^
    |
-note: returned in this order here
+note: the body returns them in the other order here
   --> $DIR/tuple_wants_struct.rs:33:16
    |
 LL |         return (width, depth);
    |                ^^^^^^^^^^^^^^
-   = help: return a struct with these fields: the names move into the signature, and members of one type can no longer trade places
+   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
 
-warning: all 2 call sites of `folded`, in 2 functions, destructure this as `(depth, width)`: the members are named everywhere except in the type; `.0` and `.1` are both `u32`, so transposing them still type-checks
+warning: every one of the 2 calls to `folded` (in 2 functions) unpacks this as `(depth, width)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u32` a swapped pair still compiles
   --> $DIR/tuple_wants_struct.rs:50:24
    |
 LL | fn folded(n: &Node) -> (u32, u32) {
    |                        ^^^^^^^^^^
    |
-   = help: return a struct with these fields: the names move into the signature, and members of one type can no longer trade places
+note: one of the calls that names them
+  --> $DIR/tuple_wants_struct.rs:62:26
+   |
+LL |     let (depth, width) = folded(n);
+   |                          ^^^^^^^^^
+   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
 
-warning: all 2 call sites of `grown`, in 2 functions, destructure this as `(depth, width)`: the members are named everywhere except in the type; `.0` and `.1` are both `u32`, so transposing them still type-checks
+warning: every one of the 2 calls to `grown` (in 2 functions) unpacks this as `(depth, width)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u32` a swapped pair still compiles
   --> $DIR/tuple_wants_struct.rs:73:23
    |
 LL | fn grown(n: &Node) -> (u32, u32) {
    |                       ^^^^^^^^^^
    |
-   = help: return a struct with these fields: the names move into the signature, and members of one type can no longer trade places
+note: one of the calls that names them
+  --> $DIR/tuple_wants_struct.rs:78:26
+   |
+LL |     (n.depth, n.width) = grown(n);
+   |                          ^^^^^^^^
+   = help: return a struct with fields `depth`, `width` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
 
-warning: all 4 call sites of `split`, in 3 functions, destructure this as `(key, value)`: the members are named everywhere except in the type; `.0` and `.1` are both `&str`, so transposing them still type-checks
+warning: every one of the 4 calls to `split` (in 3 functions) unpacks this as `(key, value)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `&str` a swapped pair still compiles
   --> $DIR/tuple_wants_struct.rs:89:22
    |
 LL | fn split(s: &str) -> Option<(&str, &str)> {
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return a struct with these fields: the names move into the signature, and members of one type can no longer trade places
+note: one of the calls that names them
+  --> $DIR/tuple_wants_struct.rs:97:24
+   |
+LL |     let (key, value) = split(s)?;
+   |                        ^^^^^^^^
+   = help: return a struct with fields `key`, `value` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
 
-warning: all 2 call sites of `bounds`, in 2 functions, destructure this as `(low, high)`: the members are named everywhere except in the type; `.0` and `.1` are both `u8`, so transposing them still type-checks
+warning: every one of the 2 calls to `bounds` (in 2 functions) unpacks this as `(low, high)`, so those are the members' names everywhere but in the type, and since `.0` and `.1` are both `u8` a swapped pair still compiles
   --> $DIR/tuple_wants_struct.rs:125:25
    |
 LL |     fn bounds(&self) -> Result<(u8, u8), ()> {
    |                         ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: return a struct with these fields: the names move into the signature, and members of one type can no longer trade places
+note: one of the calls that names them
+  --> $DIR/tuple_wants_struct.rs:130:27
+   |
+LL |         let (low, high) = self.bounds().map_err(|()| Unbounded)?;
+   |                           ^^^^^^^^^^^^^
+   = help: return a struct with fields `low`, `high` instead of the tuple; the names then live in the signature and same-typed members cannot trade places
 
 warning: 6 warnings emitted
 

--- a/ui/unchecked_construction.stderr
+++ b/ui/unchecked_construction.stderr
@@ -1,172 +1,172 @@
-warning: `port::Port` is constructed by hand here, skipping the check on `n` that `Port::new` makes before it will construct one
+warning: `port::Port` is b$DIRlt by hand here, skipping the check on `n` that `Port::new` makes
   --> $DIR/unchecked_construction.rs:37:5
    |
 LL |     Port { n: 0 }
    |     ^^^^^^^^^^^^^
    |
-note: the check in `Port::new` that this literal skips
+note: the check in `Port::new`
   --> $DIR/unchecked_construction.rs:13:16
    |
 LL |             if n <= u16::MAX as u32 {
    |                ^^^^^^^^^^^^^^^^^^^^
-   = help: construct it with `Port::new(..)`, or make `n` private so a literal like this only compiles inside `Port`'s own module
+   = help: b$DIRld it with `Port::new(..)`, or make `n` private so a literal like this only compiles inside `Port`'s module
    = note: `#[warn(unchecked_construction)]` on by default
 
-warning: `validators::NonZero` is constructed by hand here, skipping the check on `n` that `NonZero::new` makes before it will construct one
+warning: `validators::NonZero` is b$DIRlt by hand here, skipping the check on `n` that `NonZero::new` makes
   --> $DIR/unchecked_construction.rs:299:13
    |
 LL |     let _ = validators::NonZero { n: 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `NonZero::new` that this literal skips
+note: the check in `NonZero::new`
   --> $DIR/unchecked_construction.rs:241:13
    |
 LL |             match n {
    |             ^^^^^^^
-   = help: construct it with `NonZero::new(..)`, or make `n` private so a literal like this only compiles inside `NonZero`'s own module
+   = help: b$DIRld it with `NonZero::new(..)`, or make `n` private so a literal like this only compiles inside `NonZero`'s module
 
-warning: `not_validators_2::Header::port` is assigned directly here, skipping the check that `Header::decode` runs on `port` before storing it
+warning: `not_validators_2::Header::port` is assigned directly here, skipping the check on `port` that `Header::decode` makes
   --> $DIR/unchecked_construction.rs:313:9
    |
 LL |         h.port = 0;
    |         ^^^^^^^^^^
    |
-note: the check in `Header::decode` that this write skips
+note: the check in `Header::decode`
   --> $DIR/unchecked_construction.rs:159:16
    |
 LL |             if port == 0 {
    |                ^^^^^^^^^
-   = help: change `port` through a method of `Header` that repeats the check, or make `port` private so this write only compiles inside `Header`'s own module
+   = help: change `port` through a method of `Header` that repeats the check, or make `port` private so this write only compiles inside `Header`'s module
 
-warning: `validators::Even::n` is assigned directly here, skipping the check that `Even::new` runs on `n` before storing it
+warning: `validators::Even::n` is assigned directly here, skipping the check on `n` that `Even::new` makes
   --> $DIR/unchecked_construction.rs:316:9
    |
 LL |         e.n += 1;
    |         ^^^^^^^^
    |
-note: the check in `Even::new` that this write skips
+note: the check in `Even::new`
   --> $DIR/unchecked_construction.rs:201:17
    |
 LL |             if !is_even(n) {
    |                 ^^^^^^^^^^
-   = help: change `n` through a method of `Even` that repeats the check, or make `n` private so this write only compiles inside `Even`'s own module
+   = help: change `n` through a method of `Even` that repeats the check, or make `n` private so this write only compiles inside `Even`'s module
 
-warning: `validators::Small::n` is assigned directly here, skipping the check that `Small::new` runs on `n` before storing it
+warning: `validators::Small::n` is assigned directly here, skipping the check on `n` that `Small::new` makes
   --> $DIR/unchecked_construction.rs:319:9
    |
 LL |         s.n = 200;
    |         ^^^^^^^^^
    |
-note: the check in `Small::new` that this write skips
+note: the check in `Small::new`
   --> $DIR/unchecked_construction.rs:231:31
    |
 LL |             n.and_then(|n| if n < 10 { Some(Small { n }) } else { None })
    |                               ^^^^^^
-   = help: change `n` through a method of `Small` that repeats the check, or make `n` private so this write only compiles inside `Small`'s own module
+   = help: change `n` through a method of `Small` that repeats the check, or make `n` private so this write only compiles inside `Small`'s module
 
-warning: `validators::Checked` is constructed by hand here, skipping the check on `port` that `Checked::from_pairs` makes before it will construct one
+warning: `validators::Checked` is b$DIRlt by hand here, skipping the check on `port` that `Checked::from_pairs` makes
   --> $DIR/unchecked_construction.rs:328:13
    |
 LL |             Checked { port: 0, ..base },
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Checked::from_pairs` that this literal skips
+note: the check in `Checked::from_pairs`
   --> $DIR/unchecked_construction.rs:218:16
    |
 LL |             if port > 65535 {
    |                ^^^^^^^^^^^^
-   = help: construct it with `Checked::from_pairs(..)`, or make `port` private so a literal like this only compiles inside `Checked`'s own module
+   = help: b$DIRld it with `Checked::from_pairs(..)`, or make `port` private so a literal like this only compiles inside `Checked`'s module
 
-warning: `inner::Level` is produced with `mem::zeroed` here, skipping the check on `value` that `Level::new` makes before it will construct one
+warning: `inner::Level` is produced with `mem::zeroed` here, skipping the check on `value` that `Level::new` makes
   --> $DIR/unchecked_construction.rs:337:17
    |
 LL |                 std::mem::zeroed::<inner::Level>(),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Level::new` that this value never went through
+note: the check in `Level::new`
   --> $DIR/unchecked_construction.rs:257:16
    |
 LL |             if v <= 10 { Ok(Level { value: v }) } else { Err(()) }
    |                ^^^^^^^
-   = help: construct it with `Level::new(..)`, or add an explicitly unchecked constructor beside `Level::new` and call that, so the bypass is visible where the check lives
+   = help: b$DIRld it with `Level::new(..)`. If this path must skip the check, add an unchecked constructor next to `Level::new` and call that
 
-warning: `gate::Gate` is produced with `mem::transmute` here, skipping the check on `v` that `Gate::new` makes before it will construct one
+warning: `gate::Gate` is produced with `mem::transmute` here, skipping the check on `v` that `Gate::new` makes
   --> $DIR/unchecked_construction.rs:338:17
    |
 LL |                 std::mem::transmute::<u8, gate::Gate>(0),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Gate::new` that this value never went through
+note: the check in `Gate::new`
   --> $DIR/unchecked_construction.rs:406:16
    |
 LL |             if v < 2 { Some(Gate { v }) } else { None }
    |                ^^^^^
-   = help: construct it with `Gate::new(..)`, or add an explicitly unchecked constructor beside `Gate::new` and call that, so the bypass is visible where the check lives
+   = help: b$DIRld it with `Gate::new(..)`. If this path must skip the check, add an unchecked constructor next to `Gate::new` and call that
 
-warning: `gate::Gate` is produced with `MaybeUninit::assume_init` here, skipping the check on `v` that `Gate::new` makes before it will construct one
+warning: `gate::Gate` is produced with `MaybeUninit::assume_init` here, skipping the check on `v` that `Gate::new` makes
   --> $DIR/unchecked_construction.rs:339:17
    |
 LL |                 std::mem::MaybeUninit::<gate::Gate>::zeroed().assume_init(),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Gate::new` that this value never went through
+note: the check in `Gate::new`
   --> $DIR/unchecked_construction.rs:406:16
    |
 LL |             if v < 2 { Some(Gate { v }) } else { None }
    |                ^^^^^
-   = help: construct it with `Gate::new(..)`, or add an explicitly unchecked constructor beside `Gate::new` and call that, so the bypass is visible where the check lives
+   = help: b$DIRld it with `Gate::new(..)`. If this path must skip the check, add an unchecked constructor next to `Gate::new` and call that
 
-warning: `widened::Tag::s` is assigned directly here, skipping the check that `Tag::new` runs on `s` before storing it
+warning: `widened::Tag::s` is assigned directly here, skipping the check on `s` that `Tag::new` makes
   --> $DIR/unchecked_construction.rs:432:13
    |
 LL |             u.s = "";
    |             ^^^^^^^^
    |
-note: the check in `Tag::new` that this write skips
+note: the check in `Tag::new`
   --> $DIR/unchecked_construction.rs:422:16
    |
 LL |             if s.is_empty() { None } else { Some(Tag { s }) }
    |                ^^^^^^^^^^^^
-   = help: change `s` through a method of `Tag` that repeats the check, or make `s` private so this write only compiles inside `Tag`'s own module
+   = help: change `s` through a method of `Tag` that repeats the check, or make `s` private so this write only compiles inside `Tag`'s module
 
-warning: `promoted::Slot` is produced with `mem::transmute` here, skipping the check on `n` that `Slot::promote` makes before it will construct one
+warning: `promoted::Slot` is produced with `mem::transmute` here, skipping the check on `n` that `Slot::promote` makes
   --> $DIR/unchecked_construction.rs:465:22
    |
 LL |             unsafe { std::mem::transmute::<Slot<Raw>, Slot<Ok>>(s) }
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Slot::promote` that this value never went through
+note: the check in `Slot::promote`
   --> $DIR/unchecked_construction.rs:451:16
    |
 LL |             if n == 0 { None } else { Some(Slot { n, state: PhantomData }) }
    |                ^^^^^^
-   = help: construct it with `Slot::promote(..)`, or add an explicitly unchecked constructor beside `Slot::promote` and call that, so the bypass is visible where the check lives
+   = help: b$DIRld it with `Slot::promote(..)`. If this path must skip the check, add an unchecked constructor next to `Slot::promote` and call that
 
-warning: `two_validators::Pair` is constructed by hand here, skipping the check on `b` that `Pair::parse` makes before it will construct one
+warning: `two_validators::Pair` is b$DIRlt by hand here, skipping the check on `b` that `Pair::parse` makes
   --> $DIR/unchecked_construction.rs:492:13
    |
 LL |             Pair { b: 200, ..base }
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check in `Pair::parse` that this literal skips
+note: the check in `Pair::parse`
   --> $DIR/unchecked_construction.rs:482:16
    |
 LL |             if b > 99 { None } else { Some(Pair { a: 0, b }) }
    |                ^^^^^^
-   = help: construct it with `Pair::parse(..)`, or make `b` private so a literal like this only compiles inside `Pair`'s own module
+   = help: b$DIRld it with `Pair::parse(..)`, or make `b` private so a literal like this only compiles inside `Pair`'s module
 
-warning: `tuple::Digit` is constructed by hand here, skipping the check on `0` that `Digit::new` makes before it will construct one
+warning: `tuple::Digit` is b$DIRlt by hand here, skipping the check on `0` that `Digit::new` makes
   --> $DIR/unchecked_construction.rs:514:14
    |
 LL |             (Digit(10), Plain(10))
    |              ^^^^^^^^^
    |
-note: the check in `Digit::new` that this literal skips
+note: the check in `Digit::new`
   --> $DIR/unchecked_construction.rs:502:16
    |
 LL |             if d > 9 { None } else { Some(Digit(d)) }
    |                ^^^^^
-   = help: construct it with `Digit::new(..)`, or make `0` private so a literal like this only compiles inside `Digit`'s own module
+   = help: b$DIRld it with `Digit::new(..)`, or make `0` private so a literal like this only compiles inside `Digit`'s module
 
 warning: 13 warnings emitted
 

--- a/ui/unchecked_construction.stderr
+++ b/ui/unchecked_construction.stderr
@@ -1,172 +1,172 @@
-warning: `port::Port` is constructed by literal here, but `Port::new` checks `n` before constructing one
+warning: `port::Port` is constructed by hand here, skipping the check on `n` that `Port::new` makes before it will construct one
   --> $DIR/unchecked_construction.rs:37:5
    |
 LL |     Port { n: 0 }
    |     ^^^^^^^^^^^^^
    |
-note: the check this literal never runs
+note: the check in `Port::new` that this literal skips
   --> $DIR/unchecked_construction.rs:13:16
    |
 LL |             if n <= u16::MAX as u32 {
    |                ^^^^^^^^^^^^^^^^^^^^
-   = help: construct through the validating function, or move this literal into the type's module
+   = help: construct it with `Port::new(..)`, or make `n` private so a literal like this only compiles inside `Port`'s own module
    = note: `#[warn(unchecked_construction)]` on by default
 
-warning: `validators::NonZero` is constructed by literal here, but `NonZero::new` checks `n` before constructing one
+warning: `validators::NonZero` is constructed by hand here, skipping the check on `n` that `NonZero::new` makes before it will construct one
   --> $DIR/unchecked_construction.rs:299:13
    |
 LL |     let _ = validators::NonZero { n: 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this literal never runs
+note: the check in `NonZero::new` that this literal skips
   --> $DIR/unchecked_construction.rs:241:13
    |
 LL |             match n {
    |             ^^^^^^^
-   = help: construct through the validating function, or move this literal into the type's module
+   = help: construct it with `NonZero::new(..)`, or make `n` private so a literal like this only compiles inside `NonZero`'s own module
 
-warning: `not_validators_2::Header::port` is written directly here, but `Header::decode` rejects some values of `port` before storing one
+warning: `not_validators_2::Header::port` is assigned directly here, skipping the check that `Header::decode` runs on `port` before storing it
   --> $DIR/unchecked_construction.rs:313:9
    |
 LL |         h.port = 0;
    |         ^^^^^^^^^^
    |
-note: the check this write never runs
+note: the check in `Header::decode` that this write skips
   --> $DIR/unchecked_construction.rs:159:16
    |
 LL |             if port == 0 {
    |                ^^^^^^^^^
-   = help: change the value through the validating function, or make the field private and move this write into the type's module
+   = help: change `port` through a method of `Header` that repeats the check, or make `port` private so this write only compiles inside `Header`'s own module
 
-warning: `validators::Even::n` is written directly here, but `Even::new` rejects some values of `n` before storing one
+warning: `validators::Even::n` is assigned directly here, skipping the check that `Even::new` runs on `n` before storing it
   --> $DIR/unchecked_construction.rs:316:9
    |
 LL |         e.n += 1;
    |         ^^^^^^^^
    |
-note: the check this write never runs
+note: the check in `Even::new` that this write skips
   --> $DIR/unchecked_construction.rs:201:17
    |
 LL |             if !is_even(n) {
    |                 ^^^^^^^^^^
-   = help: change the value through the validating function, or make the field private and move this write into the type's module
+   = help: change `n` through a method of `Even` that repeats the check, or make `n` private so this write only compiles inside `Even`'s own module
 
-warning: `validators::Small::n` is written directly here, but `Small::new` rejects some values of `n` before storing one
+warning: `validators::Small::n` is assigned directly here, skipping the check that `Small::new` runs on `n` before storing it
   --> $DIR/unchecked_construction.rs:319:9
    |
 LL |         s.n = 200;
    |         ^^^^^^^^^
    |
-note: the check this write never runs
+note: the check in `Small::new` that this write skips
   --> $DIR/unchecked_construction.rs:231:31
    |
 LL |             n.and_then(|n| if n < 10 { Some(Small { n }) } else { None })
    |                               ^^^^^^
-   = help: change the value through the validating function, or make the field private and move this write into the type's module
+   = help: change `n` through a method of `Small` that repeats the check, or make `n` private so this write only compiles inside `Small`'s own module
 
-warning: `validators::Checked` is constructed by literal here, but `Checked::from_pairs` checks `port` before constructing one
+warning: `validators::Checked` is constructed by hand here, skipping the check on `port` that `Checked::from_pairs` makes before it will construct one
   --> $DIR/unchecked_construction.rs:328:13
    |
 LL |             Checked { port: 0, ..base },
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this literal never runs
+note: the check in `Checked::from_pairs` that this literal skips
   --> $DIR/unchecked_construction.rs:218:16
    |
 LL |             if port > 65535 {
    |                ^^^^^^^^^^^^
-   = help: construct through the validating function, or move this literal into the type's module
+   = help: construct it with `Checked::from_pairs(..)`, or make `port` private so a literal like this only compiles inside `Checked`'s own module
 
-warning: `inner::Level` is produced by `mem::zeroed` here, but `Level::new` checks `value` before constructing one
+warning: `inner::Level` is produced with `mem::zeroed` here, skipping the check on `value` that `Level::new` makes before it will construct one
   --> $DIR/unchecked_construction.rs:337:17
    |
 LL |                 std::mem::zeroed::<inner::Level>(),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this value never went through
+note: the check in `Level::new` that this value never went through
   --> $DIR/unchecked_construction.rs:257:16
    |
 LL |             if v <= 10 { Ok(Level { value: v }) } else { Err(()) }
    |                ^^^^^^^
-   = help: construct through the validating function
+   = help: construct it with `Level::new(..)`, or add an explicitly unchecked constructor beside `Level::new` and call that, so the bypass is visible where the check lives
 
-warning: `gate::Gate` is produced by `mem::transmute` here, but `Gate::new` checks `v` before constructing one
+warning: `gate::Gate` is produced with `mem::transmute` here, skipping the check on `v` that `Gate::new` makes before it will construct one
   --> $DIR/unchecked_construction.rs:338:17
    |
 LL |                 std::mem::transmute::<u8, gate::Gate>(0),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this value never went through
+note: the check in `Gate::new` that this value never went through
   --> $DIR/unchecked_construction.rs:406:16
    |
 LL |             if v < 2 { Some(Gate { v }) } else { None }
    |                ^^^^^
-   = help: construct through the validating function
+   = help: construct it with `Gate::new(..)`, or add an explicitly unchecked constructor beside `Gate::new` and call that, so the bypass is visible where the check lives
 
-warning: `gate::Gate` is produced by `MaybeUninit::assume_init` here, but `Gate::new` checks `v` before constructing one
+warning: `gate::Gate` is produced with `MaybeUninit::assume_init` here, skipping the check on `v` that `Gate::new` makes before it will construct one
   --> $DIR/unchecked_construction.rs:339:17
    |
 LL |                 std::mem::MaybeUninit::<gate::Gate>::zeroed().assume_init(),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this value never went through
+note: the check in `Gate::new` that this value never went through
   --> $DIR/unchecked_construction.rs:406:16
    |
 LL |             if v < 2 { Some(Gate { v }) } else { None }
    |                ^^^^^
-   = help: construct through the validating function
+   = help: construct it with `Gate::new(..)`, or add an explicitly unchecked constructor beside `Gate::new` and call that, so the bypass is visible where the check lives
 
-warning: `widened::Tag::s` is written directly here, but `Tag::new` rejects some values of `s` before storing one
+warning: `widened::Tag::s` is assigned directly here, skipping the check that `Tag::new` runs on `s` before storing it
   --> $DIR/unchecked_construction.rs:432:13
    |
 LL |             u.s = "";
    |             ^^^^^^^^
    |
-note: the check this write never runs
+note: the check in `Tag::new` that this write skips
   --> $DIR/unchecked_construction.rs:422:16
    |
 LL |             if s.is_empty() { None } else { Some(Tag { s }) }
    |                ^^^^^^^^^^^^
-   = help: change the value through the validating function, or make the field private and move this write into the type's module
+   = help: change `s` through a method of `Tag` that repeats the check, or make `s` private so this write only compiles inside `Tag`'s own module
 
-warning: `promoted::Slot` is produced by `mem::transmute` here, but `Slot::promote` checks `n` before constructing one
+warning: `promoted::Slot` is produced with `mem::transmute` here, skipping the check on `n` that `Slot::promote` makes before it will construct one
   --> $DIR/unchecked_construction.rs:465:22
    |
 LL |             unsafe { std::mem::transmute::<Slot<Raw>, Slot<Ok>>(s) }
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this value never went through
+note: the check in `Slot::promote` that this value never went through
   --> $DIR/unchecked_construction.rs:451:16
    |
 LL |             if n == 0 { None } else { Some(Slot { n, state: PhantomData }) }
    |                ^^^^^^
-   = help: construct through the validating function
+   = help: construct it with `Slot::promote(..)`, or add an explicitly unchecked constructor beside `Slot::promote` and call that, so the bypass is visible where the check lives
 
-warning: `two_validators::Pair` is constructed by literal here, but `Pair::parse` checks `b` before constructing one
+warning: `two_validators::Pair` is constructed by hand here, skipping the check on `b` that `Pair::parse` makes before it will construct one
   --> $DIR/unchecked_construction.rs:492:13
    |
 LL |             Pair { b: 200, ..base }
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the check this literal never runs
+note: the check in `Pair::parse` that this literal skips
   --> $DIR/unchecked_construction.rs:482:16
    |
 LL |             if b > 99 { None } else { Some(Pair { a: 0, b }) }
    |                ^^^^^^
-   = help: construct through the validating function, or move this literal into the type's module
+   = help: construct it with `Pair::parse(..)`, or make `b` private so a literal like this only compiles inside `Pair`'s own module
 
-warning: `tuple::Digit` is constructed by literal here, but `Digit::new` checks `0` before constructing one
+warning: `tuple::Digit` is constructed by hand here, skipping the check on `0` that `Digit::new` makes before it will construct one
   --> $DIR/unchecked_construction.rs:514:14
    |
 LL |             (Digit(10), Plain(10))
    |              ^^^^^^^^^
    |
-note: the check this literal never runs
+note: the check in `Digit::new` that this literal skips
   --> $DIR/unchecked_construction.rs:502:16
    |
 LL |             if d > 9 { None } else { Some(Digit(d)) }
    |                ^^^^^
-   = help: construct through the validating function, or move this literal into the type's module
+   = help: construct it with `Digit::new(..)`, or make `0` private so a literal like this only compiles inside `Digit`'s own module
 
 warning: 13 warnings emitted
 

--- a/ui/unchecked_input_len.stderr
+++ b/ui/unchecked_input_len.stderr
@@ -1,185 +1,185 @@
-warning: `hdr.len` comes from the caller and is passed to `get_unchecked` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
+warning: `hdr.len` comes from the caller and reaches `get_unchecked` here with no check on this path. The function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:28:18
    |
 LL |     unsafe { buf.get_unchecked(..hdr.len) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound on `hdr.len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:23:12
    |
 LL |         if hdr.len > buf.len() {
    |            ^^^^^^^^^^^^^^^^^^^
-   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `get_unchecked` can be given here
+   = help: check `hdr.len` on every path before this call, or once before the paths split
    = note: `#[warn(unchecked_input_len)]` on by default
 
-warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
+warning: `len` comes from the caller and reaches `split_at` here with no check on this path. The function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:32:25
    |
 LL |     let (head, _) = buf.split_at(len);
    |                         ^^^^^^^^^^^^^
    |
-note: the bound on `len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:33:8
    |
 LL |     if len > buf.len() {
    |        ^^^^^^^^^^^^^^^
-   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
+   = help: check `len` on every path before this call, or once before the paths split
 
-warning: `n` comes from the caller and is passed to `with_capacity` here on a path where nothing has checked it, although this function does bound `n` on another path
+warning: `n` comes from the caller and reaches `with_capacity` here with no check on this path. The function does bound `n` on another path
   --> $DIR/unchecked_input_len.rs:41:15
    |
 LL |     let out = Vec::with_capacity(n);
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound on `n` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:42:8
    |
 LL |     if n > 1 << 20 {
    |        ^^^^^^^^^^^
-   = help: check `n` before this call on every path (or once, before the paths split), or make the checked value the only thing `with_capacity` can be given here
+   = help: check `n` on every path before this call, or once before the paths split
 
-warning: `hdr.count` comes from the caller and is passed to `reserve` here on a path where nothing has checked it, although this function does bound `hdr.count` on another path
+warning: `hdr.count` comes from the caller and reaches `reserve` here with no check on this path. The function does bound `hdr.count` on another path
   --> $DIR/unchecked_input_len.rs:52:9
    |
 LL |     out.reserve(hdr.count as usize);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound on `hdr.count` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:49:25
    |
 LL |     if hdr.kind == 2 && hdr.count > 1024 {
    |                         ^^^^^^^^^^^^^^^^
-   = help: check `hdr.count` before this call on every path (or once, before the paths split), or make the checked value the only thing `reserve` can be given here
+   = help: check `hdr.count` on every path before this call, or once before the paths split
 
-warning: `len` comes from the caller and is passed to `get_unchecked` here on a path where nothing has checked it, although this function does bound `len` on another path
+warning: `len` comes from the caller and reaches `get_unchecked` here with no check on this path. The function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:60:22
    |
 LL |         unsafe { buf.get_unchecked(..len) }.len()
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound on `len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:57:22
    |
 LL |         if strict && len > buf.len() {
    |                      ^^^^^^^^^^^^^^^
-   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `get_unchecked` can be given here
+   = help: check `len` on every path before this call, or once before the paths split
 
-warning: `hdr.len` comes from the caller and is passed to `get_unchecked` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
+warning: `hdr.len` comes from the caller and reaches `get_unchecked` here with no check on this path. The function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:71:18
    |
 LL |     unsafe { buf.get_unchecked(..hdr.len) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound on `hdr.len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:66:12
    |
 LL |         if hdr.len + 4 > buf.len() {
    |            ^^^^^^^^^^^^^^^^^^^^^^^
-   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `get_unchecked` can be given here
+   = help: check `hdr.len` on every path before this call, or once before the paths split
 
-warning: `off` comes from the caller and is passed to `add` here on a path where nothing has checked it, although this function does bound `off` on another path
+warning: `off` comes from the caller and reaches `add` here with no check on this path. The function does bound `off` on another path
   --> $DIR/unchecked_input_len.rs:75:27
    |
 LL |     let p = unsafe { base.add(off) };
    |                           ^^^^^^^^
    |
-note: the bound on `off` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:76:8
    |
 LL |     if off >= cap {
    |        ^^^^^^^^^^
-   = help: check `off` before this call on every path (or once, before the paths split), or make the checked value the only thing `add` can be given here
+   = help: check `off` on every path before this call, or once before the paths split
 
-warning: `hdr.len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
+warning: `hdr.len` comes from the caller and reaches `split_at` here with no check on this path. The function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:92:9
    |
 LL |     buf.split_at(hdr.len).0.len()
    |         ^^^^^^^^^^^^^^^^^
    |
-note: the bound on `hdr.len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:85:16
    |
 LL |             if hdr.len > buf.len() {
    |                ^^^^^^^^^^^^^^^^^^^
-   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
+   = help: check `hdr.len` on every path before this call, or once before the paths split
 
-warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
+warning: `len` comes from the caller and reaches `split_at` here with no check on this path. The function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:101:25
    |
 LL |     let (head, _) = buf.split_at(len);
    |                         ^^^^^^^^^^^^^
    |
-note: the bound on `len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:102:8
    |
 LL |     if len > buf.len() {
    |        ^^^^^^^^^^^^^^^
-   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
+   = help: check `len` on every path before this call, or once before the paths split
 
-warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
+warning: `len` comes from the caller and reaches `split_at` here with no check on this path. The function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:110:25
    |
 LL |     let (head, _) = buf.split_at(len);
    |                         ^^^^^^^^^^^^^
    |
-note: the bound on `len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:111:8
    |
 LL |     if len > buf.len() {
    |        ^^^^^^^^^^^^^^^
-   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
+   = help: check `len` on every path before this call, or once before the paths split
 
-warning: `len` comes from the caller and is passed to `add` here on a path where nothing has checked it, although this function does bound `len` on another path
+warning: `len` comes from the caller and reaches `add` here with no check on this path. The function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:124:39
    |
 LL |         let p = unsafe { buf.as_ptr().add(len) };
    |                                       ^^^^^^^^
    |
-note: the bound on `len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:125:12
    |
 LL |         if len > buf.len() {
    |            ^^^^^^^^^^^^^^^
-   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `add` can be given here
+   = help: check `len` on every path before this call, or once before the paths split
 
-warning: `hdr.len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
+warning: `hdr.len` comes from the caller and reaches `split_at` here with no check on this path. The function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:137:9
    |
 LL |     buf.split_at(hdr.len).0
    |         ^^^^^^^^^^^^^^^^^
    |
-note: the bound on `hdr.len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:134:26
    |
 LL |     if hdr.kind == 1 && (hdr.len > buf.len() || !fits(&hdr.len, buf)) {
    |                          ^^^^^^^^^^^^^^^^^^^
-   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
+   = help: check `hdr.len` on every path before this call, or once before the paths split
 
-warning: `q.len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `q.len` on another path
+warning: `q.len` comes from the caller and reaches `split_at` here with no check on this path. The function does bound `q.len` on another path
   --> $DIR/unchecked_input_len.rs:145:9
    |
 LL |     buf.split_at(unsafe { (*q).len }).0.len()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound on `q.len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:142:37
    |
 LL |     if unsafe { (*q).kind } == 1 && unsafe { (*q).len } > buf.len() {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: check `q.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
+   = help: check `q.len` on every path before this call, or once before the paths split
 
-warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
+warning: `len` comes from the caller and reaches `split_at` here with no check on this path. The function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:156:9
    |
 LL |     buf.split_at(len).0.len()
    |         ^^^^^^^^^^^^^
    |
-note: the bound on `len` that does not cover this path
+note: the bound that does not cover this path
   --> $DIR/unchecked_input_len.rs:153:20
    |
 LL |     if sum == 0 && len > buf.len() {
    |                    ^^^^^^^^^^^^^^^
-   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
+   = help: check `len` on every path before this call, or once before the paths split
 
 warning: 14 warnings emitted
 

--- a/ui/unchecked_input_len.stderr
+++ b/ui/unchecked_input_len.stderr
@@ -1,185 +1,185 @@
-warning: `hdr.len` reaches `get_unchecked` here without having been checked, though this function bounds it elsewhere
+warning: `hdr.len` comes from the caller and is passed to `get_unchecked` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:28:18
    |
 LL |     unsafe { buf.get_unchecked(..hdr.len) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `hdr.len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:23:12
    |
 LL |         if hdr.len > buf.len() {
    |            ^^^^^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `get_unchecked` can be given here
    = note: `#[warn(unchecked_input_len)]` on by default
 
-warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:32:25
    |
 LL |     let (head, _) = buf.split_at(len);
    |                         ^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:33:8
    |
 LL |     if len > buf.len() {
    |        ^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
 
-warning: `n` reaches `with_capacity` here without having been checked, though this function bounds it elsewhere
+warning: `n` comes from the caller and is passed to `with_capacity` here on a path where nothing has checked it, although this function does bound `n` on another path
   --> $DIR/unchecked_input_len.rs:41:15
    |
 LL |     let out = Vec::with_capacity(n);
    |               ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `n` that does not cover this path
   --> $DIR/unchecked_input_len.rs:42:8
    |
 LL |     if n > 1 << 20 {
    |        ^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `n` before this call on every path (or once, before the paths split), or make the checked value the only thing `with_capacity` can be given here
 
-warning: `hdr.count` reaches `reserve` here without having been checked, though this function bounds it elsewhere
+warning: `hdr.count` comes from the caller and is passed to `reserve` here on a path where nothing has checked it, although this function does bound `hdr.count` on another path
   --> $DIR/unchecked_input_len.rs:52:9
    |
 LL |     out.reserve(hdr.count as usize);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `hdr.count` that does not cover this path
   --> $DIR/unchecked_input_len.rs:49:25
    |
 LL |     if hdr.kind == 2 && hdr.count > 1024 {
    |                         ^^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `hdr.count` before this call on every path (or once, before the paths split), or make the checked value the only thing `reserve` can be given here
 
-warning: `len` reaches `get_unchecked` here without having been checked, though this function bounds it elsewhere
+warning: `len` comes from the caller and is passed to `get_unchecked` here on a path where nothing has checked it, although this function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:60:22
    |
 LL |         unsafe { buf.get_unchecked(..len) }.len()
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:57:22
    |
 LL |         if strict && len > buf.len() {
    |                      ^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `get_unchecked` can be given here
 
-warning: `hdr.len` reaches `get_unchecked` here without having been checked, though this function bounds it elsewhere
+warning: `hdr.len` comes from the caller and is passed to `get_unchecked` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:71:18
    |
 LL |     unsafe { buf.get_unchecked(..hdr.len) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `hdr.len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:66:12
    |
 LL |         if hdr.len + 4 > buf.len() {
    |            ^^^^^^^^^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `get_unchecked` can be given here
 
-warning: `off` reaches `add` here without having been checked, though this function bounds it elsewhere
+warning: `off` comes from the caller and is passed to `add` here on a path where nothing has checked it, although this function does bound `off` on another path
   --> $DIR/unchecked_input_len.rs:75:27
    |
 LL |     let p = unsafe { base.add(off) };
    |                           ^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `off` that does not cover this path
   --> $DIR/unchecked_input_len.rs:76:8
    |
 LL |     if off >= cap {
    |        ^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `off` before this call on every path (or once, before the paths split), or make the checked value the only thing `add` can be given here
 
-warning: `hdr.len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+warning: `hdr.len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:92:9
    |
 LL |     buf.split_at(hdr.len).0.len()
    |         ^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `hdr.len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:85:16
    |
 LL |             if hdr.len > buf.len() {
    |                ^^^^^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
 
-warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:101:25
    |
 LL |     let (head, _) = buf.split_at(len);
    |                         ^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:102:8
    |
 LL |     if len > buf.len() {
    |        ^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
 
-warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:110:25
    |
 LL |     let (head, _) = buf.split_at(len);
    |                         ^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:111:8
    |
 LL |     if len > buf.len() {
    |        ^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
 
-warning: `len` reaches `add` here without having been checked, though this function bounds it elsewhere
+warning: `len` comes from the caller and is passed to `add` here on a path where nothing has checked it, although this function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:124:39
    |
 LL |         let p = unsafe { buf.as_ptr().add(len) };
    |                                       ^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:125:12
    |
 LL |         if len > buf.len() {
    |            ^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `add` can be given here
 
-warning: `hdr.len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+warning: `hdr.len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `hdr.len` on another path
   --> $DIR/unchecked_input_len.rs:137:9
    |
 LL |     buf.split_at(hdr.len).0
    |         ^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `hdr.len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:134:26
    |
 LL |     if hdr.kind == 1 && (hdr.len > buf.len() || !fits(&hdr.len, buf)) {
    |                          ^^^^^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `hdr.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
 
-warning: `q.len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+warning: `q.len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `q.len` on another path
   --> $DIR/unchecked_input_len.rs:145:9
    |
 LL |     buf.split_at(unsafe { (*q).len }).0.len()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `q.len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:142:37
    |
 LL |     if unsafe { (*q).kind } == 1 && unsafe { (*q).len } > buf.len() {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `q.len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
 
-warning: `len` reaches `split_at` here without having been checked, though this function bounds it elsewhere
+warning: `len` comes from the caller and is passed to `split_at` here on a path where nothing has checked it, although this function does bound `len` on another path
   --> $DIR/unchecked_input_len.rs:156:9
    |
 LL |     buf.split_at(len).0.len()
    |         ^^^^^^^^^^^^^
    |
-note: the bound that does not cover this use
+note: the bound on `len` that does not cover this path
   --> $DIR/unchecked_input_len.rs:153:20
    |
 LL |     if sum == 0 && len > buf.len() {
    |                    ^^^^^^^^^^^^^^^
-   = help: check it before it sizes anything on every path, or make the check the only way to obtain the value this use takes
+   = help: check `len` before this call on every path (or once, before the paths split), or make the checked value the only thing `split_at` can be given here
 
 warning: 14 warnings emitted
 

--- a/ui/unit_mismatch.stderr
+++ b/ui/unit_mismatch.stderr
@@ -1,35 +1,35 @@
-warning: `timeout_ms` claims ms and `deadline_ns` claims ns; arithmetic between them mixes units
+warning: `timeout_ms` says it is in ms and `deadline_ns` says ns, and this arithmetic uses them as if they were the same unit
   --> $DIR/unit_mismatch.rs:11:5
    |
 LL |     t.timeout_ms + t.deadline_ns
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side, or rename whichever name is lying about its unit
+   = help: convert one side to the other's unit first, or if `timeout_ms` or `deadline_ns` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
    = note: `#[warn(unit_mismatch)]` on by default
 
-warning: `timeout_ms` claims ms and `deadline_ns` claims ns; comparison between them mixes units
+warning: `timeout_ms` says it is in ms and `deadline_ns` says ns, and this comparison uses them as if they were the same unit
   --> $DIR/unit_mismatch.rs:15:5
    |
 LL |     t.timeout_ms < t.deadline_ns
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side, or rename whichever name is lying about its unit
+   = help: convert one side to the other's unit first, or if `timeout_ms` or `deadline_ns` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
 
-warning: `timeout_ms` claims ms and `size_bytes` claims bytes; comparison between them mixes units
+warning: `timeout_ms` says it is in ms and `size_bytes` says bytes, and this comparison uses them as if they were the same unit
   --> $DIR/unit_mismatch.rs:19:5
    |
 LL |     t.timeout_ms == t.size_bytes
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side, or rename whichever name is lying about its unit
+   = help: convert one side to the other's unit first, or if `timeout_ms` or `size_bytes` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
 
-warning: `timeout_ms` claims ms and `elapsed_ns` claims ns; arithmetic between them mixes units
+warning: `timeout_ms` says it is in ms and `elapsed_ns` says ns, and this arithmetic uses them as if they were the same unit
   --> $DIR/unit_mismatch.rs:40:5
    |
 LL |     t.timeout_ms + elapsed_ns()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side, or rename whichever name is lying about its unit
+   = help: convert one side to the other's unit first, or if `timeout_ms` or `elapsed_ns` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
 
 warning: 4 warnings emitted
 

--- a/ui/unit_mismatch.stderr
+++ b/ui/unit_mismatch.stderr
@@ -1,35 +1,35 @@
-warning: `timeout_ms` says it is in ms and `deadline_ns` says ns, and this arithmetic uses them as if they were the same unit
+warning: `timeout_ms` says milliseconds and `deadline_ns` says nanoseconds, and this arithmetic mixes them
   --> $DIR/unit_mismatch.rs:11:5
    |
 LL |     t.timeout_ms + t.deadline_ns
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side to the other's unit first, or if `timeout_ms` or `deadline_ns` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
+   = help: convert one side first. If a name is wrong about its unit, rename it. A `Duration` or a unit newtype would catch the next one
    = note: `#[warn(unit_mismatch)]` on by default
 
-warning: `timeout_ms` says it is in ms and `deadline_ns` says ns, and this comparison uses them as if they were the same unit
+warning: `timeout_ms` says milliseconds and `deadline_ns` says nanoseconds, and this comparison mixes them
   --> $DIR/unit_mismatch.rs:15:5
    |
 LL |     t.timeout_ms < t.deadline_ns
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side to the other's unit first, or if `timeout_ms` or `deadline_ns` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
+   = help: convert one side first. If a name is wrong about its unit, rename it. A `Duration` or a unit newtype would catch the next one
 
-warning: `timeout_ms` says it is in ms and `size_bytes` says bytes, and this comparison uses them as if they were the same unit
+warning: `timeout_ms` says milliseconds and `size_bytes` says bytes, and this comparison mixes them
   --> $DIR/unit_mismatch.rs:19:5
    |
 LL |     t.timeout_ms == t.size_bytes
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side to the other's unit first, or if `timeout_ms` or `size_bytes` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
+   = help: convert one side first. If a name is wrong about its unit, rename it. A `Duration` or a unit newtype would catch the next one
 
-warning: `timeout_ms` says it is in ms and `elapsed_ns` says ns, and this arithmetic uses them as if they were the same unit
+warning: `timeout_ms` says milliseconds and `elapsed_ns` says nanoseconds, and this arithmetic mixes them
   --> $DIR/unit_mismatch.rs:40:5
    |
 LL |     t.timeout_ms + elapsed_ns()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: convert one side to the other's unit first, or if `timeout_ms` or `elapsed_ns` is wrong about its unit, rename it; a `Duration` or a unit newtype makes the compiler catch the next one
+   = help: convert one side first. If a name is wrong about its unit, rename it. A `Duration` or a unit newtype would catch the next one
 
 warning: 4 warnings emitted
 

--- a/ui/unread_error_variant.stderr
+++ b/ui/unread_error_variant.stderr
@@ -1,35 +1,55 @@
-warning: `LoadError::Corrupt` is constructed here, but no pattern outside `LoadError`'s trait impls ever names it
+warning: `LoadError::Corrupt` is constructed here, but no `match` arm or pattern anywhere (outside `LoadError`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
   --> $DIR/unread_error_variant.rs:26:18
    |
 LL |         1 => Err(LoadError::Corrupt("bad header".to_owned())),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the variant's structure is never read; handle it distinctly or collapse it into another variant
+note: the variant, which nothing matches on
+  --> $DIR/unread_error_variant.rs:9:5
+   |
+LL |     Corrupt(String),
+   |     ^^^^^^^
+   = help: add an arm for `LoadError::Corrupt` where `LoadError` is matched, or fold it into the variant it is currently lumped with
    = note: `#[warn(unread_error_variant)]` on by default
 
-warning: `Mode::Slow` is constructed here, but no pattern outside `Mode`'s trait impls ever names it
+warning: `Mode::Slow` is constructed here, but no `match` arm or pattern anywhere (outside `Mode`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
   --> $DIR/unread_error_variant.rs:96:31
    |
 LL |     speed(Mode::Fast) + speed(Mode::Slow) + speed(Mode::Crawl) + speed(Mode::Off)
    |                               ^^^^^^^^^^
    |
-   = help: the variant's structure is never read; handle it distinctly or collapse it into another variant
+note: the variant, which nothing matches on
+  --> $DIR/unread_error_variant.rs:83:5
+   |
+LL |     Slow,
+   |     ^^^^
+   = help: add an arm for `Mode::Slow` where `Mode` is matched, or fold it into the variant it is currently lumped with
 
-warning: `Mode::Crawl` is constructed here, but no pattern outside `Mode`'s trait impls ever names it
+warning: `Mode::Crawl` is constructed here, but no `match` arm or pattern anywhere (outside `Mode`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
   --> $DIR/unread_error_variant.rs:96:51
    |
 LL |     speed(Mode::Fast) + speed(Mode::Slow) + speed(Mode::Crawl) + speed(Mode::Off)
    |                                                   ^^^^^^^^^^^
    |
-   = help: the variant's structure is never read; handle it distinctly or collapse it into another variant
+note: the variant, which nothing matches on
+  --> $DIR/unread_error_variant.rs:84:5
+   |
+LL |     Crawl,
+   |     ^^^^^
+   = help: add an arm for `Mode::Crawl` where `Mode` is matched, or fold it into the variant it is currently lumped with
 
-warning: `ParseError::Malformed` is constructed here, but no pattern outside `ParseError`'s trait impls ever names it
+warning: `ParseError::Malformed` is constructed here, but no `match` arm or pattern anywhere (outside `ParseError`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
   --> $DIR/unread_error_variant.rs:176:30
    |
 LL |     s.parse::<u32>().map_err(ParseError::Malformed)
    |                              ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: the variant's structure is never read; handle it distinctly or collapse it into another variant
+note: the variant, which nothing matches on
+  --> $DIR/unread_error_variant.rs:169:5
+   |
+LL |     Malformed(std::num::ParseIntError),
+   |     ^^^^^^^^^
+   = help: add an arm for `ParseError::Malformed` where `ParseError` is matched, or fold it into the variant it is currently lumped with
 
 warning: 4 warnings emitted
 

--- a/ui/unread_error_variant.stderr
+++ b/ui/unread_error_variant.stderr
@@ -1,55 +1,55 @@
-warning: `LoadError::Corrupt` is constructed here, but no `match` arm or pattern anywhere (outside `LoadError`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
+warning: `LoadError::Corrupt` is constructed here, but no pattern anywhere singles it out (its own trait impls aside). What it carries is never read, and it is only ever caught by a catch-all
   --> $DIR/unread_error_variant.rs:26:18
    |
 LL |         1 => Err(LoadError::Corrupt("bad header".to_owned())),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the variant, which nothing matches on
+note: the variant
   --> $DIR/unread_error_variant.rs:9:5
    |
 LL |     Corrupt(String),
    |     ^^^^^^^
-   = help: add an arm for `LoadError::Corrupt` where `LoadError` is matched, or fold it into the variant it is currently lumped with
+   = help: add an arm for `LoadError::Corrupt` where `LoadError` is matched, or fold it into the variant it is lumped with
    = note: `#[warn(unread_error_variant)]` on by default
 
-warning: `Mode::Slow` is constructed here, but no `match` arm or pattern anywhere (outside `Mode`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
+warning: `Mode::Slow` is constructed here, but no pattern anywhere singles it out (its own trait impls aside). What it carries is never read, and it is only ever caught by a catch-all
   --> $DIR/unread_error_variant.rs:96:31
    |
 LL |     speed(Mode::Fast) + speed(Mode::Slow) + speed(Mode::Crawl) + speed(Mode::Off)
    |                               ^^^^^^^^^^
    |
-note: the variant, which nothing matches on
+note: the variant
   --> $DIR/unread_error_variant.rs:83:5
    |
 LL |     Slow,
    |     ^^^^
-   = help: add an arm for `Mode::Slow` where `Mode` is matched, or fold it into the variant it is currently lumped with
+   = help: add an arm for `Mode::Slow` where `Mode` is matched, or fold it into the variant it is lumped with
 
-warning: `Mode::Crawl` is constructed here, but no `match` arm or pattern anywhere (outside `Mode`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
+warning: `Mode::Crawl` is constructed here, but no pattern anywhere singles it out (its own trait impls aside). What it carries is never read, and it is only ever caught by a catch-all
   --> $DIR/unread_error_variant.rs:96:51
    |
 LL |     speed(Mode::Fast) + speed(Mode::Slow) + speed(Mode::Crawl) + speed(Mode::Off)
    |                                                   ^^^^^^^^^^^
    |
-note: the variant, which nothing matches on
+note: the variant
   --> $DIR/unread_error_variant.rs:84:5
    |
 LL |     Crawl,
    |     ^^^^^
-   = help: add an arm for `Mode::Crawl` where `Mode` is matched, or fold it into the variant it is currently lumped with
+   = help: add an arm for `Mode::Crawl` where `Mode` is matched, or fold it into the variant it is lumped with
 
-warning: `ParseError::Malformed` is constructed here, but no `match` arm or pattern anywhere (outside `ParseError`'s own trait impls) ever singles it out, so whatever it carries is never read and it is only ever handled by a catch-all
+warning: `ParseError::Malformed` is constructed here, but no pattern anywhere singles it out (its own trait impls aside). What it carries is never read, and it is only ever caught by a catch-all
   --> $DIR/unread_error_variant.rs:176:30
    |
 LL |     s.parse::<u32>().map_err(ParseError::Malformed)
    |                              ^^^^^^^^^^^^^^^^^^^^^
    |
-note: the variant, which nothing matches on
+note: the variant
   --> $DIR/unread_error_variant.rs:169:5
    |
 LL |     Malformed(std::num::ParseIntError),
    |     ^^^^^^^^^
-   = help: add an arm for `ParseError::Malformed` where `ParseError` is matched, or fold it into the variant it is currently lumped with
+   = help: add an arm for `ParseError::Malformed` where `ParseError` is matched, or fold it into the variant it is lumped with
 
 warning: 4 warnings emitted
 

--- a/ui/wildcard_over_own_enum.stderr
+++ b/ui/wildcard_over_own_enum.stderr
@@ -1,75 +1,105 @@
-warning: this arm absorbs every future variant of `Op` (3 variants today)
+warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:12:9
    |
 LL |         _ => 0,
    |         ^
    |
+note: `Op`, whose new variants would fall into this arm
+  --> $DIR/wildcard_over_own_enum.rs:3:1
+   |
+LL | enum Op {
+   | ^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: list the remaining variants; the compiler then flags every new one added
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
    |
 LL -         _ => 0,
 LL +         Op::Sub | Op::Mul => 0,
    |
 
-warning: this arm absorbs every future variant of `Op` (3 variants today)
+warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:19:9
    |
 LL |         other => cost(other),
    |         ^^^^^
    |
-help: list the remaining variants; the compiler then flags every new one added
+note: `Op`, whose new variants would fall into this arm
+  --> $DIR/wildcard_over_own_enum.rs:3:1
+   |
+LL | enum Op {
+   | ^^^^^^^
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
    |
 LL |         other @ (Op::Sub | Op::Mul) => cost(other),
    |               +++++++++++++++++++++
 
-warning: this arm absorbs every future variant of `Entry` (3 variants today)
+warning: this catch-all also matches any variant added to `Entry` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:96:9
    |
 LL |         _ => 0,
    |         ^
    |
-help: list the remaining variants; the compiler then flags every new one added
+note: `Entry`, whose new variants would fall into this arm
+  --> $DIR/wildcard_over_own_enum.rs:87:1
+   |
+LL | pub enum Entry {
+   | ^^^^^^^^^^^^^^
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Entry` grows
    |
 LL -         _ => 0,
 LL +         Entry::Memory | Entry::Irq => 0,
    |
 
-warning: this arm absorbs every future variant of `Op` (3 variants today)
+warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:163:9
    |
 LL |         _ => {
    |         ^
    |
-help: list the remaining variants; the compiler then flags every new one added
+note: `Op`, whose new variants would fall into this arm
+  --> $DIR/wildcard_over_own_enum.rs:3:1
+   |
+LL | enum Op {
+   | ^^^^^^^
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
    |
 LL -         _ => {
 LL +         Op::Sub | Op::Mul => {
    |
 
-warning: this arm absorbs every future variant of `Op` (3 variants today)
+warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:208:13
    |
 LL |             _ => 0,
    |             ^
    |
-help: list the remaining variants; the compiler then flags every new one added
+note: `Op`, whose new variants would fall into this arm
+  --> $DIR/wildcard_over_own_enum.rs:3:1
+   |
+LL | enum Op {
+   | ^^^^^^^
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
    |
 LL -             _ => 0,
 LL +             Op::Add | Op::Mul => 0,
    |
 
-warning: this arm absorbs every future variant of `Op` (3 variants today)
+warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:217:9
    |
 LL |         other => {
    |         ^^^^^
    |
-help: list the remaining variants; the compiler then flags every new one added
+note: `Op`, whose new variants would fall into this arm
+  --> $DIR/wildcard_over_own_enum.rs:3:1
+   |
+LL | enum Op {
+   | ^^^^^^^
+help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
    |
 LL |         other @ (Op::Sub | Op::Mul) => {
    |               +++++++++++++++++++++
 
-warning: this `match` on `Op` is written out arm for arm a second time
+warning: this `match` on `Op` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
   --> $DIR/wildcard_over_own_enum.rs:219:13
    |
 LL | /             match other {
@@ -79,7 +109,7 @@ LL | |                 Op::Mul => 3,
 LL | |             }
    | |_____________^
    |
-note: the same match is here
+note: the other copy
   --> $DIR/wildcard_over_own_enum.rs:177:18
    |
 LL |           other => match other {
@@ -89,7 +119,7 @@ LL | |             Op::Sub => 2,
 LL | |             Op::Mul => 3,
 LL | |         },
    | |_________^
-   = help: the mapping lives in two places kept in step by hand; a method on the enum states it once
+   = help: move the mapping into a method on `Op` and call it from both places
    = note: `#[warn(same_match_twice)]` on by default
 
 warning: 7 warnings emitted

--- a/ui/wildcard_over_own_enum.stderr
+++ b/ui/wildcard_over_own_enum.stderr
@@ -1,105 +1,105 @@
-warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Op` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:12:9
    |
 LL |         _ => 0,
    |         ^
    |
-note: `Op`, whose new variants would fall into this arm
+note: `Op` is defined here
   --> $DIR/wildcard_over_own_enum.rs:3:1
    |
 LL | enum Op {
    | ^^^^^^^
    = note: `#[warn(wildcard_over_own_enum)]` on by default
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
+help: list the remaining variants instead of `_`
    |
 LL -         _ => 0,
 LL +         Op::Sub | Op::Mul => 0,
    |
 
-warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Op` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:19:9
    |
 LL |         other => cost(other),
    |         ^^^^^
    |
-note: `Op`, whose new variants would fall into this arm
+note: `Op` is defined here
   --> $DIR/wildcard_over_own_enum.rs:3:1
    |
 LL | enum Op {
    | ^^^^^^^
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
+help: list the remaining variants instead of `other`
    |
 LL |         other @ (Op::Sub | Op::Mul) => cost(other),
    |               +++++++++++++++++++++
 
-warning: this catch-all also matches any variant added to `Entry` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Entry` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:96:9
    |
 LL |         _ => 0,
    |         ^
    |
-note: `Entry`, whose new variants would fall into this arm
+note: `Entry` is defined here
   --> $DIR/wildcard_over_own_enum.rs:87:1
    |
 LL | pub enum Entry {
    | ^^^^^^^^^^^^^^
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Entry` grows
+help: list the remaining variants instead of `_`
    |
 LL -         _ => 0,
 LL +         Entry::Memory | Entry::Irq => 0,
    |
 
-warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Op` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:163:9
    |
 LL |         _ => {
    |         ^
    |
-note: `Op`, whose new variants would fall into this arm
+note: `Op` is defined here
   --> $DIR/wildcard_over_own_enum.rs:3:1
    |
 LL | enum Op {
    | ^^^^^^^
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
+help: list the remaining variants instead of `_`
    |
 LL -         _ => {
 LL +         Op::Sub | Op::Mul => {
    |
 
-warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Op` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:208:13
    |
 LL |             _ => 0,
    |             ^
    |
-note: `Op`, whose new variants would fall into this arm
+note: `Op` is defined here
   --> $DIR/wildcard_over_own_enum.rs:3:1
    |
 LL | enum Op {
    | ^^^^^^^
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
+help: list the remaining variants instead of `_`
    |
 LL -             _ => 0,
 LL +             Op::Add | Op::Mul => 0,
    |
 
-warning: this catch-all also matches any variant added to `Op` later (3 today), so a new variant lands here silently instead of failing to compile
+warning: this catch-all will also match any variant added to `Op` later (3 today). A new variant lands here silently instead of failing to compile
   --> $DIR/wildcard_over_own_enum.rs:217:9
    |
 LL |         other => {
    |         ^^^^^
    |
-note: `Op`, whose new variants would fall into this arm
+note: `Op` is defined here
   --> $DIR/wildcard_over_own_enum.rs:3:1
    |
 LL | enum Op {
    | ^^^^^^^
-help: spell out the remaining variants instead; the compiler then points at this `match` whenever `Op` grows
+help: list the remaining variants instead of `other`
    |
 LL |         other @ (Op::Sub | Op::Mul) => {
    |               +++++++++++++++++++++
 
-warning: this `match` on `Op` repeats an earlier one arm for arm, so the same table from variants to results exists twice and a change to one copy silently misses the other
+warning: this `match` on `Op` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other
   --> $DIR/wildcard_over_own_enum.rs:219:13
    |
 LL | /             match other {


### PR DESCRIPTION
Every diagnostic now has the same three parts. The warning says what is wrong in one or two short sentences using the code's own names. A note points at the other place that proves it, when there is one (the constructor that checks, the twin match, the opposite lock order, the read that unwraps): 22 lints gained such a note. The help is an edit to make, not a principle.

Before: "`ceiling` and `limit` of `Exceeded` agree one-for-one across all 3 places it is constructed, so one is a stored projection of the other". After: "`limit` always has the same value for a given `ceiling`, in all 3 places `Exceeded` is built. It is a stored copy of something `ceiling` decides", with a note at one construction and the help "add `fn limit(&self)` to `Ceiling` and delete the `limit` field".

What each lint detects, its spans, counts and the wildcard fix are unchanged; only text moved, which the ui expectations show line for line.